### PR TITLE
fix(exam): tolerate cached system form payloads

### DIFF
--- a/apps/api/exam-management/catalog.ts
+++ b/apps/api/exam-management/catalog.ts
@@ -197,7 +197,7 @@ export const CreateExamSystem = api(
 		code: string
 		name: string
 		letter: string
-		trainingTypeId: number
+		trainingTypeId?: number
 		description?: string
 	}): Promise<{ data: SystemResponse }> => {
 		const actor = await getActor()
@@ -208,7 +208,7 @@ export const CreateExamSystem = api(
 			typeof body.code !== 'string' ||
 			typeof body.name !== 'string' ||
 			typeof body.letter !== 'string' ||
-			body.trainingTypeId == null
+			body.trainingTypeId === null
 		) {
 			throw APIError.invalidArgument(
 				'Mã, tên, letter và loại đào tạo là bắt buộc'
@@ -217,7 +217,9 @@ export const CreateExamSystem = api(
 		const code = body.code.trim().toUpperCase()
 		const name = body.name.trim()
 		const letter = body.letter.trim().toUpperCase()
-		const trainingTypeId = Number(body.trainingTypeId)
+		// Giữ tương thích với bundle FE cũ còn cache trong lúc rollout.
+		// Mọi insert xuống DB vẫn luôn có training_type_id hợp lệ, không gửi null.
+		const trainingTypeId = Number(body.trainingTypeId ?? 1)
 		if (!code || !name || !letter) {
 			throw APIError.invalidArgument('Mã, tên và letter (A/B) bắt buộc')
 		}


### PR DESCRIPTION
## Tóm tắt
- Cho phép API tiếp nhận bundle FE cũ chưa gửi trainingTypeId trong lúc rollout/cache
- Mặc định trainingTypeId = 1 trước khi insert, nên DB vẫn luôn nhận giá trị non-null
- Tiếp tục từ chối null, 0, số âm và giá trị không hợp lệ
- FE mới vẫn chủ động gửi trainingTypeId: 1

## Kiểm thử
- Gửi đúng payload production cũ không có trainingTypeId
- POST /exam/systems trả HTTP 200
- Bản ghi được lưu với training_type_id = 1

Fix follow-up cho #176.