### PR TITLE
feat(exam): expand essay exam catalog management

### DIFF
--- a/apps/api/exam-management/assignments.ts
+++ b/apps/api/exam-management/assignments.ts
@@ -9,6 +9,7 @@ import { api, APIError, Query } from 'encore.dev/api'
 import { and, asc, desc, eq, inArray, like, ne, or, sql } from 'drizzle-orm'
 import orm from '../database'
 import {
+	examAcademicTitles,
 	examClasses,
 	examFaculties,
 	examFacultyHeads,
@@ -118,6 +119,111 @@ async function ensureDeptHeadRole(userId: number) {
 	if (!has) {
 		await orm.insert(userRoles).values({ userId, roleId: role.id })
 	}
+}
+
+async function releaseDeptHeadRoleIfUnused(userId: number) {
+	const [stillHead] = await orm
+		.select({ id: examFacultyHeads.id })
+		.from(examFacultyHeads)
+		.where(eq(examFacultyHeads.userId, userId))
+		.limit(1)
+	if (stillHead) return
+	const [role] = await orm
+		.select({ id: roles.id })
+		.from(roles)
+		.where(eq(roles.name, 'exam_dept_head'))
+		.limit(1)
+	if (role) {
+		await orm
+			.delete(userRoles)
+			.where(
+				and(eq(userRoles.userId, userId), eq(userRoles.roleId, role.id))
+			)
+	}
+	const [teacher] = await orm
+		.select({ id: examTeachers.id })
+		.from(examTeachers)
+		.where(eq(examTeachers.userId, userId))
+		.limit(1)
+	if (teacher) {
+		await orm
+			.update(users)
+			.set({ position: 'Giáo viên' })
+			.where(eq(users.id, userId))
+	}
+}
+
+function isFacultyHeadTitle(name: string) {
+	return /^Chủ nhiệm khoa(?:,|$)/i.test(name.trim())
+}
+
+/** Đồng bộ phân công CNK từ chức danh của giáo viên. */
+async function assignFacultyHeadFromTeacher(
+	user: typeof users.$inferSelect,
+	facultyCode: string,
+	facultyName: string
+) {
+	await ensureDeptHeadRole(user.id)
+	const displaced = await orm
+		.select({ userId: examFacultyHeads.userId })
+		.from(examFacultyHeads)
+		.where(
+			and(
+				eq(examFacultyHeads.facultyCode, facultyCode),
+				ne(examFacultyHeads.userId, user.id)
+			)
+		)
+	await orm
+		.delete(examFacultyHeads)
+		.where(
+			or(
+				and(
+					eq(examFacultyHeads.facultyCode, facultyCode),
+					ne(examFacultyHeads.userId, user.id)
+				),
+				and(
+					eq(examFacultyHeads.userId, user.id),
+					ne(examFacultyHeads.facultyCode, facultyCode)
+				)
+			)!
+		)
+	const [existing] = await orm
+		.select()
+		.from(examFacultyHeads)
+		.where(
+			and(
+				eq(examFacultyHeads.userId, user.id),
+				eq(examFacultyHeads.facultyCode, facultyCode)
+			)
+		)
+		.limit(1)
+	if (existing) {
+		await orm
+			.update(examFacultyHeads)
+			.set({
+				username: user.username,
+				displayName: user.displayName,
+				facultyName,
+				updatedAt: sql`(datetime('now'))`
+			})
+			.where(eq(examFacultyHeads.id, existing.id))
+	} else {
+		await orm.insert(examFacultyHeads).values({
+			facultyCode,
+			facultyName,
+			userId: user.id,
+			username: user.username,
+			displayName: user.displayName
+		})
+	}
+	for (const old of displaced) await releaseDeptHeadRoleIfUnused(old.userId)
+}
+
+async function removeFacultyHeadAssignment(userId: number) {
+	await orm
+		.delete(examFacultyHeads)
+		.where(eq(examFacultyHeads.userId, userId))
+	await releaseDeptHeadRoleIfUnused(userId)
 }
 
 /** Chức vụ gắn TK đào tạo — khóa đổi lung tung */
@@ -1166,11 +1272,166 @@ export interface TeacherCatalogRow {
 	displayName: string | null
 	facultyCode: string
 	facultyName: string | null
+	academicTitleId: number | null
+	academicTitleName: string | null
+	academicTitlePercentage: number | null
 	note: string | null
 	createdByUserId: number | null
 	createdByUsername: string | null
 	createdByDisplayName: string | null
 }
+
+export interface AcademicTitleRow {
+	id: number
+	createdAt: string
+	updatedAt: string
+	name: string
+	percentage: number
+	sortOrder: number
+}
+
+function academicTitleDto(
+	row: typeof examAcademicTitles.$inferSelect
+): AcademicTitleRow {
+	return {
+		id: row.id,
+		createdAt: row.createdAt,
+		updatedAt: row.updatedAt,
+		name: row.name,
+		percentage: row.percentage,
+		sortOrder: row.sortOrder
+	}
+}
+
+async function requireAcademicTitle(id: number) {
+	const [row] = await orm
+		.select()
+		.from(examAcademicTitles)
+		.where(eq(examAcademicTitles.id, id))
+		.limit(1)
+	if (!row) throw APIError.invalidArgument('Chức danh không tồn tại')
+	return row
+}
+
+/** Danh mục chức danh dùng khi khai báo giáo viên. */
+export const ListExamAcademicTitles = api(
+	{ auth: true, expose: true, method: 'GET', path: '/exam/academic-titles' },
+	async (): Promise<{ data: AcademicTitleRow[] }> => {
+		const actor = await getActor()
+		if (!canViewTeachingAssignments(actor)) {
+			throw APIError.permissionDenied(
+				'Không có quyền xem danh mục chức danh'
+			)
+		}
+		const rows = await orm
+			.select()
+			.from(examAcademicTitles)
+			.orderBy(
+				asc(examAcademicTitles.sortOrder),
+				asc(examAcademicTitles.percentage),
+				asc(examAcademicTitles.name)
+			)
+		return { data: rows.map(academicTitleDto) }
+	}
+)
+
+export const CreateExamAcademicTitle = api(
+	{ auth: true, expose: true, method: 'POST', path: '/exam/academic-titles' },
+	async (body: {
+		name: string
+		percentage: number
+		sortOrder?: number
+	}): Promise<{ data: AcademicTitleRow }> => {
+		const actor = await getActor()
+		if (!actor.isSuperAdmin)
+			throw APIError.permissionDenied('Chỉ admin được thêm chức danh')
+		const name = (body.name || '').trim()
+		if (!name) throw APIError.invalidArgument('Nhập tên chức danh')
+		if (
+			!Number.isFinite(body.percentage) ||
+			body.percentage < 0 ||
+			body.percentage > 100
+		) {
+			throw APIError.invalidArgument('Tỷ lệ phải từ 0 đến 100%')
+		}
+		const [row] = await orm
+			.insert(examAcademicTitles)
+			.values({
+				name,
+				percentage: Math.round(body.percentage),
+				sortOrder: body.sortOrder ?? 0
+			})
+			.returning()
+		return { data: academicTitleDto(row!) }
+	}
+)
+
+export const UpdateExamAcademicTitle = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'PATCH',
+		path: '/exam/academic-titles/:id'
+	},
+	async (body: {
+		id: number
+		name: string
+		percentage: number
+		sortOrder?: number
+	}): Promise<{ data: AcademicTitleRow }> => {
+		const actor = await getActor()
+		if (!actor.isSuperAdmin)
+			throw APIError.permissionDenied('Chỉ admin được sửa chức danh')
+		const existing = await requireAcademicTitle(body.id)
+		const name = (body.name || '').trim()
+		if (!name) throw APIError.invalidArgument('Nhập tên chức danh')
+		if (
+			!Number.isFinite(body.percentage) ||
+			body.percentage < 0 ||
+			body.percentage > 100
+		) {
+			throw APIError.invalidArgument('Tỷ lệ phải từ 0 đến 100%')
+		}
+		const [row] = await orm
+			.update(examAcademicTitles)
+			.set({
+				name,
+				percentage: Math.round(body.percentage),
+				sortOrder: body.sortOrder ?? existing.sortOrder,
+				updatedAt: sql`(datetime('now'))`
+			})
+			.where(eq(examAcademicTitles.id, body.id))
+			.returning()
+		return { data: academicTitleDto(row!) }
+	}
+)
+
+export const DeleteExamAcademicTitle = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'DELETE',
+		path: '/exam/academic-titles/:id'
+	},
+	async ({ id }: { id: number }): Promise<{ ok: boolean }> => {
+		const actor = await getActor()
+		if (!actor.isSuperAdmin)
+			throw APIError.permissionDenied('Chỉ admin được xóa chức danh')
+		const [used] = await orm
+			.select({ id: examTeachers.id })
+			.from(examTeachers)
+			.where(eq(examTeachers.academicTitleId, id))
+			.limit(1)
+		if (used)
+			throw APIError.failedPrecondition(
+				'Chức danh đang được giáo viên sử dụng'
+			)
+		await orm
+			.delete(examAcademicTitles)
+			.where(eq(examAcademicTitles.id, id))
+		return { ok: true }
+	}
+)
 
 export interface FacultyOption {
 	code: string
@@ -1227,6 +1488,44 @@ export interface FacultyHeadRow {
 	note: string | null
 }
 
+/** Danh sách Chủ nhiệm khoa hiện tại để hiển thị trong danh mục khoa. */
+export const ListExamFacultyHeads = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/exam/faculty-heads'
+	},
+	async (): Promise<{ data: FacultyHeadRow[] }> => {
+		const actor = await getActor()
+		if (!canViewTeachingAssignments(actor)) {
+			throw APIError.permissionDenied('Không có quyền xem Chủ nhiệm khoa')
+		}
+		const scope = await getScopedFacultyCodes(actor)
+		const rows = await orm
+			.select()
+			.from(examFacultyHeads)
+			.orderBy(examFacultyHeads.facultyCode)
+		const visible =
+			scope === null
+				? rows
+				: rows.filter((row) => scope.includes(row.facultyCode))
+		return {
+			data: visible.map((row) => ({
+				id: row.id,
+				createdAt: row.createdAt,
+				updatedAt: row.updatedAt,
+				facultyCode: row.facultyCode,
+				facultyName: row.facultyName,
+				userId: row.userId,
+				username: row.username,
+				displayName: row.displayName,
+				note: row.note
+			}))
+		}
+	}
+)
+
 /**
  * Gán / cập nhật Chủ nhiệm khoa theo mã khoa (K1…K8).
  * 1 khoa = 1 CNK chính. Chức vụ «Chủ nhiệm khoa» gắn tài khoản — không đơn vị.
@@ -1274,7 +1573,15 @@ export const UpsertExamFacultyHead = api(
 		if (!u) throw APIError.notFound('Tài khoản không tồn tại')
 
 		await ensureDeptHeadRole(u.id)
-		await lockTrainingUserProfile(u.id, 'Chủ nhiệm khoa')
+		const displaced = await orm
+			.select({ userId: examFacultyHeads.userId })
+			.from(examFacultyHeads)
+			.where(
+				and(
+					eq(examFacultyHeads.facultyCode, facultyCode),
+					ne(examFacultyHeads.userId, u.id)
+				)
+			)
 
 		// 1 khoa = 1 CNK: gỡ head khác trên cùng mã khoa
 		await orm
@@ -1332,6 +1639,8 @@ export const UpsertExamFacultyHead = api(
 				.returning()
 			row = created!
 		}
+		for (const old of displaced)
+			await releaseDeptHeadRoleIfUnused(old.userId)
 
 		return {
 			data: {
@@ -1346,6 +1655,36 @@ export const UpsertExamFacultyHead = api(
 				note: row.note
 			}
 		}
+	}
+)
+
+export const DeleteExamFacultyHead = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'DELETE',
+		path: '/exam/faculty-heads/:facultyCode'
+	},
+	async ({
+		facultyCode
+	}: {
+		facultyCode: string
+	}): Promise<{ ok: boolean }> => {
+		const actor = await getActor()
+		if (!actor.isSuperAdmin)
+			throw APIError.permissionDenied(
+				'Chỉ admin được bỏ phân công Chủ nhiệm khoa'
+			)
+		const code = facultyCode.trim().toUpperCase()
+		const rows = await orm
+			.select({ userId: examFacultyHeads.userId })
+			.from(examFacultyHeads)
+			.where(eq(examFacultyHeads.facultyCode, code))
+		await orm
+			.delete(examFacultyHeads)
+			.where(eq(examFacultyHeads.facultyCode, code))
+		for (const row of rows) await releaseDeptHeadRoleIfUnused(row.userId)
+		return { ok: true }
 	}
 )
 
@@ -1399,6 +1738,8 @@ export const ListExamTeacherCatalog = api(
 				asc(examTeachers.facultyCode),
 				asc(examTeachers.displayName)
 			)
+		const titleRows = await orm.select().from(examAcademicTitles)
+		const titleById = new Map(titleRows.map((title) => [title.id, title]))
 
 		// Dedup theo userId (phòng khi DB thiếu unique)
 		const seen = new Set<number>()
@@ -1406,6 +1747,9 @@ export const ListExamTeacherCatalog = api(
 		for (const r of rows) {
 			if (seen.has(r.userId)) continue
 			seen.add(r.userId)
+			const title = r.academicTitleId
+				? titleById.get(r.academicTitleId)
+				: null
 			data.push({
 				id: r.id,
 				createdAt: r.createdAt,
@@ -1415,6 +1759,9 @@ export const ListExamTeacherCatalog = api(
 				displayName: r.displayName,
 				facultyCode: r.facultyCode,
 				facultyName: r.facultyName,
+				academicTitleId: r.academicTitleId ?? null,
+				academicTitleName: title?.name ?? null,
+				academicTitlePercentage: title?.percentage ?? null,
 				note: r.note,
 				createdByUserId: r.createdByUserId ?? null,
 				createdByUsername: r.createdByUsername ?? null,
@@ -1441,6 +1788,7 @@ export const CreateExamTeacherCatalog = api(
 		password?: string
 		displayName?: string
 		facultyCode: string
+		academicTitleId: number
 		note?: string
 	}): Promise<{ data: TeacherCatalogRow }> => {
 		const actor = await getActor()
@@ -1468,6 +1816,7 @@ export const CreateExamTeacherCatalog = api(
 				`Khoa ${facultyCode} không có trong danh mục đào tạo`
 			)
 		}
+		const academicTitle = await requireAcademicTitle(body.academicTitleId)
 
 		let u: typeof users.$inferSelect | undefined
 
@@ -1573,12 +1922,21 @@ export const CreateExamTeacherCatalog = api(
 				displayName: finalName,
 				facultyCode,
 				facultyName,
+				academicTitleId: academicTitle.id,
 				note: body.note || null,
 				createdByUserId: actor.userId,
 				createdByUsername: actor.username,
 				createdByDisplayName: actor.displayName
 			})
 			.returning()
+
+		if (isFacultyHeadTitle(academicTitle.name)) {
+			await assignFacultyHeadFromTeacher(
+				{ ...u, displayName: finalName },
+				facultyCode,
+				facultyName
+			)
+		}
 
 		return {
 			data: {
@@ -1590,6 +1948,9 @@ export const CreateExamTeacherCatalog = api(
 				displayName: row!.displayName,
 				facultyCode: row!.facultyCode,
 				facultyName: row!.facultyName,
+				academicTitleId: row!.academicTitleId ?? null,
+				academicTitleName: academicTitle.name,
+				academicTitlePercentage: academicTitle.percentage,
 				note: row!.note,
 				createdByUserId: row!.createdByUserId ?? null,
 				createdByUsername: row!.createdByUsername ?? null,
@@ -1610,6 +1971,7 @@ export const UpdateExamTeacherCatalog = api(
 	async (params: {
 		id: number
 		facultyCode?: string
+		academicTitleId?: number
 		displayName?: string
 		note?: string | null
 	}): Promise<{ data: TeacherCatalogRow }> => {
@@ -1664,6 +2026,10 @@ export const UpdateExamTeacherCatalog = api(
 		if (params.note !== undefined) {
 			patch.note = params.note
 		}
+		if (params.academicTitleId !== undefined) {
+			const title = await requireAcademicTitle(params.academicTitleId)
+			patch.academicTitleId = title.id
+		}
 
 		const [row] = await orm
 			.update(examTeachers)
@@ -1671,6 +2037,25 @@ export const UpdateExamTeacherCatalog = api(
 			.where(eq(examTeachers.id, params.id))
 			.returning()
 
+		const title = row!.academicTitleId
+			? await requireAcademicTitle(row!.academicTitleId)
+			: null
+		const [teacherUser] = await orm
+			.select()
+			.from(users)
+			.where(eq(users.id, row!.userId))
+			.limit(1)
+		if (teacherUser && title && isFacultyHeadTitle(title.name)) {
+			await assignFacultyHeadFromTeacher(
+				teacherUser,
+				row!.facultyCode,
+				row!.facultyName ||
+					(await resolveFacultyName(row!.facultyCode)) ||
+					row!.facultyCode
+			)
+		} else {
+			await removeFacultyHeadAssignment(row!.userId)
+		}
 		return {
 			data: {
 				id: row!.id,
@@ -1681,6 +2066,9 @@ export const UpdateExamTeacherCatalog = api(
 				displayName: row!.displayName,
 				facultyCode: row!.facultyCode,
 				facultyName: row!.facultyName,
+				academicTitleId: row!.academicTitleId ?? null,
+				academicTitleName: title?.name ?? null,
+				academicTitlePercentage: title?.percentage ?? null,
 				note: row!.note,
 				createdByUserId: row!.createdByUserId ?? null,
 				createdByUsername: row!.createdByUsername ?? null,

--- a/apps/api/exam-management/catalog.ts
+++ b/apps/api/exam-management/catalog.ts
@@ -51,6 +51,11 @@ export interface MajorResponse {
 	systemId: number
 	levelCode: string | null
 	shortCode: string | null
+	catalogNumber: string | null
+	nationalMajorCode: string | null
+	qualification: string | null
+	trainingDuration: string | null
+	trainingForm: string | null
 	systemCode?: string | null
 	systemName?: string | null
 	systemLetter?: string | null
@@ -386,6 +391,11 @@ async function mapMajor(
 		systemId: r.systemId,
 		levelCode: r.levelCode ?? null,
 		shortCode: r.shortCode ?? null,
+		catalogNumber: r.catalogNumber ?? null,
+		nationalMajorCode: r.nationalMajorCode ?? null,
+		qualification: r.qualification ?? null,
+		trainingDuration: r.trainingDuration ?? null,
+		trainingForm: r.trainingForm ?? null,
 		systemCode: sys?.code ?? null,
 		systemName: sys?.name ?? null,
 		systemLetter: sys?.letter ?? null,
@@ -437,6 +447,11 @@ export const CreateExamMajor = api(
 		levelCode?: string | null
 		shortCode?: string | null
 		code?: string | null
+		catalogNumber?: string | null
+		nationalMajorCode?: string | null
+		qualification?: string | null
+		trainingDuration?: string | null
+		trainingForm?: string | null
 		description?: string
 	}): Promise<{ data: MajorResponse }> => {
 		const actor = await getActor()
@@ -456,13 +471,19 @@ export const CreateExamMajor = api(
 			.limit(1)
 		if (!sys) throw APIError.notFound('Hệ không tồn tại')
 
-		const code = buildMajorCode({
-			letter: sys.letter,
-			levelCode: body.levelCode,
-			shortCode: body.shortCode,
-			majorName: name,
-			manualCode: body.code
-		})
+		const nationalMajorCode = body.nationalMajorCode?.trim() || null
+		const catalogNumber = nationalMajorCode
+			? `${sys.letter.toUpperCase()}.${nationalMajorCode}`
+			: body.catalogNumber?.trim() || null
+		const code =
+			catalogNumber ||
+			buildMajorCode({
+				letter: sys.letter,
+				levelCode: body.levelCode,
+				shortCode: body.shortCode,
+				majorName: name,
+				manualCode: body.code
+			})
 
 		const [row] = await orm
 			.insert(examMajors)
@@ -472,6 +493,11 @@ export const CreateExamMajor = api(
 				systemId: body.systemId,
 				levelCode: body.levelCode?.trim().toUpperCase() || null,
 				shortCode: body.shortCode?.trim().toUpperCase() || null,
+				catalogNumber,
+				nationalMajorCode,
+				qualification: body.qualification?.trim() || null,
+				trainingDuration: body.trainingDuration?.trim() || null,
+				trainingForm: body.trainingForm?.trim() || null,
 				description: body.description || null
 			})
 			.returning()
@@ -487,6 +513,11 @@ export const UpdateExamMajor = api(
 		name?: string
 		levelCode?: string | null
 		shortCode?: string | null
+		catalogNumber?: string | null
+		nationalMajorCode?: string | null
+		qualification?: string | null
+		trainingDuration?: string | null
+		trainingForm?: string | null
 		systemId?: number
 		description?: string | null
 	}): Promise<{ data: MajorResponse }> => {
@@ -502,11 +533,31 @@ export const UpdateExamMajor = api(
 			.where(eq(examMajors.id, params.id))
 			.limit(1)
 		if (!existing) throw APIError.notFound('Ngành không tồn tại')
+		const nextSystemId = params.systemId ?? existing.systemId
+		const nextNationalMajorCode =
+			params.nationalMajorCode !== undefined
+				? params.nationalMajorCode?.trim() || null
+				: existing.nationalMajorCode
+		let nextCatalogNumber =
+			params.catalogNumber !== undefined
+				? params.catalogNumber?.trim() || null
+				: existing.catalogNumber
+		let nextCode = params.code?.trim().toUpperCase() || existing.code
+		if (nextNationalMajorCode) {
+			const [system] = await orm
+				.select({ letter: examSystems.letter })
+				.from(examSystems)
+				.where(eq(examSystems.id, nextSystemId))
+				.limit(1)
+			if (!system) throw APIError.notFound('Hệ không tồn tại')
+			nextCatalogNumber = `${system.letter.toUpperCase()}.${nextNationalMajorCode}`
+			nextCode = nextCatalogNumber
+		}
 
 		const [row] = await orm
 			.update(examMajors)
 			.set({
-				code: params.code?.trim().toUpperCase() || existing.code,
+				code: nextCode,
 				name: params.name?.trim() || existing.name,
 				systemId: params.systemId ?? existing.systemId,
 				levelCode:
@@ -517,6 +568,20 @@ export const UpdateExamMajor = api(
 					params.shortCode !== undefined
 						? params.shortCode?.trim().toUpperCase() || null
 						: existing.shortCode,
+				catalogNumber: nextCatalogNumber,
+				nationalMajorCode: nextNationalMajorCode,
+				qualification:
+					params.qualification !== undefined
+						? params.qualification?.trim() || null
+						: existing.qualification,
+				trainingDuration:
+					params.trainingDuration !== undefined
+						? params.trainingDuration?.trim() || null
+						: existing.trainingDuration,
+				trainingForm:
+					params.trainingForm !== undefined
+						? params.trainingForm?.trim() || null
+						: existing.trainingForm,
 				description:
 					params.description !== undefined
 						? params.description
@@ -524,6 +589,25 @@ export const UpdateExamMajor = api(
 			})
 			.where(eq(examMajors.id, params.id))
 			.returning()
+		if (existing.code !== nextCode) {
+			const linkedSubjects = await orm
+				.select({
+					id: examSubjects.id,
+					code: examSubjects.code,
+					baseCode: examSubjects.baseCode
+				})
+				.from(examSubjects)
+				.where(eq(examSubjects.majorId, params.id))
+			for (const subject of linkedSubjects) {
+				const baseCode =
+					subject.baseCode?.trim() ||
+					subject.code.slice(existing.code.length + 1)
+				await orm
+					.update(examSubjects)
+					.set({ code: buildSubjectCode(nextCode, baseCode) })
+					.where(eq(examSubjects.id, subject.id))
+			}
+		}
 		return { data: await mapMajor(row!) }
 	}
 )
@@ -833,7 +917,7 @@ export const ListExamClasses = api(
 		majorId?: Query<number>
 		facultyId?: Query<number>
 	}): Promise<{ data: ClassCatalogResponse[] }> => {
-		await getActor()
+		const actor = await getActor()
 		const conditions = []
 		if (q.systemId)
 			conditions.push(eq(examMajors.systemId, Number(q.systemId)))
@@ -849,6 +933,20 @@ export const ListExamClasses = api(
 					like(examClasses.name, `%${kw}%`)
 				)!
 			)
+		}
+		if (isScopedDeptHead(actor)) {
+			const facCodes = await getDeptHeadFacultyCodes(actor)
+			if (facCodes && facCodes.length) {
+				const codes = facCodes.map((code) => code.toUpperCase())
+				conditions.push(
+					sql`upper(${examFaculties.code}) in (${sql.join(
+						codes.map((code) => sql`${code}`),
+						sql`, `
+					)})`
+				)
+			} else {
+				return { data: [] }
+			}
 		}
 		const where = conditions.length ? and(...conditions) : undefined
 		const rows = await orm
@@ -1214,6 +1312,8 @@ export const CreateExamSubject = api(
 	async (body: {
 		name: string
 		facultyId: number
+		majorId?: number
+		sourceSubjectId?: number
 		baseCode?: string
 		code?: string
 		creditHours?: number
@@ -1224,11 +1324,18 @@ export const CreateExamSubject = api(
 		if (!canManageCatalog(actor)) {
 			throw APIError.permissionDenied('Không có quyền quản lý môn')
 		}
-		const name = body.name.trim()
+		const [sourceSubject] = body.sourceSubjectId
+			? await orm
+					.select()
+					.from(examSubjects)
+					.where(eq(examSubjects.id, body.sourceSubjectId))
+					.limit(1)
+			: [null]
+		const name = (sourceSubject?.name || body.name).trim()
 		if (!name || !body.facultyId) {
 			throw APIError.invalidArgument('Tên môn và khoa bắt buộc')
 		}
-		const [fac] = await orm
+		let [fac] = await orm
 			.select({
 				id: examFaculties.id,
 				code: examFaculties.code,
@@ -1243,7 +1350,68 @@ export const CreateExamSubject = api(
 			.limit(1)
 		if (!fac) throw APIError.notFound('Khoa không tồn tại')
 
-		const baseCode = (body.baseCode || body.code || '').trim().toUpperCase()
+		// Khoa là danh mục dùng chung. CSDL cũ lưu một bản ghi khoa theo từng
+		// ngành, vì vậy tự tạo bản ghi liên kết tương ứng khi thêm môn vào ngành.
+		if (body.majorId && fac.majorId !== body.majorId) {
+			const [targetMajor] = await orm
+				.select({ id: examMajors.id })
+				.from(examMajors)
+				.where(eq(examMajors.id, body.majorId))
+				.limit(1)
+			if (!targetMajor) throw APIError.notFound('Ngành không tồn tại')
+			let [targetFaculty] = await orm
+				.select({
+					id: examFaculties.id,
+					code: examFaculties.code,
+					name: examFaculties.name,
+					majorId: examFaculties.majorId,
+					majorCode: examMajors.code,
+					majorName: examMajors.name
+				})
+				.from(examFaculties)
+				.leftJoin(examMajors, eq(examFaculties.majorId, examMajors.id))
+				.where(
+					and(
+						eq(examFaculties.majorId, body.majorId),
+						eq(examFaculties.code, fac.code)
+					)
+				)
+				.limit(1)
+			if (!targetFaculty) {
+				const [created] = await orm
+					.insert(examFaculties)
+					.values({
+						code: fac.code,
+						name: fac.name,
+						majorId: body.majorId
+					})
+					.returning()
+				const [major] = await orm
+					.select({ code: examMajors.code, name: examMajors.name })
+					.from(examMajors)
+					.where(eq(examMajors.id, body.majorId))
+					.limit(1)
+				targetFaculty = {
+					id: created!.id,
+					code: created!.code,
+					name: created!.name,
+					majorId: created!.majorId,
+					majorCode: major?.code ?? null,
+					majorName: major?.name ?? null
+				}
+			}
+			fac = targetFaculty
+		}
+
+		const baseCode = (
+			sourceSubject?.baseCode ||
+			sourceSubject?.code.split('_').pop() ||
+			body.baseCode ||
+			body.code ||
+			''
+		)
+			.trim()
+			.toUpperCase()
 		if (!baseCode) {
 			throw APIError.invalidArgument('Mã môn (baseCode) bắt buộc')
 		}
@@ -1259,8 +1427,10 @@ export const CreateExamSubject = api(
 					? baseCode.split('_').pop()!
 					: baseCode,
 				name,
-				creditHours: body.creditHours ?? 0,
-				lessonHours: body.lessonHours ?? 0,
+				creditHours:
+					sourceSubject?.creditHours ?? body.creditHours ?? 0,
+				lessonHours:
+					sourceSubject?.lessonHours ?? body.lessonHours ?? 0,
 				facultyId: fac.id,
 				majorId: fac.majorId,
 				description: body.description || null

--- a/apps/api/exam-management/catalog.ts
+++ b/apps/api/exam-management/catalog.ts
@@ -162,6 +162,42 @@ export function buildSubjectCode(majorCode: string, baseCode: string): string {
 	return `${maj}_${base}`
 }
 
+type LegacySystemRow = {
+	id: number
+	createdAt: string
+	updatedAt: string
+	code: string
+	name: string
+	letter: string
+	description: string | null
+	trainingTypeId?: number | null
+}
+
+async function hasTrainingTypeColumn(): Promise<boolean> {
+	const columns = await orm.all(
+		sql`PRAGMA table_info(exam_systems)`
+	)
+	return columns.some((column) => column.name === 'training_type_id')
+}
+
+async function listSystems(kw?: string): Promise<LegacySystemRow[]> {
+	const hasTrainingType = await hasTrainingTypeColumn()
+	const pattern = kw ? `%${kw}%` : null
+	const rows = await orm.all(
+		sql`SELECT id, createdAt, updatedAt, code, name, letter,
+			description${hasTrainingType ? sql`, training_type_id AS trainingTypeId` : sql``}
+		FROM exam_systems
+		${pattern ? sql`WHERE code LIKE ${pattern} OR name LIKE ${pattern} OR letter LIKE ${pattern}` : sql``}
+		ORDER BY letter`
+	)
+	return rows as LegacySystemRow[]
+}
+
+async function getSystem(id: number): Promise<LegacySystemRow | null> {
+	const rows = await listSystems()
+	return rows.find((row) => row.id === id) ?? null
+}
+
 // ── Hệ (chỉ 2: QS/DS) ─────────────────────────────────────────
 
 export const ListExamSystems = api(
@@ -169,19 +205,7 @@ export const ListExamSystems = api(
 	async (q: { q?: Query<string> }): Promise<{ data: SystemResponse[] }> => {
 		await getActor()
 		const kw = (q.q || '').trim()
-		const rows = kw
-			? await orm
-					.select()
-					.from(examSystems)
-					.where(
-						or(
-							like(examSystems.code, `%${kw}%`),
-							like(examSystems.name, `%${kw}%`),
-							like(examSystems.letter, `%${kw}%`)
-						)!
-					)
-					.orderBy(examSystems.letter)
-			: await orm.select().from(examSystems).orderBy(examSystems.letter)
+		const rows = await listSystems(kw)
 		return {
 			data: rows.map((r) => ({
 				id: r.id,
@@ -241,16 +265,15 @@ export const CreateExamSystem = api(
 		if (duplicate) {
 			throw APIError.alreadyExists('Mã hoặc letter của hệ đã tồn tại')
 		}
-		const [row] = await orm
-			.insert(examSystems)
-			.values({
-				code,
-				name,
-				letter,
-				trainingTypeId,
-				description: body.description || null
-			})
-			.returning()
+		const hasTrainingType = await hasTrainingTypeColumn()
+		let row: LegacySystemRow | undefined
+		if (hasTrainingType) {
+			const [inserted] = await orm.insert(examSystems).values({ code, name, letter, trainingTypeId, description: body.description || null }).returning()
+			row = inserted
+		} else {
+			await orm.run(sql`INSERT INTO exam_systems (code, name, letter, description) VALUES (${code}, ${name}, ${letter}, ${body.description || null})`)
+			row = await listSystems().then((rows) => rows.find((item) => item.code === code))
+		}
 		return {
 			data: {
 				id: row!.id,
@@ -279,11 +302,7 @@ export const UpdateExamSystem = api(
 		if (!canManageCatalog(actor)) {
 			throw APIError.permissionDenied('Không có quyền sửa hệ đào tạo')
 		}
-		const [existing] = await orm
-			.select()
-			.from(examSystems)
-			.where(eq(examSystems.id, params.id))
-			.limit(1)
+		const existing = await getSystem(params.id)
 		if (!existing) throw APIError.notFound('Hệ đào tạo không tồn tại')
 
 		if (
@@ -310,7 +329,7 @@ export const UpdateExamSystem = api(
 		const trainingTypeId =
 			params.trainingTypeId !== undefined
 				? Number(params.trainingTypeId)
-				: existing.trainingTypeId
+				: Number(existing.trainingTypeId ?? 1)
 		if (!code || !name || !letter) {
 			throw APIError.invalidArgument('Mã, tên và letter (A/B) bắt buộc')
 		}
@@ -335,9 +354,10 @@ export const UpdateExamSystem = api(
 			throw APIError.alreadyExists('Mã hoặc letter của hệ đã tồn tại')
 		}
 
-		const [row] = await orm
-			.update(examSystems)
-			.set({
+		const hasTrainingType = await hasTrainingTypeColumn()
+		let row: LegacySystemRow | undefined
+		if (hasTrainingType) {
+			const [updated] = await orm.update(examSystems).set({
 				code,
 				name,
 				letter,
@@ -346,9 +366,12 @@ export const UpdateExamSystem = api(
 					params.description !== undefined
 						? params.description
 						: existing.description
-			})
-			.where(eq(examSystems.id, params.id))
-			.returning()
+			}).where(eq(examSystems.id, params.id)).returning()
+			row = updated
+		} else {
+			await orm.run(sql`UPDATE exam_systems SET code = ${code}, name = ${name}, letter = ${letter}, description = ${params.description !== undefined ? params.description : existing.description} WHERE id = ${params.id}`)
+			row = await getSystem(params.id) ?? undefined
+		}
 		return { data: row! }
 	}
 )
@@ -377,11 +400,7 @@ export const DeleteExamSystem = api(
 async function mapMajor(
 	r: typeof examMajors.$inferSelect
 ): Promise<MajorResponse> {
-	const [sys] = await orm
-		.select()
-		.from(examSystems)
-		.where(eq(examSystems.id, r.systemId))
-		.limit(1)
+	const sys = await getSystem(r.systemId)
 	return {
 		id: r.id,
 		createdAt: r.createdAt,
@@ -464,11 +483,7 @@ export const CreateExamMajor = api(
 		if (!name || !body.systemId) {
 			throw APIError.invalidArgument('Tên ngành và hệ bắt buộc')
 		}
-		const [sys] = await orm
-			.select()
-			.from(examSystems)
-			.where(eq(examSystems.id, body.systemId))
-			.limit(1)
+		const sys = await getSystem(body.systemId)
 		if (!sys) throw APIError.notFound('Hệ không tồn tại')
 
 		const nationalMajorCode = body.nationalMajorCode?.trim() || null

--- a/apps/api/exam-management/draws.ts
+++ b/apps/api/exam-management/draws.ts
@@ -51,7 +51,7 @@ export interface DrawResponse {
 	/** Đã xuất in → vào kho đề đã dùng */
 	printedAt: string | null
 	printedByUsername: string | null
-	/** Quá 3 ngày từ ngày rút → không cho in */
+	/** |Ngày thi − ngày hiện tại| > 3 → không cho in */
 	printBlocked: boolean
 	printBlockedAt: string | null
 	printBlockedReason: string | null
@@ -99,8 +99,8 @@ function mapDraw(
 		majorName?: string | null
 	}
 ): DrawResponse {
-	const daysSince = daysBetweenDates(r.drawnAt, todayVnDate())
-	const overdue = isDrawPrintOverdue(r.drawnAt) || !!r.printBlocked
+	const daysSince = daysBetweenDates(r.examDate, todayVnDate())
+	const overdue = isDrawPrintOverdue(r.examDate)
 	return {
 		id: r.id,
 		createdAt: r.createdAt,
@@ -126,9 +126,10 @@ function mapDraw(
 		printedByUsername: r.printedByUsername ?? null,
 		printBlocked: overdue,
 		printBlockedAt: r.printBlockedAt ?? null,
-		printBlockedReason:
-			r.printBlockedReason ??
-			(overdue ? 'Đã quá 3 ngày kể từ ngày rút — không cho in' : null),
+		printBlockedReason: overdue
+			? r.printBlockedReason ||
+				'Ngày thi và ngày hiện tại chênh quá 3 ngày — không cho in'
+			: null,
 		daysSinceDraw: daysSince,
 		examDate: r.examDate,
 		examTime: r.examTime,
@@ -137,19 +138,21 @@ function mapDraw(
 	}
 }
 
-/** Đánh dấu print_blocked nếu quá 3 ngày (lazy) */
+/** Đồng bộ trạng thái in theo |ngày thi − ngày hiện tại| (lazy). */
 async function ensurePrintBlock(
 	draw: typeof examDraws.$inferSelect
 ): Promise<typeof examDraws.$inferSelect> {
-	if (draw.printBlocked) return draw
-	if (!isDrawPrintOverdue(draw.drawnAt)) return draw
+	const overdue = isDrawPrintOverdue(draw.examDate)
+	if (overdue === draw.printBlocked) return draw
 	const at = nowIso()
-	const reason = `Quá 3 ngày kể từ ngày rút (${String(draw.drawnAt).slice(0, 10)}) — không cho in`
+	const reason = overdue
+		? `Ngày thi (${draw.examDate || '—'}) và ngày hiện tại (${todayVnDate()}) chênh quá 3 ngày — không cho in`
+		: null
 	const [row] = await orm
 		.update(examDraws)
 		.set({
-			printBlocked: true,
-			printBlockedAt: at,
+			printBlocked: overdue,
+			printBlockedAt: overdue ? at : null,
 			printBlockedReason: reason
 		})
 		.where(eq(examDraws.id, draw.id))
@@ -157,8 +160,8 @@ async function ensurePrintBlock(
 	return (
 		row || {
 			...draw,
-			printBlocked: true,
-			printBlockedAt: at,
+			printBlocked: overdue,
+			printBlockedAt: overdue ? at : null,
 			printBlockedReason: reason
 		}
 	)
@@ -291,7 +294,7 @@ export const DrawExam = api(
 		if (isExamDrawDateOverLimit(examDate, drawnAtPreview, 3)) {
 			const gap = daysBetweenDates(examDate, drawnAtPreview)
 			throw APIError.failedPrecondition(
-				`Ngày thi (${examDate}) và ngày rút (${drawnAtPreview.slice(0, 10)}) chênh ${gap} ngày — không được quá 3 ngày.`
+				`Ngày thi (${examDate}) và ngày hiện tại (${drawnAtPreview.slice(0, 10)}) chênh ${gap} ngày — không được quá 3 ngày.`
 			)
 		}
 
@@ -618,7 +621,7 @@ function formatVnDateLong(isoOrYmd: string | null | undefined): string {
 /**
  * Xuất đề / đáp án để in — form chuẩn «ĐỀ THI HẾT HỌC PHẦN».
  * kind: questions | answers
- * Chặn in nếu đã quá 3 ngày kể từ ngày rút.
+ * Chặn in nếu ngày thi và ngày hiện tại chênh quá 3 ngày.
  */
 export const ExportDrawPrint = api(
 	{
@@ -651,10 +654,10 @@ export const ExportDrawPrint = api(
 		if (!draw0) throw APIError.notFound('Phiếu bốc đề không tồn tại')
 
 		const draw = await ensurePrintBlock(draw0)
-		if (draw.printBlocked || isDrawPrintOverdue(draw.drawnAt)) {
+		if (draw.printBlocked || isDrawPrintOverdue(draw.examDate)) {
 			throw APIError.failedPrecondition(
 				draw.printBlockedReason ||
-					'Đề đã rút quá 3 ngày — không được in. Xem bảng «Đề đã rút quá 3 ngày».'
+					'Ngày thi và ngày hiện tại chênh quá 3 ngày — không được in.'
 			)
 		}
 
@@ -984,7 +987,7 @@ export const ExportDrawMinutes = api(
 )
 
 /**
- * Danh sách đề đã rút quá 3 ngày (không cho in).
+ * Danh sách phiếu có ngày thi và ngày hiện tại chênh quá 3 ngày.
  * Đồng thời lazy-mark print_blocked.
  */
 export const ListOverdueDraws = api(
@@ -1017,7 +1020,7 @@ export const ListOverdueDraws = api(
 		const out: DrawResponse[] = []
 		for (const r of rows) {
 			const blocked = await ensurePrintBlock(r.draw)
-			if (blocked.printBlocked || isDrawPrintOverdue(blocked.drawnAt)) {
+			if (blocked.printBlocked || isDrawPrintOverdue(blocked.examDate)) {
 				out.push(
 					mapDraw({
 						...blocked,

--- a/apps/api/exam-management/helpers.ts
+++ b/apps/api/exam-management/helpers.ts
@@ -446,7 +446,7 @@ export function canManageTeachingAssignments(actor: Actor) {
 
 /** Danh mục ngành/môn: super + CNK (quản môn ngành) + Ban KT xem/vận hành */
 export function canManageCatalogApi(actor: Actor): boolean {
-	return actor.isSuperAdmin || isNganhOperator(actor) || isExamOffice(actor)
+	return actor.isSuperAdmin || isNganhOperator(actor)
 }
 
 export function statusLabel(s: string): string {
@@ -765,13 +765,13 @@ export function isExamDrawDateOverLimit(
 	return d > maxDays
 }
 
-/** true nếu đã quá maxDays kể từ ngày rút (không cho in) */
+/** true nếu |ngày thi − ngày hiện tại| quá maxDays (không cho in) */
 export function isDrawPrintOverdue(
-	drawnAt: string | null | undefined,
+	examDate: string | null | undefined,
 	now = todayVnDate(),
 	maxDays = 3
 ): boolean {
-	const d = daysBetweenDates(drawnAt, now)
+	const d = daysBetweenDates(examDate, now)
 	if (d == null) return false
 	return d > maxDays
 }

--- a/apps/api/migrations/0042_exam_academic_titles.sql
+++ b/apps/api/migrations/0042_exam_academic_titles.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS `exam_academic_titles` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+	`updatedAt` text DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+	`name` text NOT NULL,
+	`percentage` integer NOT NULL,
+	`sort_order` integer DEFAULT 0 NOT NULL
+);--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `exam_academic_titles_name_uq`
+	ON `exam_academic_titles` (`name`);--> statement-breakpoint
+
+ALTER TABLE `exam_teachers` ADD COLUMN `academic_title_id` integer;--> statement-breakpoint
+
+INSERT OR IGNORE INTO `exam_academic_titles` (`name`, `percentage`, `sort_order`) VALUES
+('Giảng viên kiêm nhiệm khác', 0, 10),
+('Giám đốc, Hiệu trưởng, Chính ủy', 10, 20),
+('Phó Giám đốc, Phó Hiệu trưởng, Phó Chính ủy', 15, 30),
+('Trưởng phòng và tương đương', 20, 40),
+('Phó Trưởng phòng, Trưởng ban trực thuộc nhà trường và tương đương', 25, 50),
+('Chủ nhiệm khoa, Trưởng khoa', 45, 60),
+('Chủ nhiệm khoa, Trưởng khoa kiêm Bí thư đảng ủy, Bí thư chi bộ', 50, 70),
+('Phó Chủ nhiệm khoa, Phó Trưởng khoa kiêm Bí thư đảng ủy, Bí thư chi bộ', 55, 80),
+('Trưởng bộ môn kiêm Bí thư chi bộ', 65, 90),
+('Phó Chủ nhiệm khoa, Phó Trưởng khoa', 70, 100),
+('Phó Trưởng bộ môn kiêm Bí thư chi bộ', 70, 110),
+('Phó Trưởng bộ môn kiêm Phó Bí thư chi bộ', 75, 120),
+('Trưởng bộ môn', 80, 130),
+('Phó Trưởng bộ môn', 85, 140),
+('Giảng viên', 100, 150);--> statement-breakpoint
+
+UPDATE `exam_teachers`
+SET `academic_title_id` = (SELECT `id` FROM `exam_academic_titles` WHERE `name` = 'Giảng viên')
+WHERE `academic_title_id` IS NULL;

--- a/apps/api/migrations/0043_restore_exam_classes.sql
+++ b/apps/api/migrations/0043_restore_exam_classes.sql
@@ -1,0 +1,16 @@
+-- Phục hồi bảng danh mục lớp thi cho các DB cũ đã đánh dấu migration 0042
+-- nhưng thực tế chưa tạo đủ bảng phân hệ đề thi.
+CREATE TABLE IF NOT EXISTS `exam_classes` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`major_id` integer,
+	`faculty_id` integer,
+	`cohort` text,
+	`description` text
+);--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS `exam_classes_code_unique`
+	ON `exam_classes` (`code`);

--- a/apps/api/migrations/0044_restore_exam_runtime_tables.sql
+++ b/apps/api/migrations/0044_restore_exam_runtime_tables.sql
@@ -1,0 +1,163 @@
+-- Phục hồi các bảng vận hành đề thi bị thiếu trên DB legacy.
+CREATE TABLE IF NOT EXISTS `exam_teaching_assignments` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`subject_id` integer NOT NULL,
+	`class_id` integer,
+	`user_id` integer NOT NULL,
+	`username` text,
+	`display_name` text,
+	`note` text,
+	`teaching_start` text,
+	`teaching_end` text,
+	`assigned_by_user_id` integer,
+	`assigned_by_username` text,
+	`assigned_by_display_name` text
+);--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `exam_teaching_assignment_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`action` text NOT NULL,
+	`subject_id` integer,
+	`subject_code` text,
+	`subject_name` text,
+	`major_id` integer,
+	`major_code` text,
+	`faculty_id` integer,
+	`faculty_code` text,
+	`class_id` integer,
+	`class_code` text,
+	`class_name` text,
+	`teacher_user_id` integer,
+	`teacher_username` text,
+	`teacher_display_name` text,
+	`note` text,
+	`actor_user_id` integer,
+	`actor_username` text,
+	`actor_display_name` text,
+	`summary` text NOT NULL
+);--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `exam_major_heads` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL,
+	`major_id` integer NOT NULL,
+	`user_id` integer NOT NULL,
+	`username` text,
+	`display_name` text,
+	`note` text
+);--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `exams` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`title` text NOT NULL,
+	`subject_id` integer NOT NULL,
+	`paper_number` integer,
+	`status` text DEFAULT 'DRAFT' NOT NULL,
+	`created_by_user_id` integer,
+	`created_by_username` text,
+	`created_by_display_name` text,
+	`approved_by_user_id` integer,
+	`approved_by_username` text,
+	`approved_by_display_name` text,
+	`approved_at` text,
+	`approved_by_rank` text,
+	`approved_by_position` text,
+	`approved_by_signature_url` text,
+	`approved_by_title` text,
+	`dept_head_user_id` integer,
+	`dept_head_username` text,
+	`dept_head_display_name` text,
+	`dept_head_rank` text,
+	`dept_head_signature_url` text,
+	`dept_head_approved_at` text,
+	`qr_code` text,
+	`locked` integer DEFAULT false NOT NULL,
+	`class_id` integer,
+	`class_name` text,
+	`duration_minutes` integer DEFAULT 60,
+	`question_file_url` text,
+	`question_file_name` text,
+	`answer_file_url` text,
+	`answer_file_name` text,
+	`note` text,
+	`return_note` text
+);--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS `exams_code_unique` ON `exams` (`code`);--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `exam_questions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`exam_id` integer NOT NULL,
+	`question_number` integer DEFAULT 1 NOT NULL,
+	`content` text NOT NULL,
+	`answer` text,
+	`points` integer DEFAULT 1 NOT NULL
+);--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `exam_workflow_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`exam_id` integer NOT NULL,
+	`action` text NOT NULL,
+	`from_status` text,
+	`to_status` text,
+	`note` text,
+	`actor_user_id` integer,
+	`actor_username` text,
+	`actor_display_name` text
+);--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `exam_draws` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`draw_code` text NOT NULL,
+	`exam_id` integer NOT NULL,
+	`exam_code` text,
+	`paper_number` integer,
+	`subject_id` integer,
+	`major_id` integer,
+	`draw_type` text NOT NULL,
+	`class_id` integer,
+	`class_name` text,
+	`drawn_by_user_id` integer,
+	`drawn_by_username` text,
+	`drawn_by_display_name` text,
+	`drawn_at` text NOT NULL,
+	`printed_at` text,
+	`printed_by_user_id` integer,
+	`printed_by_username` text,
+	`print_blocked` integer DEFAULT false NOT NULL,
+	`print_blocked_at` text,
+	`print_blocked_reason` text,
+	`exam_date` text,
+	`exam_time` text,
+	`location` text,
+	`note` text
+);--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS `exam_draws_draw_code_unique` ON `exam_draws` (`draw_code`);--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS `exam_draw_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`draw_id` integer,
+	`action` text NOT NULL,
+	`summary` text NOT NULL,
+	`details` text,
+	`actor_user_id` integer,
+	`actor_username` text,
+	`actor_display_name` text
+);

--- a/apps/api/migrations/0045_exam_major_official_catalog.sql
+++ b/apps/api/migrations/0045_exam_major_official_catalog.sql
@@ -1,0 +1,22 @@
+ALTER TABLE `exam_majors` ADD COLUMN `catalog_number` text;--> statement-breakpoint
+ALTER TABLE `exam_majors` ADD COLUMN `national_major_code` text;--> statement-breakpoint
+ALTER TABLE `exam_majors` ADD COLUMN `qualification` text;--> statement-breakpoint
+ALTER TABLE `exam_majors` ADD COLUMN `training_duration` text;--> statement-breakpoint
+ALTER TABLE `exam_majors` ADD COLUMN `training_form` text;--> statement-breakpoint
+
+UPDATE `exam_majors` SET `name`='Y sĩ đa khoa', `catalog_number`='B.6720101', `national_major_code`='6720101', `qualification`='Cao đẳng', `training_duration`='3 năm', `training_form`='Chính quy' WHERE `code`='B_CDYSDK';--> statement-breakpoint
+UPDATE `exam_majors` SET `name`='Dược', `catalog_number`='B.6720201', `national_major_code`='6720201', `qualification`='Cao đẳng', `training_duration`='3 năm', `training_form`='Chính quy' WHERE `code`='B_CDDUOC';--> statement-breakpoint
+UPDATE `exam_majors` SET `name`='Điều dưỡng', `catalog_number`='B.6720301', `national_major_code`='6720301', `qualification`='Cao đẳng', `training_duration`='3 năm', `training_form`='Chính quy' WHERE `code`='B_CDDD';--> statement-breakpoint
+UPDATE `exam_majors` SET `name`='Y sĩ đa khoa', `catalog_number`='A.6720101', `national_major_code`='6720101', `qualification`='Cao đẳng', `training_duration`='3 năm', `training_form`='Chính quy' WHERE `code`='A_CDYSDK';--> statement-breakpoint
+UPDATE `exam_majors` SET `name`='Điều dưỡng', `catalog_number`='A.6720301', `national_major_code`='6720301', `qualification`='Cao đẳng', `training_duration`='3 năm', `training_form`='Chính quy' WHERE `code`='A_CDDD';--> statement-breakpoint
+UPDATE `exam_majors` SET `name`='Điều dưỡng', `catalog_number`='A.6720302', `national_major_code`='6720301', `qualification`='Cao đẳng', `training_duration`='3 năm', `training_form`='Liên thông' WHERE `code`='A_LTDD';--> statement-breakpoint
+UPDATE `exam_majors` SET `name`='Y sĩ đa khoa', `catalog_number`='A.5720101', `national_major_code`='5720101', `qualification`='Trung cấp', `training_duration`='2,5 năm', `training_form`='Chính quy' WHERE `code`='A_TCYSDK';--> statement-breakpoint
+
+INSERT OR IGNORE INTO `exam_majors` (`code`,`name`,`system_id`,`level_code`,`short_code`,`catalog_number`,`national_major_code`,`qualification`,`training_duration`,`training_form`,`description`)
+SELECT 'A_TCKTCBMA','Kỹ thuật chế biến món ăn',`id`,'TC','KTCBMA','A.5810207','5810207','Trung cấp','2 năm','Chính quy','Danh mục ngành đào tạo chính thức' FROM `exam_systems` WHERE `letter`='A';--> statement-breakpoint
+INSERT OR IGNORE INTO `exam_majors` (`code`,`name`,`system_id`,`level_code`,`short_code`,`catalog_number`,`national_major_code`,`qualification`,`training_duration`,`training_form`,`description`)
+SELECT 'A_CLKTCBMA','Kỹ thuật chế biến món ăn',`id`,'TC','KTCBMA','A.5810208','5810207','Trung cấp','1 năm','Chuyển loại','Danh mục ngành đào tạo chính thức' FROM `exam_systems` WHERE `letter`='A';--> statement-breakpoint
+INSERT OR IGNORE INTO `exam_majors` (`code`,`name`,`system_id`,`level_code`,`short_code`,`catalog_number`,`national_major_code`,`qualification`,`training_duration`,`training_form`,`description`)
+SELECT 'A_TCTCNH','Tài chính – Ngân hàng',`id`,'TC','TCNH','A.5340202','5340202','Trung cấp','2 năm','Chính quy','Danh mục ngành đào tạo chính thức' FROM `exam_systems` WHERE `letter`='A';--> statement-breakpoint
+INSERT OR IGNORE INTO `exam_majors` (`code`,`name`,`system_id`,`level_code`,`short_code`,`catalog_number`,`national_major_code`,`qualification`,`training_duration`,`training_form`,`description`)
+SELECT 'A_SCNYDD','Nhân viên quân y đại đội',`id`,'SC','NYDD','A.6720100','6720100','Sơ cấp','6 tháng','Chính quy','Danh mục ngành đào tạo chính thức' FROM `exam_systems` WHERE `letter`='A';

--- a/apps/api/migrations/0046_use_catalog_number_as_major_code.sql
+++ b/apps/api/migrations/0046_use_catalog_number_as_major_code.sql
@@ -1,0 +1,21 @@
+-- Dùng mã số chính thức (A/B + mã ngành) làm mã ngành duy nhất trong hệ thống.
+-- Đổi tiền tố mã môn trước khi đổi mã ngành để còn đối chiếu được tiền tố cũ.
+UPDATE `exam_subjects`
+SET `code` = (
+	SELECT `catalog_number` || substr(`exam_subjects`.`code`, length(`exam_majors`.`code`) + 1)
+	FROM `exam_majors`
+	WHERE `exam_majors`.`id` = `exam_subjects`.`major_id`
+)
+WHERE EXISTS (
+	SELECT 1
+	FROM `exam_majors`
+	WHERE `exam_majors`.`id` = `exam_subjects`.`major_id`
+		AND `exam_majors`.`catalog_number` IS NOT NULL
+		AND `exam_majors`.`catalog_number` <> ''
+);--> statement-breakpoint
+
+UPDATE `exam_majors`
+SET `code` = `catalog_number`
+WHERE `catalog_number` IS NOT NULL
+	AND `catalog_number` <> ''
+	AND `code` <> `catalog_number`;

--- a/apps/api/migrations/0047_sync_exam_log_major_codes.sql
+++ b/apps/api/migrations/0047_sync_exam_log_major_codes.sql
@@ -1,0 +1,21 @@
+-- Đồng bộ các bản ghi lịch sử phân công với mã số ngành/môn hiện hành.
+UPDATE `exam_teaching_assignment_logs`
+SET
+	`summary` = replace(
+		replace(
+			`summary`,
+			coalesce(`subject_code`, ''),
+			coalesce((SELECT `code` FROM `exam_subjects` WHERE `id` = `subject_id`), `subject_code`, '')
+		),
+		coalesce(`major_code`, ''),
+		coalesce((SELECT `code` FROM `exam_majors` WHERE `id` = `major_id`), `major_code`, '')
+	),
+	`subject_code` = coalesce(
+		(SELECT `code` FROM `exam_subjects` WHERE `id` = `subject_id`),
+		`subject_code`
+	),
+	`major_code` = coalesce(
+		(SELECT `code` FROM `exam_majors` WHERE `id` = `major_id`),
+		`major_code`
+	)
+WHERE `major_id` IS NOT NULL OR `subject_id` IS NOT NULL;

--- a/apps/api/migrations/meta/0047_snapshot.json
+++ b/apps/api/migrations/meta/0047_snapshot.json
@@ -1,0 +1,6159 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c9dd64f7-b331-47df-ac46-69818a43617b",
+  "prevId": "dfff3282-0fb1-42a4-b9fe-17c78924f6f5",
+  "tables": {
+    "account_audit_logs": {
+      "name": "account_audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_display_name": {
+          "name": "actor_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_is_admin": {
+          "name": "actor_is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "room_code": {
+          "name": "room_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "room_name": {
+          "name": "room_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "floor_name": {
+          "name": "floor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "building_code": {
+          "name": "building_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "building_name": {
+          "name": "building_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_label": {
+          "name": "account_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "actions": {
+      "name": "actions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "actions_name_unique": {
+          "name": "actions_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "asset_broken_logs": {
+      "name": "asset_broken_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'OTHER'"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repair_request_id": {
+          "name": "repair_request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "room_asset_id": {
+          "name": "room_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_asset_id": {
+          "name": "source_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "asset_code": {
+          "name": "asset_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_code": {
+          "name": "original_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "asset_name": {
+          "name": "asset_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "original_grade": {
+          "name": "original_grade",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grade_after": {
+          "name": "grade_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "room_code": {
+          "name": "room_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "room_name": {
+          "name": "room_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "floor_name": {
+          "name": "floor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "building_code": {
+          "name": "building_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "building_name": {
+          "name": "building_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit_name": {
+          "name": "unit_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nganh_code": {
+          "name": "nganh_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_note": {
+          "name": "result_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "performer": {
+          "name": "performer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_display_name": {
+          "name": "actor_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "asset_movement_logs": {
+      "name": "asset_movement_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "room_asset_id": {
+          "name": "room_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executing_unit": {
+          "name": "executing_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "install_address": {
+          "name": "install_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "asset_code": {
+          "name": "asset_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "asset_name": {
+          "name": "asset_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "quantity_before": {
+          "name": "quantity_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "quantity_after": {
+          "name": "quantity_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "grade": {
+          "name": "grade",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "manufacture_year": {
+          "name": "manufacture_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_year": {
+          "name": "usage_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason_other": {
+          "name": "reason_other",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_date": {
+          "name": "decision_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_number": {
+          "name": "decision_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signer": {
+          "name": "signer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "performer": {
+          "name": "performer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "building_code": {
+          "name": "building_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "building_name": {
+          "name": "building_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "room_code": {
+          "name": "room_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "room_name": {
+          "name": "room_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "floor_name": {
+          "name": "floor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_movement_logs_room_asset_id_room_assets_id_fk": {
+          "name": "asset_movement_logs_room_asset_id_room_assets_id_fk",
+          "tableFrom": "asset_movement_logs",
+          "tableTo": "room_assets",
+          "columnsFrom": [
+            "room_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "asset_proposal_items": {
+      "name": "asset_proposal_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "material_code": {
+          "name": "material_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "material_name": {
+          "name": "material_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "room_asset_id": {
+          "name": "room_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_asset_id": {
+          "name": "source_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_grade": {
+          "name": "original_grade",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_code": {
+          "name": "original_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nganh_code": {
+          "name": "nganh_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chuyen_nganh_code": {
+          "name": "chuyen_nganh_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_room_id": {
+          "name": "from_room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_room_code": {
+          "name": "from_room_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_room_name": {
+          "name": "from_room_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_note": {
+          "name": "location_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_room_id": {
+          "name": "target_room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_room_code": {
+          "name": "target_room_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_room_name": {
+          "name": "target_room_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "asset_proposal_logs": {
+      "name": "asset_proposal_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "proposal_type": {
+          "name": "proposal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_display_name": {
+          "name": "actor_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_is_admin": {
+          "name": "actor_is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "asset_proposals": {
+      "name": "asset_proposals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "proposal_type": {
+          "name": "proposal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit_id": {
+          "name": "unit_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit_name": {
+          "name": "unit_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nganh_code": {
+          "name": "nganh_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposed_by_user_id": {
+          "name": "proposed_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposed_by_username": {
+          "name": "proposed_by_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "proposed_by_display_name": {
+          "name": "proposed_by_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin_note": {
+          "name": "admin_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_number": {
+          "name": "decision_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_nganh_code": {
+          "name": "decision_nganh_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_issuing_level": {
+          "name": "decision_issuing_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_signer": {
+          "name": "decision_signer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_at": {
+          "name": "decision_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_username": {
+          "name": "decided_by_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_display_name": {
+          "name": "decided_by_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "buildings": {
+      "name": "buildings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "manager_code": {
+          "name": "manager_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "area": {
+          "name": "area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "buildings_code_unique": {
+          "name": "buildings_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "catalog_audit_logs": {
+      "name": "catalog_audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_display_name": {
+          "name": "actor_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_is_admin": {
+          "name": "actor_is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entity_code": {
+          "name": "entity_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_code": {
+          "name": "parent_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_name": {
+          "name": "parent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "catalog_stock_logs": {
+      "name": "catalog_stock_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "movement_type": {
+          "name": "movement_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "material_code": {
+          "name": "material_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "material_name": {
+          "name": "material_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nganh_code": {
+          "name": "nganh_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chuyen_nganh_code": {
+          "name": "chuyen_nganh_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chuyen_nganh_name": {
+          "name": "chuyen_nganh_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "quantity_before": {
+          "name": "quantity_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "quantity_after": {
+          "name": "quantity_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_new_material": {
+          "name": "is_new_material",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_display_name": {
+          "name": "actor_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_is_admin": {
+          "name": "actor_is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "categories_code_unique": {
+          "name": "categories_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "classes": {
+      "name": "classes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "graduatedAt": {
+          "name": "graduatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'ongoing'"
+        },
+        "unitId": {
+          "name": "unitId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "class_unit_unique_constraint": {
+          "name": "class_unit_unique_constraint",
+          "columns": [
+            "name",
+            "unitId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "classes_unitId_units_id_fk": {
+          "name": "classes_unitId_units_id_fk",
+          "tableFrom": "classes",
+          "tableTo": "units",
+          "columnsFrom": [
+            "unitId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exam_academic_titles": {
+      "name": "exam_academic_titles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "percentage": {
+          "name": "percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "exam_academic_titles_name_uq": {
+          "name": "exam_academic_titles_name_uq",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exam_classes": {
+      "name": "exam_classes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "major_id": {
+          "name": "major_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "faculty_id": {
+          "name": "faculty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cohort": {
+          "name": "cohort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "exam_classes_code_unique": {
+          "name": "exam_classes_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exam_draw_logs": {
+      "name": "exam_draw_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "draw_id": {
+          "name": "draw_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_display_name": {
+          "name": "actor_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exam_draws": {
+      "name": "exam_draws",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "draw_code": {
+          "name": "draw_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exam_id": {
+          "name": "exam_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exam_code": {
+          "name": "exam_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paper_number": {
+          "name": "paper_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "major_id": {
+          "name": "major_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "draw_type": {
+          "name": "draw_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "class_name": {
+          "name": "class_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "drawn_by_user_id": {
+          "name": "drawn_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "drawn_by_username": {
+          "name": "drawn_by_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "drawn_by_display_name": {
+          "name": "drawn_by_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "drawn_at": {
+          "name": "drawn_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "printed_at": {
+          "name": "printed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "printed_by_user_id": {
+          "name": "printed_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "printed_by_username": {
+          "name": "printed_by_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "print_blocked": {
+          "name": "print_blocked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "print_blocked_at": {
+          "name": "print_blocked_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "print_blocked_reason": {
+          "name": "print_blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exam_date": {
+          "name": "exam_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exam_time": {
+          "name": "exam_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "exam_draws_draw_code_unique": {
+          "name": "exam_draws_draw_code_unique",
+          "columns": [
+            "draw_code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exam_faculties": {
+      "name": "exam_faculties",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "major_id": {
+          "name": "major_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "exam_faculties_major_code_uq": {
+          "name": "exam_faculties_major_code_uq",
+          "columns": [
+            "major_id",
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exam_faculty_heads": {
+      "name": "exam_faculty_heads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "faculty_code": {
+          "name": "faculty_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "faculty_name": {
+          "name": "faculty_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "exam_faculty_heads_user_fac_uq": {
+          "name": "exam_faculty_heads_user_fac_uq",
+          "columns": [
+            "user_id",
+            "faculty_code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exam_major_heads": {
+      "name": "exam_major_heads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "major_id": {
+          "name": "major_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exam_majors": {
+      "name": "exam_majors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_id": {
+          "name": "system_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level_code": {
+          "name": "level_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "short_code": {
+          "name": "short_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "catalog_number": {
+          "name": "catalog_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "national_major_code": {
+          "name": "national_major_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "qualification": {
+          "name": "qualification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "training_duration": {
+          "name": "training_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "training_form": {
+          "name": "training_form",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "exam_majors_code_unique": {
+          "name": "exam_majors_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exam_questions": {
+      "name": "exam_questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "exam_id": {
+          "name": "exam_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question_number": {
+          "name": "question_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exam_subjects": {
+      "name": "exam_subjects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_code": {
+          "name": "base_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credit_hours": {
+          "name": "credit_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lesson_hours": {
+          "name": "lesson_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "faculty_id": {
+          "name": "faculty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "major_id": {
+          "name": "major_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "exam_subjects_code_unique": {
+          "name": "exam_subjects_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exam_systems": {
+      "name": "exam_systems",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "letter": {
+          "name": "letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "training_type_id": {
+          "name": "training_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "exam_systems_code_unique": {
+          "name": "exam_systems_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        },
+        "exam_systems_letter_unique": {
+          "name": "exam_systems_letter_unique",
+          "columns": [
+            "letter"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exam_teachers": {
+      "name": "exam_teachers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "faculty_code": {
+          "name": "faculty_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "faculty_name": {
+          "name": "faculty_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "academic_title_id": {
+          "name": "academic_title_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_username": {
+          "name": "created_by_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_display_name": {
+          "name": "created_by_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "exam_teachers_user_uq": {
+          "name": "exam_teachers_user_uq",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exam_teaching_assignment_logs": {
+      "name": "exam_teaching_assignment_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject_code": {
+          "name": "subject_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject_name": {
+          "name": "subject_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "major_id": {
+          "name": "major_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "major_code": {
+          "name": "major_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "faculty_id": {
+          "name": "faculty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "faculty_code": {
+          "name": "faculty_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "class_code": {
+          "name": "class_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "class_name": {
+          "name": "class_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "teacher_user_id": {
+          "name": "teacher_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "teacher_username": {
+          "name": "teacher_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "teacher_display_name": {
+          "name": "teacher_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_display_name": {
+          "name": "actor_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exam_teaching_assignments": {
+      "name": "exam_teaching_assignments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "teaching_start": {
+          "name": "teaching_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "teaching_end": {
+          "name": "teaching_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assigned_by_user_id": {
+          "name": "assigned_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assigned_by_username": {
+          "name": "assigned_by_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assigned_by_display_name": {
+          "name": "assigned_by_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exam_workflow_logs": {
+      "name": "exam_workflow_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "exam_id": {
+          "name": "exam_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_display_name": {
+          "name": "actor_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exams": {
+      "name": "exams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paper_number": {
+          "name": "paper_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'DRAFT'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_username": {
+          "name": "created_by_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_display_name": {
+          "name": "created_by_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_by_username": {
+          "name": "approved_by_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_by_display_name": {
+          "name": "approved_by_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_by_rank": {
+          "name": "approved_by_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_by_position": {
+          "name": "approved_by_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_by_signature_url": {
+          "name": "approved_by_signature_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_by_title": {
+          "name": "approved_by_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dept_head_user_id": {
+          "name": "dept_head_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dept_head_username": {
+          "name": "dept_head_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dept_head_display_name": {
+          "name": "dept_head_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dept_head_rank": {
+          "name": "dept_head_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dept_head_signature_url": {
+          "name": "dept_head_signature_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dept_head_approved_at": {
+          "name": "dept_head_approved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "qr_code": {
+          "name": "qr_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locked": {
+          "name": "locked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "class_name": {
+          "name": "class_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 60
+        },
+        "question_file_url": {
+          "name": "question_file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "question_file_name": {
+          "name": "question_file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "answer_file_url": {
+          "name": "answer_file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "answer_file_name": {
+          "name": "answer_file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "return_note": {
+          "name": "return_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "exams_code_unique": {
+          "name": "exams_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "floors": {
+      "name": "floors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "building_id": {
+          "name": "building_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "floor_number": {
+          "name": "floor_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "floors_building_id_buildings_id_fk": {
+          "name": "floors_building_id_buildings_id_fk",
+          "tableFrom": "floors",
+          "tableTo": "buildings",
+          "columnsFrom": [
+            "building_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "resources": {
+      "name": "resources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "resources_name_unique": {
+          "name": "resources_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "permissions": {
+      "name": "permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_id": {
+          "name": "action_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "permissions_name_unique": {
+          "name": "permissions_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "permissions_resource_id_resources_id_fk": {
+          "name": "permissions_resource_id_resources_id_fk",
+          "tableFrom": "permissions",
+          "tableTo": "resources",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "permissions_action_id_actions_id_fk": {
+          "name": "permissions_action_id_actions_id_fk",
+          "tableFrom": "permissions",
+          "tableTo": "actions",
+          "columnsFrom": [
+            "action_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "roles": {
+      "name": "roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "role_permissions": {
+      "name": "role_permissions",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_id_pk": {
+          "columns": [
+            "role_id",
+            "permission_id"
+          ],
+          "name": "role_permissions_role_id_permission_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_roles": {
+      "name": "user_roles",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "columns": [
+            "user_id",
+            "role_id"
+          ],
+          "name": "user_roles_user_id_role_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "isSuperUser": {
+          "name": "isSuperUser",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "unitId": {
+          "name": "unitId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signature_url": {
+          "name": "signature_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "users_unitId_units_id_fk": {
+          "name": "users_unitId_units_id_fk",
+          "tableFrom": "users",
+          "tableTo": "units",
+          "columnsFrom": [
+            "unitId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "units": {
+      "name": "units",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "units_alias_unique": {
+          "name": "units_alias_unique",
+          "columns": [
+            "alias"
+          ],
+          "isUnique": true
+        },
+        "units_name_unique": {
+          "name": "units_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "parent_id_fk": {
+          "name": "parent_id_fk",
+          "tableFrom": "units",
+          "tableTo": "units",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "students": {
+      "name": "students",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "fullName": {
+          "name": "fullName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "birthPlace": {
+          "name": "birthPlace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "dob": {
+          "name": "dob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "previousUnit": {
+          "name": "previousUnit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "previousPosition": {
+          "name": "previousPosition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'Học viên'"
+        },
+        "ethnic": {
+          "name": "ethnic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "religion": {
+          "name": "religion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'Không'"
+        },
+        "enlistmentPeriod": {
+          "name": "enlistmentPeriod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "politicalOrg": {
+          "name": "politicalOrg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "politicalOrgOfficialDate": {
+          "name": "politicalOrgOfficialDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cpvId": {
+          "name": "cpvId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "educationLevel": {
+          "name": "educationLevel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "schoolName": {
+          "name": "schoolName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "major": {
+          "name": "major",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "isGraduated": {
+          "name": "isGraduated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "talent": {
+          "name": "talent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'Không'"
+        },
+        "shortcoming": {
+          "name": "shortcoming",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'Không'"
+        },
+        "policyBeneficiaryGroup": {
+          "name": "policyBeneficiaryGroup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'Không'"
+        },
+        "fatherName": {
+          "name": "fatherName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "fatherDob": {
+          "name": "fatherDob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "fatherPhoneNumber": {
+          "name": "fatherPhoneNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "fatherJob": {
+          "name": "fatherJob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "motherName": {
+          "name": "motherName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "motherDob": {
+          "name": "motherDob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "motherPhoneNumber": {
+          "name": "motherPhoneNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "motherJob": {
+          "name": "motherJob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "isMarried": {
+          "name": "isMarried",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "spouseName": {
+          "name": "spouseName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "spouseDob": {
+          "name": "spouseDob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "spouseJob": {
+          "name": "spouseJob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "spousePhoneNumber": {
+          "name": "spousePhoneNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "childrenInfos": {
+          "name": "childrenInfos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "familySize": {
+          "name": "familySize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "familyBackground": {
+          "name": "familyBackground",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'Không'"
+        },
+        "familyBirthOrder": {
+          "name": "familyBirthOrder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "achievement": {
+          "name": "achievement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'Không'"
+        },
+        "disciplinaryHistory": {
+          "name": "disciplinaryHistory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'Không'"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "classId": {
+          "name": "classId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cpvOfficialAt": {
+          "name": "cpvOfficialAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "siblings": {
+          "name": "siblings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "contactPerson": {
+          "name": "contactPerson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "studentId": {
+          "name": "studentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "relatedDocumentations": {
+          "name": "relatedDocumentations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "students_classId_classes_id_fk": {
+          "name": "students_classId_classes_id_fk",
+          "tableFrom": "students",
+          "tableTo": "classes",
+          "columnsFrom": [
+            "classId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rooms": {
+      "name": "rooms",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "floor_id": {
+          "name": "floor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "room_code": {
+          "name": "room_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "room_name": {
+          "name": "room_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "room_type": {
+          "name": "room_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "manager": {
+          "name": "manager",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "manager_code": {
+          "name": "manager_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_password": {
+          "name": "account_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rooms_room_code_unique": {
+          "name": "rooms_room_code_unique",
+          "columns": [
+            "room_code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "rooms_floor_id_floors_id_fk": {
+          "name": "rooms_floor_id_floors_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "floors",
+          "columnsFrom": [
+            "floor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rooms_class_id_classes_id_fk": {
+          "name": "rooms_class_id_classes_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "classes",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "room_images": {
+      "name": "room_images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "room_images_room_id_rooms_id_fk": {
+          "name": "room_images_room_id_rooms_id_fk",
+          "tableFrom": "room_images",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "room_assets": {
+      "name": "room_assets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "broken_quantity": {
+          "name": "broken_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "holding_unit_id": {
+          "name": "holding_unit_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "manufacture_year": {
+          "name": "manufacture_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_year": {
+          "name": "usage_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "install_address": {
+          "name": "install_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'NORMAL'"
+        },
+        "purchase_date": {
+          "name": "purchase_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "broken_at": {
+          "name": "broken_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repair_started_at": {
+          "name": "repair_started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repair_completed_at": {
+          "name": "repair_completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repair_performer": {
+          "name": "repair_performer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "room_assets_code_unique": {
+          "name": "room_assets_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "room_assets_room_id_rooms_id_fk": {
+          "name": "room_assets_room_id_rooms_id_fk",
+          "tableFrom": "room_assets",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "room_assets_holding_unit_id_units_id_fk": {
+          "name": "room_assets_holding_unit_id_units_id_fk",
+          "tableFrom": "room_assets",
+          "tableTo": "units",
+          "columnsFrom": [
+            "holding_unit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "repair_logs": {
+      "name": "repair_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "room_asset_id": {
+          "name": "room_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repair_date": {
+          "name": "repair_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "performer": {
+          "name": "performer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "repair_logs_room_asset_id_room_assets_id_fk": {
+          "name": "repair_logs_room_asset_id_room_assets_id_fk",
+          "tableFrom": "repair_logs",
+          "tableTo": "room_assets",
+          "columnsFrom": [
+            "room_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory_logs": {
+      "name": "inventory_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "room_asset_id": {
+          "name": "room_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inventory_date": {
+          "name": "inventory_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actual_quantity": {
+          "name": "actual_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expected_quantity": {
+          "name": "expected_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "inventory_logs_room_asset_id_room_assets_id_fk": {
+          "name": "inventory_logs_room_asset_id_room_assets_id_fk",
+          "tableFrom": "inventory_logs",
+          "tableTo": "room_assets",
+          "columnsFrom": [
+            "room_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "replacement_logs": {
+      "name": "replacement_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "room_asset_id": {
+          "name": "room_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replacement_date": {
+          "name": "replacement_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "old_asset": {
+          "name": "old_asset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "new_asset": {
+          "name": "new_asset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "performer": {
+          "name": "performer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "replacement_logs_room_asset_id_room_assets_id_fk": {
+          "name": "replacement_logs_room_asset_id_room_assets_id_fk",
+          "tableFrom": "replacement_logs",
+          "tableTo": "room_assets",
+          "columnsFrom": [
+            "room_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_nganh": {
+      "name": "user_nganh",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nganh_code": {
+          "name": "nganh_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_nganh_user_nganh_uq": {
+          "name": "user_nganh_user_nganh_uq",
+          "columns": [
+            "user_id",
+            "nganh_code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_nganh_user_id_users_id_fk": {
+          "name": "user_nganh_user_id_users_id_fk",
+          "tableFrom": "user_nganh",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "repair_requests": {
+      "name": "repair_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "room_asset_id": {
+          "name": "room_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_asset_id": {
+          "name": "source_asset_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "original_grade": {
+          "name": "original_grade",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "asset_name": {
+          "name": "asset_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'PENDING'"
+        },
+        "broken_at": {
+          "name": "broken_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reported_by_name": {
+          "name": "reported_by_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reported_by_user_id": {
+          "name": "reported_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assigned_to_name": {
+          "name": "assigned_to_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assigned_by_name": {
+          "name": "assigned_by_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repair_started_at": {
+          "name": "repair_started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin_note": {
+          "name": "admin_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "repair_requests_room_id_rooms_id_fk": {
+          "name": "repair_requests_room_id_rooms_id_fk",
+          "tableFrom": "repair_requests",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repair_requests_room_asset_id_room_assets_id_fk": {
+          "name": "repair_requests_room_asset_id_room_assets_id_fk",
+          "tableFrom": "repair_requests",
+          "tableTo": "room_assets",
+          "columnsFrom": [
+            "room_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "repair_requests_source_asset_id_room_assets_id_fk": {
+          "name": "repair_requests_source_asset_id_room_assets_id_fk",
+          "tableFrom": "repair_requests",
+          "tableTo": "room_assets",
+          "columnsFrom": [
+            "source_asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "repair_requests_reported_by_user_id_users_id_fk": {
+          "name": "repair_requests_reported_by_user_id_users_id_fk",
+          "tableFrom": "repair_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reported_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "suppliers": {
+      "name": "suppliers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact_person": {
+          "name": "contact_person",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "suppliers_code_unique": {
+          "name": "suppliers_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "materials": {
+      "name": "materials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "min_quantity": {
+          "name": "min_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ACTIVE'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "materials_code_unique": {
+          "name": "materials_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "materials_category_id_categories_id_fk": {
+          "name": "materials_category_id_categories_id_fk",
+          "tableFrom": "materials",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "materials_supplier_id_suppliers_id_fk": {
+          "name": "materials_supplier_id_suppliers_id_fk",
+          "tableFrom": "materials",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "warehouses": {
+      "name": "warehouses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "manager": {
+          "name": "manager",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "warehouses_code_unique": {
+          "name": "warehouses_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "warehouse_items": {
+      "name": "warehouse_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "min_quantity": {
+          "name": "min_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "warehouse_items_warehouse_id_warehouses_id_fk": {
+          "name": "warehouse_items_warehouse_id_warehouses_id_fk",
+          "tableFrom": "warehouse_items",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "warehouse_items_material_id_materials_id_fk": {
+          "name": "warehouse_items_material_id_materials_id_fk",
+          "tableFrom": "warehouse_items",
+          "tableTo": "materials",
+          "columnsFrom": [
+            "material_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_items": {
+      "name": "notification_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "notifiableType": {
+          "name": "notifiableType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notifiableId": {
+          "name": "notifiableId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notificationId": {
+          "name": "notificationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "notification_items_notification_idx": {
+          "name": "notification_items_notification_idx",
+          "columns": [
+            "notificationId"
+          ],
+          "isUnique": false
+        },
+        "notification_items_item_idx": {
+          "name": "notification_items_item_idx",
+          "columns": [
+            "notifiableType",
+            "notifiableId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notification_items_notificationId_notifications_id_fk": {
+          "name": "notification_items_notificationId_notifications_id_fk",
+          "tableFrom": "notification_items",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notificationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notificationType": {
+          "name": "notificationType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'birthday'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "isBatch": {
+          "name": "isBatch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "batchKey": {
+          "name": "batchKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "totalCount": {
+          "name": "totalCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "recipientId": {
+          "name": "recipientId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recipient_idx": {
+          "name": "recipient_idx",
+          "columns": [
+            "recipientId"
+          ],
+          "isUnique": false
+        },
+        "batch_idx": {
+          "name": "batch_idx",
+          "columns": [
+            "batchKey"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_recipientId_users_id_fk": {
+          "name": "notifications_recipientId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_actorId_users_id_fk": {
+          "name": "notifications_actorId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/api/migrations/meta/_journal.json
+++ b/apps/api/migrations/meta/_journal.json
@@ -295,6 +295,48 @@
 			"when": 1766100000000,
 			"tag": "0041_exam-assignment-teaching-period",
 			"breakpoints": true
+		},
+		{
+			"idx": 42,
+			"version": "6",
+			"when": 1785552000000,
+			"tag": "0042_exam_academic_titles",
+			"breakpoints": true
+		},
+		{
+			"idx": 43,
+			"version": "6",
+			"when": 1785552600000,
+			"tag": "0043_restore_exam_classes",
+			"breakpoints": true
+		},
+		{
+			"idx": 44,
+			"version": "6",
+			"when": 1785553200000,
+			"tag": "0044_restore_exam_runtime_tables",
+			"breakpoints": true
+		},
+		{
+			"idx": 45,
+			"version": "6",
+			"when": 1785553800000,
+			"tag": "0045_exam_major_official_catalog",
+			"breakpoints": true
+		},
+		{
+			"idx": 46,
+			"version": "6",
+			"when": 1785554400000,
+			"tag": "0046_use_catalog_number_as_major_code",
+			"breakpoints": true
+		},
+		{
+			"idx": 47,
+			"version": "6",
+			"when": 1785555000000,
+			"tag": "0047_sync_exam_log_major_codes",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/api/schema/exam-bank.ts
+++ b/apps/api/schema/exam-bank.ts
@@ -47,7 +47,7 @@ export const examSystems = sqliteTable('exam_systems', {
 /**
  * Ngành đào tạo thuộc một hệ (cột trên sheet tổng hợp).
  * Tên vd «Y sĩ đa khoa (trung cấp)»; trình độ gắn trong ngành (levelCode).
- * Mã: {letter}_{LEVEL}{MAJOR_ABBR} — vd B_CDDD (chỉnh tay được).
+ * Mã dùng chính mã số danh mục — vd B.6720301.
  */
 export const examMajors = sqliteTable('exam_majors', {
 	...baseSchema,
@@ -58,6 +58,13 @@ export const examMajors = sqliteTable('exam_majors', {
 	levelCode: text('level_code'),
 	/** Viết tắt ngành (DD, YSDK, DUOC…) */
 	shortCode: text('short_code'),
+	/** Mã số chương trình hiển thị, vd A.6720101 */
+	catalogNumber: text('catalog_number'),
+	/** Mã ngành theo danh mục Bộ GDĐT, vd 6720101 */
+	nationalMajorCode: text('national_major_code'),
+	qualification: text('qualification'),
+	trainingDuration: text('training_duration'),
+	trainingForm: text('training_form'),
 	description: text('description')
 })
 
@@ -94,7 +101,7 @@ export const examClasses = sqliteTable('exam_classes', {
 
 /**
  * Môn học thuộc khoa.
- * code = full (B_CDDD_M009K2), baseCode = mã gốc file (M009K2)
+ * code = full (B.6720301_M009K2), baseCode = mã gốc file (M009K2)
  * majorId denormalized từ faculty để join đề thi / CNK.
  */
 export const examSubjects = sqliteTable('exam_subjects', {
@@ -175,6 +182,8 @@ export const examTeachers = sqliteTable(
 		/** Mã khoa trong DMĐT: K1…K8 (không dùng faculty_id vì lặp theo ngành) */
 		facultyCode: text('faculty_code').notNull(),
 		facultyName: text('faculty_name'),
+		/** Chức danh giảng dạy, tham chiếu exam_academic_titles */
+		academicTitleId: int('academic_title_id'),
 		note: text('note'),
 		createdByUserId: int('created_by_user_id'),
 		createdByUsername: text('created_by_username'),
@@ -183,6 +192,18 @@ export const examTeachers = sqliteTable(
 	(t) => ({
 		uqUser: uniqueIndex('exam_teachers_user_uq').on(t.userId)
 	})
+)
+
+/** Danh mục chức danh giảng dạy và định mức quy đổi (%). */
+export const examAcademicTitles = sqliteTable(
+	'exam_academic_titles',
+	{
+		...baseSchema,
+		name: text('name').notNull(),
+		percentage: int('percentage').notNull(),
+		sortOrder: int('sort_order').notNull().default(0)
+	},
+	(t) => ({ uqName: uniqueIndex('exam_academic_titles_name_uq').on(t.name) })
 )
 
 /**

--- a/apps/web/src/api/exam.ts
+++ b/apps/web/src/api/exam.ts
@@ -42,7 +42,7 @@ export interface ExamSystem {
 	description: string | null
 }
 
-/** Ngành đào tạo (cột chương trình) — mã vd B_CDDD */
+/** Ngành đào tạo (cột chương trình) — mã dùng mã số, vd B.6720301 */
 export interface ExamMajor {
 	id: number
 	createdAt: string
@@ -52,6 +52,11 @@ export interface ExamMajor {
 	systemId: number
 	levelCode: string | null
 	shortCode: string | null
+	catalogNumber: string | null
+	nationalMajorCode: string | null
+	qualification: string | null
+	trainingDuration: string | null
+	trainingForm: string | null
 	systemCode?: string | null
 	systemName?: string | null
 	systemLetter?: string | null
@@ -305,15 +310,39 @@ export interface ExamTeacherCatalog {
 	displayName: string | null
 	facultyCode: string
 	facultyName: string | null
+	academicTitleId: number | null
+	academicTitleName: string | null
+	academicTitlePercentage: number | null
 	note: string | null
 	createdByUserId?: number | null
 	createdByUsername?: string | null
 	createdByDisplayName?: string | null
 }
 
+export interface ExamAcademicTitle {
+	id: number
+	createdAt: string
+	updatedAt: string
+	name: string
+	percentage: number
+	sortOrder: number
+}
+
 export interface ExamFacultyOption {
 	code: string
 	name: string
+}
+
+export interface ExamFacultyHead {
+	id: number
+	createdAt: string
+	updatedAt: string
+	facultyCode: string
+	facultyName: string | null
+	userId: number
+	username: string | null
+	displayName: string | null
+	note: string | null
 }
 
 // ── Hệ → Ngành → Khoa → Môn / Lớp ────────────────────────────
@@ -382,6 +411,11 @@ export async function CreateExamMajor(body: {
 	shortCode?: string | null
 	/** Để trống → tự sinh A/B_CD… */
 	code?: string | null
+	catalogNumber?: string | null
+	nationalMajorCode?: string | null
+	qualification?: string | null
+	trainingDuration?: string | null
+	trainingForm?: string | null
 	description?: string
 }) {
 	const resp = await jsonFetch<{ data: ExamMajor }>('/exam/majors', {
@@ -399,6 +433,11 @@ export async function UpdateExamMajor(
 		levelCode?: string | null
 		shortCode?: string | null
 		systemId?: number
+		catalogNumber?: string | null
+		nationalMajorCode?: string | null
+		qualification?: string | null
+		trainingDuration?: string | null
+		trainingForm?: string | null
 		description?: string | null
 	}
 ) {
@@ -547,6 +586,8 @@ export async function ListExamSubjects(params?: {
 export async function CreateExamSubject(body: {
 	name: string
 	facultyId: number
+	majorId?: number
+	sourceSubjectId?: number
 	baseCode?: string
 	code?: string
 	creditHours?: number
@@ -628,7 +669,10 @@ export async function CreateExamAssignment(body: {
 }) {
 	const resp = await jsonFetch<{ data: ExamAssignment }>(
 		'/exam/assignments',
-		{ method: 'POST', body: JSON.stringify(body) }
+		{
+			method: 'POST',
+			body: JSON.stringify(body)
+		}
 	)
 	return resp.data
 }
@@ -694,6 +738,13 @@ export async function ListExamFacultyOptions() {
 	return resp.data
 }
 
+export async function ListExamFacultyHeads() {
+	const resp = await jsonFetch<{ data: ExamFacultyHead[] }>(
+		'/exam/faculty-heads'
+	)
+	return resp.data
+}
+
 /** Gán Chủ nhiệm khoa theo mã khoa (1 CNK / khoa) — admin */
 export async function UpsertExamFacultyHead(body: {
 	userId: number
@@ -716,6 +767,15 @@ export async function UpsertExamFacultyHead(body: {
 	return resp.data
 }
 
+export async function DeleteExamFacultyHead(facultyCode: string) {
+	return jsonFetch<{ ok: boolean }>(
+		`/exam/faculty-heads/${encodeURIComponent(facultyCode)}`,
+		{
+			method: 'DELETE'
+		}
+	)
+}
+
 export async function ListExamTeacherCatalog(params?: {
 	facultyCode?: string
 	q?: string
@@ -728,6 +788,52 @@ export async function ListExamTeacherCatalog(params?: {
 		`/exam/teacher-catalog${qs}`
 	)
 	return resp.data
+}
+
+export async function ListExamAcademicTitles() {
+	const resp = await jsonFetch<{ data: ExamAcademicTitle[] }>(
+		'/exam/academic-titles'
+	)
+	return resp.data
+}
+
+export async function CreateExamAcademicTitle(body: {
+	name: string
+	percentage: number
+	sortOrder?: number
+}) {
+	const resp = await jsonFetch<{ data: ExamAcademicTitle }>(
+		'/exam/academic-titles',
+		{
+			method: 'POST',
+			body: JSON.stringify(body)
+		}
+	)
+	return resp.data
+}
+
+export async function UpdateExamAcademicTitle(
+	id: number,
+	body: {
+		name: string
+		percentage: number
+		sortOrder?: number
+	}
+) {
+	const resp = await jsonFetch<{ data: ExamAcademicTitle }>(
+		`/exam/academic-titles/${id}`,
+		{
+			method: 'PATCH',
+			body: JSON.stringify(body)
+		}
+	)
+	return resp.data
+}
+
+export async function DeleteExamAcademicTitle(id: number) {
+	return jsonFetch<{ ok: boolean }>(`/exam/academic-titles/${id}`, {
+		method: 'DELETE'
+	})
 }
 
 export async function ListExamTeacherCandidates(q?: string) {
@@ -745,6 +851,7 @@ export async function CreateExamTeacherCatalog(body: {
 	password?: string
 	displayName?: string
 	facultyCode: string
+	academicTitleId: number
 	note?: string
 }) {
 	const resp = await jsonFetch<{ data: ExamTeacherCatalog }>(
@@ -758,6 +865,7 @@ export async function UpdateExamTeacherCatalog(
 	id: number,
 	body: {
 		facultyCode?: string
+		academicTitleId?: number
 		displayName?: string
 		note?: string | null
 	}
@@ -904,7 +1012,10 @@ export async function DeleteExam(id: number) {
 export async function SubmitExam(id: number, note?: string) {
 	const resp = await jsonFetch<{ data: ExamItem }>(
 		`/exam/exams/${id}/submit`,
-		{ method: 'POST', body: JSON.stringify({ note }) }
+		{
+			method: 'POST',
+			body: JSON.stringify({ note })
+		}
 	)
 	return resp.data
 }
@@ -916,7 +1027,10 @@ export async function DecideExam(
 ) {
 	const resp = await jsonFetch<{ data: ExamItem }>(
 		`/exam/exams/${id}/decide`,
-		{ method: 'POST', body: JSON.stringify({ decision, note }) }
+		{
+			method: 'POST',
+			body: JSON.stringify({ decision, note })
+		}
 	)
 	return resp.data
 }
@@ -1275,7 +1389,7 @@ export async function printDrawMinutes(params: {
 	return r
 }
 
-/** Đề đã rút quá 3 ngày — không cho in */
+/** Phiếu có |ngày thi − ngày hiện tại| > 3 — không cho in */
 export async function ListOverdueDraws() {
 	const resp = await jsonFetch<{ data: ExamDraw[] }>('/exam/draws-overdue')
 	return resp.data

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -316,6 +316,12 @@ const data = {
 					examKey: 'classes' as const
 				},
 				{
+					title: 'Danh mục khoa',
+					url: '/de-thi/khoa',
+					icon: Layers,
+					examKey: 'faculties' as const
+				},
+				{
 					title: 'Danh mục giáo viên',
 					url: '/de-thi/giao-vien',
 					icon: UsersRound,
@@ -739,6 +745,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 					examKey: 'overview' as const
 				},
 				{
+					title: 'Danh mục khoa',
+					url: '/de-thi/khoa',
+					icon: Layers
+				},
+				{
 					title: 'Danh mục giáo viên',
 					url: '/de-thi/giao-vien',
 					icon: UsersRound,
@@ -935,6 +946,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 					url: '/de-thi/lop',
 					icon: GraduationCap,
 					examKey: 'classes'
+				},
+				{
+					title: 'Danh mục khoa',
+					url: '/de-thi/khoa',
+					icon: Layers
 				},
 				{
 					title: 'Danh mục giáo viên',

--- a/apps/web/src/components/exam/ExamCatalogPage.tsx
+++ b/apps/web/src/components/exam/ExamCatalogPage.tsx
@@ -1,12 +1,12 @@
 /**
  * Danh mục đào tạo (khớp sheet Tổng hợp mã môn):
- *   Hệ (Quân sự A / Dân sự B)
- *     → Ngành (Y sĩ TC/CD/LT, Điều dưỡng, Dược…)
- *       → Khoa → Môn
+ *   Hệ → Ngành đào tạo
+ *   Khoa → Môn học do khoa đảm nhận (danh mục dùng chung theo mã khoa)
  */
 import { useEffect, useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
+	Building2,
 	ChevronDown,
 	ChevronRight,
 	GraduationCap,
@@ -181,6 +181,46 @@ export default function ExamCatalogPage() {
 		return m
 	}, [subjects])
 
+	/**
+	 * Dữ liệu cũ lưu một bản ghi khoa cho từng ngành. Danh mục khoa dùng chung
+	 * gom các bản ghi đó theo mã để người dùng chỉ thấy một khoa và toàn bộ môn
+	 * mà khoa đảm nhận ở các ngành.
+	 */
+	const facultyDirectory = useMemo(() => {
+		const grouped = new Map<
+			string,
+			{
+				code: string
+				name: string
+				majorNames: Set<string>
+				subjects: ExamSubject[]
+			}
+		>()
+		for (const faculty of faculties) {
+			const code = faculty.code.trim().toUpperCase()
+			const current = grouped.get(code) || {
+				code,
+				name: faculty.name,
+				majorNames: new Set<string>(),
+				subjects: []
+			}
+			if (faculty.majorName) current.majorNames.add(faculty.majorName)
+			current.subjects.push(...(subjectsByFaculty.get(faculty.id) || []))
+			grouped.set(code, current)
+		}
+		return [...grouped.values()]
+			.map((faculty) => ({
+				...faculty,
+				majorNames: [...faculty.majorNames].sort((a, b) =>
+					a.localeCompare(b, 'vi')
+				),
+				subjects: faculty.subjects.sort((a, b) =>
+					a.name.localeCompare(b.name, 'vi')
+				)
+			}))
+			.sort((a, b) => a.code.localeCompare(b.code, 'vi'))
+	}, [faculties, subjectsByFaculty])
+
 	function toggle(
 		setter: (fn: (prev: Set<number>) => Set<number>) => void,
 		id: number
@@ -291,30 +331,56 @@ export default function ExamCatalogPage() {
 	})
 
 	const saveFaculty = useMutation({
-		mutationFn: () => {
+		mutationFn: async () => {
+			if (editFacultyId === -1) {
+				const sameFaculty = faculties.filter(
+					(f) =>
+						f.code.trim().toUpperCase() ===
+						facultyForm.majorLabel.trim().toUpperCase()
+				)
+				return Promise.all(
+					sameFaculty.map((faculty) =>
+						UpdateExamFaculty(faculty.id, {
+							code: facultyForm.code,
+							name: facultyForm.name
+						})
+					)
+				)
+			}
 			if (editFacultyId != null) {
-				return UpdateExamFaculty(editFacultyId, {
+				return [
+					await UpdateExamFaculty(editFacultyId, {
+						code: facultyForm.code,
+						name: facultyForm.name,
+						majorId: facultyForm.majorId
+					})
+				]
+			}
+			return [
+				await CreateExamFaculty({
 					code: facultyForm.code,
 					name: facultyForm.name,
 					majorId: facultyForm.majorId
 				})
-			}
-			return CreateExamFaculty({
-				code: facultyForm.code,
-				name: facultyForm.name,
-				majorId: facultyForm.majorId
-			})
+			]
 		},
-		onSuccess: (f) => {
+		onSuccess: (rows) => {
+			const f = rows[0]
 			toast.success(
-				editFacultyId != null ? 'Đã cập nhật khoa' : 'Đã thêm khoa'
+				editFacultyId === -1
+					? `Đã cập nhật khoa trên ${rows.length} ngành`
+					: editFacultyId != null
+						? 'Đã cập nhật khoa'
+						: 'Đã thêm khoa'
 			)
 			setFacultyOpen(false)
 			setEditFacultyId(null)
 			void qc.invalidateQueries({ queryKey: ['exam-faculties'] })
 			void qc.invalidateQueries({ queryKey: ['exam-subjects'] })
-			setOpenMajors((p) => new Set(p).add(f.majorId))
-			setOpenFaculties((p) => new Set(p).add(f.id))
+			if (f) {
+				setOpenMajors((p) => new Set(p).add(f.majorId))
+				setOpenFaculties((p) => new Set(p).add(f.id))
+			}
 		},
 		onError: (e: Error) => toast.error(e.message)
 	})
@@ -438,6 +504,18 @@ export default function ExamCatalogPage() {
 		setFacultyOpen(true)
 	}
 
+	function openEditFacultyDirectory(code: string, name: string) {
+		setEditFacultyId(-1)
+		setFacultyForm({
+			code,
+			name,
+			majorId: 0,
+			/** Tạm giữ mã gốc để cập nhật mọi bản ghi khoa cùng mã. */
+			majorLabel: code
+		})
+		setFacultyOpen(true)
+	}
+
 	function openAddSubject(f: ExamFaculty, m?: ExamMajor) {
 		const major = m || majors.find((x) => x.id === f.majorId) || null
 		setEditSubjectId(null)
@@ -488,9 +566,8 @@ export default function ExamCatalogPage() {
 					Danh mục đào tạo
 				</h1>
 				<p className='text-muted-foreground text-sm'>
-					Cây: <strong>Hệ</strong> → <strong>Ngành trong hệ</strong> →
-					Khoa → Môn. Ví dụ Hệ quân sự gồm Y sĩ (TC/CD/LT), Điều
-					dưỡng…
+					<strong>Hệ</strong> → <strong>Ngành đào tạo</strong>. Khoa
+					là danh mục dùng chung và phụ trách giảng dạy các môn học.
 				</p>
 			</div>
 
@@ -508,6 +585,119 @@ export default function ExamCatalogPage() {
 					)?.message || 'unknown'}
 				</div>
 			)}
+
+			<Card>
+				<CardHeader className='pb-3'>
+					<CardTitle className='flex items-center gap-2'>
+						<Building2 className='h-5 w-5' />
+						Danh mục khoa
+					</CardTitle>
+					<CardDescription>
+						Mỗi khoa chỉ hiển thị một lần; bên trong là các môn học
+						do khoa đảm nhận ở tất cả ngành đào tạo.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					{loading ? (
+						<div className='flex justify-center py-8'>
+							<Loader2 className='h-7 w-7 animate-spin' />
+						</div>
+					) : !facultyDirectory.length ? (
+						<p className='text-muted-foreground py-6 text-center text-sm'>
+							Chưa có khoa trong danh mục.
+						</p>
+					) : (
+						<div className='space-y-2'>
+							{facultyDirectory.map((faculty) => (
+								<details
+									key={faculty.code}
+									className='group overflow-hidden rounded-lg border'
+								>
+									<summary className='bg-muted/40 hover:bg-muted/60 flex cursor-pointer list-none flex-wrap items-center gap-2 px-3 py-2.5'>
+										<ChevronRight className='h-4 w-4 transition-transform group-open:rotate-90' />
+										<Badge
+											variant='outline'
+											className='font-mono'
+										>
+											{faculty.code}
+										</Badge>
+										<span className='font-medium'>
+											{faculty.name}
+										</span>
+										<Badge variant='secondary'>
+											{faculty.subjects.length} môn
+										</Badge>
+										<span className='text-muted-foreground ml-auto text-xs'>
+											Phụ trách{' '}
+											{faculty.majorNames.length} ngành
+										</span>
+										{canManage && (
+											<Button
+												type='button'
+												size='icon'
+												variant='ghost'
+												className='h-7 w-7'
+												title='Sửa khoa dùng chung'
+												onClick={(event) => {
+													event.preventDefault()
+													event.stopPropagation()
+													openEditFacultyDirectory(
+														faculty.code,
+														faculty.name
+													)
+												}}
+											>
+												<Pencil className='h-3.5 w-3.5' />
+											</Button>
+										)}
+									</summary>
+									<div className='border-t p-3'>
+										{!faculty.subjects.length ? (
+											<p className='text-muted-foreground text-sm'>
+												Chưa có môn học thuộc khoa này.
+											</p>
+										) : (
+											<div className='grid gap-2 md:grid-cols-2'>
+												{faculty.subjects.map(
+													(subject) => (
+														<div
+															key={subject.id}
+															className='flex items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm'
+														>
+															<div className='min-w-0 font-medium'>
+																{subject.name}
+															</div>
+															<div className='text-muted-foreground mt-0.5 flex flex-wrap gap-x-2 text-xs'>
+																<span className='font-mono'>
+																	{
+																		subject.code
+																	}
+																</span>
+																{subject.majorName && (
+																	<span>
+																		{
+																			subject.majorName
+																		}
+																	</span>
+																)}
+																<span>
+																	{subject.creditHours ||
+																		0}{' '}
+																	tín chỉ
+																</span>
+															</div>
+														</div>
+													)
+												)}
+											</div>
+										)}
+									</div>
+								</details>
+							))}
+						</div>
+					)}
+				</CardContent>
+			</Card>
 
 			<Card>
 				<CardHeader className='flex flex-row flex-wrap items-center justify-between gap-2 space-y-0 pb-3'>
@@ -1380,6 +1570,17 @@ export default function ExamCatalogPage() {
 								/>
 							</div>
 						</div>
+						{canManage && (
+							<Button
+								size='icon'
+								variant='ghost'
+								className='h-7 w-7 shrink-0'
+								title='Sửa môn học'
+								onClick={() => openEditSubject(subject)}
+							>
+								<Pencil className='h-3.5 w-3.5' />
+							</Button>
+						)}
 					</div>
 					<DialogFooter>
 						<Button

--- a/apps/web/src/components/exam/ExamClassesPage.tsx
+++ b/apps/web/src/components/exam/ExamClassesPage.tsx
@@ -41,6 +41,7 @@ import {
 	SelectTrigger,
 	SelectValue
 } from '@/components/ui/select'
+
 import {
 	Dialog,
 	DialogContent,

--- a/apps/web/src/components/exam/ExamDrawPage.tsx
+++ b/apps/web/src/components/exam/ExamDrawPage.tsx
@@ -198,7 +198,7 @@ export default function ExamDrawPage() {
 			toast.success(
 				`Đã bốc — mã đề ${d.examCode || '—'} · mã bốc ${d.drawCode}` +
 					(d.printBlocked
-						? ' — không in (quá 3 ngày).'
+						? ' — không in (cách ngày thi quá 3 ngày).'
 						: ' — đang mở in đề (#1).') +
 					(classId ? ` Tiếp: rút phiếu «${other}» cho lớp.` : '')
 			)
@@ -716,8 +716,7 @@ export default function ExamDrawPage() {
 									}
 								/>
 								<p className='text-muted-foreground mt-1 text-[11px]'>
-									|Ngày thi − ngày rút| ≤ 3 ngày. Ngày rút =
-									ngày hệ thống khi bấm rút.
+									|Ngày thi − ngày hiện tại| ≤ 3 ngày.
 								</p>
 							</div>
 							<div>
@@ -1192,7 +1191,8 @@ export default function ExamDrawPage() {
 					<CardDescription>
 						Chỉ hiện <strong>mã đề</strong> và{' '}
 						<strong>mã bốc</strong> (không hiện chẵn/lẻ — xem kho đã
-						in). Phiếu quá 3 ngày kể từ ngày rút → không cho in.
+						in). Chỉ cho in khi ngày thi và ngày hiện tại chênh
+						không quá 3 ngày.
 					</CardDescription>
 				</CardHeader>
 				<CardContent>
@@ -1235,7 +1235,7 @@ export default function ExamDrawPage() {
 													variant='destructive'
 													className='ml-1'
 												>
-													Quá 3 ngày
+													Ngoài 3 ngày
 												</Badge>
 											) : null}
 										</TableCell>
@@ -1308,11 +1308,11 @@ export default function ExamDrawPage() {
 				</CardContent>
 			</Card>
 
-			{/* Đề đã rút quá 3 ngày — không cho in */}
+			{/* Phiếu ngoài khoảng 3 ngày so với ngày thi — không cho in */}
 			<Card className='border-destructive/40'>
 				<CardHeader>
 					<CardTitle className='text-destructive'>
-						Đề đã rút quá 3 ngày
+						Ngoài khoảng in 3 ngày so với ngày thi
 					</CardTitle>
 					<CardDescription>
 						Không cho in. Cần rút lại hoặc xử lý theo quy chế.
@@ -1331,7 +1331,9 @@ export default function ExamDrawPage() {
 									<TableHead>Mã bốc</TableHead>
 									<TableHead>Lớp</TableHead>
 									<TableHead>Ngày rút</TableHead>
-									<TableHead>Số ngày</TableHead>
+									<TableHead>
+										Chênh ngày thi/hiện tại
+									</TableHead>
 									<TableHead>Lý do</TableHead>
 								</TableRow>
 							</TableHeader>

--- a/apps/web/src/components/exam/ExamFacultiesPage.tsx
+++ b/apps/web/src/components/exam/ExamFacultiesPage.tsx
@@ -1,0 +1,741 @@
+import {
+	CreateExamSubject,
+	DeleteExamFacultyHead,
+	DeleteExamSubject,
+	type ExamSubject,
+	ListExamFaculties,
+	ListExamFacultyHeads,
+	ListExamFacultyOptions,
+	ListExamSubjects,
+	ListExamTeacherCatalog,
+	UpdateExamFaculty,
+	UpdateExamSubject,
+	UpsertExamFacultyHead
+} from '@/api/exam'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle
+} from '@/components/ui/card'
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue
+} from '@/components/ui/select'
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow
+} from '@/components/ui/table'
+import { canManageExamCatalog } from '@/lib/exam-roles'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Link } from '@tanstack/react-router'
+import {
+	BookOpen,
+	Loader2,
+	Pencil,
+	Plus,
+	ShieldCheck,
+	Trash2,
+	Users
+} from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { toast } from 'sonner'
+
+export default function ExamFacultiesPage() {
+	const qc = useQueryClient()
+	const canManage = canManageExamCatalog()
+	const [editingCode, setEditingCode] = useState<string | null>(null)
+	const [managingCode, setManagingCode] = useState<string | null>(null)
+	const [subjectEditorOpen, setSubjectEditorOpen] = useState(false)
+	const [editingSubjectId, setEditingSubjectId] = useState<number | null>(
+		null
+	)
+	const [form, setForm] = useState({ code: '', name: '', headUserId: 'none' })
+	const [subjectForm, setSubjectForm] = useState({
+		baseCode: '',
+		name: '',
+		creditHours: '0',
+		lessonHours: '0'
+	})
+
+	const optionsQ = useQuery({
+		queryKey: ['exam-faculty-options'],
+		queryFn: ListExamFacultyOptions
+	})
+	const facultiesQ = useQuery({
+		queryKey: ['exam-faculties'],
+		queryFn: () => ListExamFaculties()
+	})
+	const subjectsQ = useQuery({
+		queryKey: ['exam-subjects'],
+		queryFn: () => ListExamSubjects()
+	})
+	const teachersQ = useQuery({
+		queryKey: ['exam-teacher-catalog'],
+		queryFn: () => ListExamTeacherCatalog()
+	})
+	const headsQ = useQuery({
+		queryKey: ['exam-faculty-heads'],
+		queryFn: ListExamFacultyHeads
+	})
+
+	const rows = useMemo(() => {
+		return (optionsQ.data || []).map((faculty) => {
+			const uniqueSubjects = new Map<
+				string,
+				NonNullable<typeof subjectsQ.data>[number]
+			>()
+			for (const subject of (subjectsQ.data || []).filter(
+				(s) => s.facultyCode === faculty.code
+			)) {
+				const key = (subject.baseCode || subject.name)
+					.trim()
+					.toUpperCase()
+				if (!uniqueSubjects.has(key)) uniqueSubjects.set(key, subject)
+			}
+			return {
+				...faculty,
+				subjects: [...uniqueSubjects.values()].sort((a, b) =>
+					a.name.localeCompare(b.name, 'vi')
+				),
+				teachers: (teachersQ.data || []).filter(
+					(t) => t.facultyCode === faculty.code
+				),
+				head:
+					(headsQ.data || []).find(
+						(h) => h.facultyCode === faculty.code
+					) || null
+			}
+		})
+	}, [optionsQ.data, subjectsQ.data, teachersQ.data, headsQ.data])
+
+	const save = useMutation({
+		mutationFn: async () => {
+			if (!editingCode) throw new Error('Thiếu khoa cần sửa')
+			const records = (facultiesQ.data || []).filter(
+				(faculty) =>
+					faculty.code.toUpperCase() === editingCode.toUpperCase()
+			)
+			const facultyUpdates = Promise.all(
+				records.map((faculty) =>
+					UpdateExamFaculty(faculty.id, {
+						code: form.code,
+						name: form.name
+					})
+				)
+			)
+			const oldHead = (headsQ.data || []).find(
+				(h) => h.facultyCode === editingCode
+			)
+			const newHeadId =
+				form.headUserId === 'none' ? null : Number(form.headUserId)
+			const headUpdate = newHeadId
+				? oldHead?.userId === newHeadId
+					? Promise.resolve(null)
+					: UpsertExamFacultyHead({
+							userId: newHeadId,
+							facultyCode: form.code
+						})
+				: oldHead
+					? DeleteExamFacultyHead(editingCode)
+					: Promise.resolve(null)
+			return Promise.all([facultyUpdates, headUpdate]).then(
+				([updated]) => updated
+			)
+		},
+		onSuccess: (records) => {
+			toast.success(`Đã cập nhật khoa trên ${records.length} ngành`)
+			setEditingCode(null)
+			void qc.invalidateQueries({ queryKey: ['exam-faculties'] })
+			void qc.invalidateQueries({ queryKey: ['exam-faculty-options'] })
+			void qc.invalidateQueries({ queryKey: ['exam-subjects'] })
+			void qc.invalidateQueries({ queryKey: ['exam-faculty-heads'] })
+		},
+		onError: (error: Error) => toast.error(error.message)
+	})
+
+	const managedFaculty = rows.find((faculty) => faculty.code === managingCode)
+	const managedRecords = (facultiesQ.data || []).filter(
+		(faculty) => faculty.code === managingCode
+	)
+	const managedSubjects = (subjectsQ.data || [])
+		.filter((subject) => subject.facultyCode === managingCode)
+		.sort((a, b) => a.name.localeCompare(b.name, 'vi'))
+
+	const openCreateSubject = () => {
+		setEditingSubjectId(null)
+		setSubjectForm({
+			baseCode: '',
+			name: '',
+			creditHours: '0',
+			lessonHours: '0'
+		})
+		setSubjectEditorOpen(true)
+	}
+
+	const openEditSubject = (subject: ExamSubject) => {
+		setEditingSubjectId(subject.id)
+		setSubjectForm({
+			baseCode: subject.baseCode || subject.code.split('_').pop() || '',
+			name: subject.name,
+			creditHours: String(subject.creditHours || 0),
+			lessonHours: String(subject.lessonHours || 0)
+		})
+		setSubjectEditorOpen(true)
+	}
+
+	const saveSubject = useMutation({
+		mutationFn: () => {
+			const editing = (subjectsQ.data || []).find(
+				(subject) => subject.id === editingSubjectId
+			)
+			const facultyId = editing?.facultyId || managedRecords[0]?.id
+			if (!facultyId) throw new Error('Không tìm thấy khoa phụ trách')
+			const body = {
+				facultyId,
+				baseCode: subjectForm.baseCode,
+				name: subjectForm.name,
+				creditHours: Number(subjectForm.creditHours) || 0,
+				lessonHours: Number(subjectForm.lessonHours) || 0
+			}
+			return editingSubjectId == null
+				? CreateExamSubject(body)
+				: UpdateExamSubject(editingSubjectId, body)
+		},
+		onSuccess: () => {
+			toast.success(
+				editingSubjectId == null
+					? 'Đã thêm môn học'
+					: 'Đã cập nhật môn học'
+			)
+			setSubjectEditorOpen(false)
+			void qc.invalidateQueries({ queryKey: ['exam-subjects'] })
+		},
+		onError: (error: Error) => toast.error(error.message)
+	})
+
+	const removeSubject = useMutation({
+		mutationFn: (id: number) => DeleteExamSubject(id),
+		onSuccess: () => {
+			toast.success('Đã xóa môn học')
+			void qc.invalidateQueries({ queryKey: ['exam-subjects'] })
+		},
+		onError: (error: Error) => toast.error(error.message)
+	})
+
+	const loading =
+		optionsQ.isLoading ||
+		subjectsQ.isLoading ||
+		teachersQ.isLoading ||
+		headsQ.isLoading
+	const error =
+		optionsQ.error || subjectsQ.error || teachersQ.error || headsQ.error
+
+	return (
+		<div className='space-y-6 p-4 md:p-6'>
+			<div>
+				<h1 className='text-2xl font-semibold tracking-tight'>
+					Danh mục khoa
+				</h1>
+				<p className='text-muted-foreground text-sm'>
+					Khoa quản lý môn học, giáo viên thuộc khoa và Chủ nhiệm khoa
+					duyệt đề.
+				</p>
+			</div>
+			{error && (
+				<div className='rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive'>
+					{error.message}
+				</div>
+			)}
+			{loading ? (
+				<div className='flex justify-center py-12'>
+					<Loader2 className='h-8 w-8 animate-spin' />
+				</div>
+			) : (
+				<div className='grid gap-4 lg:grid-cols-2'>
+					{rows.map((faculty) => (
+						<Card key={faculty.code}>
+							<CardHeader className='pb-3'>
+								<div className='flex items-start justify-between gap-2'>
+									<div>
+										<CardTitle className='flex items-center gap-2'>
+											<Badge variant='outline'>
+												{faculty.code}
+											</Badge>
+											{faculty.name}
+										</CardTitle>
+										<CardDescription className='mt-1'>
+											{faculty.subjects.length} môn ·{' '}
+											{faculty.teachers.length} giáo viên
+										</CardDescription>
+									</div>
+									{canManage && (
+										<Button
+											size='icon'
+											variant='ghost'
+											title='Sửa khoa'
+											onClick={() => {
+												setEditingCode(faculty.code)
+												setForm({
+													code: faculty.code,
+													name: faculty.name,
+													headUserId: faculty.head
+														? String(
+																faculty.head
+																	.userId
+															)
+														: 'none'
+												})
+											}}
+										>
+											<Pencil className='h-4 w-4' />
+										</Button>
+									)}
+								</div>
+							</CardHeader>
+							<CardContent className='space-y-4'>
+								<div className='rounded-md border p-3'>
+									<div className='flex items-center justify-between gap-3'>
+										<div>
+											<div className='mb-2 flex items-center gap-2 text-sm font-medium'>
+												<ShieldCheck className='h-4 w-4' />{' '}
+												Chủ nhiệm khoa
+											</div>
+											<p className='text-muted-foreground text-sm'>
+												{faculty.head?.displayName ||
+													faculty.head?.username ||
+													'Chưa phân công'}
+											</p>
+										</div>
+										{canManage && (
+											<Button
+												size='sm'
+												variant='outline'
+												onClick={() => {
+													setEditingCode(faculty.code)
+													setForm({
+														code: faculty.code,
+														name: faculty.name,
+														headUserId: faculty.head
+															? String(
+																	faculty.head
+																		.userId
+																)
+															: 'none'
+													})
+												}}
+											>
+												<Pencil className='mr-2 h-3.5 w-3.5' />
+												{faculty.head
+													? 'Thay đổi'
+													: 'Phân công'}
+											</Button>
+										)}
+									</div>
+								</div>
+								<div>
+									<div className='mb-2 flex items-center gap-2 text-sm font-medium'>
+										<BookOpen className='h-4 w-4' /> Môn học
+									</div>
+									<div className='max-h-40 space-y-1 overflow-auto'>
+										{faculty.subjects.length ? (
+											faculty.subjects.map((subject) => (
+												<div
+													key={subject.id}
+													className='rounded border px-2 py-1.5 text-xs'
+												>
+													<span className='font-mono'>
+														{subject.code}
+													</span>{' '}
+													— {subject.name}
+												</div>
+											))
+										) : (
+											<p className='text-muted-foreground text-sm'>
+												Chưa có môn.
+											</p>
+										)}
+									</div>
+								</div>
+								<div>
+									<div className='mb-2 flex items-center gap-2 text-sm font-medium'>
+										<Users className='h-4 w-4' /> Giáo viên
+									</div>
+									<div className='flex flex-wrap gap-1'>
+										{faculty.teachers.length ? (
+											faculty.teachers.map((teacher) => (
+												<Badge
+													key={teacher.id}
+													variant='secondary'
+												>
+													{teacher.displayName ||
+														teacher.username}
+												</Badge>
+											))
+										) : (
+											<p className='text-muted-foreground text-sm'>
+												Chưa có giáo viên.
+											</p>
+										)}
+									</div>
+								</div>
+								<div className='flex gap-2'>
+									<Button asChild size='sm' variant='outline'>
+										<Link to='/de-thi/giao-vien'>
+											Quản lý giáo viên
+										</Link>
+									</Button>
+									<Button
+										size='sm'
+										variant='outline'
+										onClick={() =>
+											setManagingCode(faculty.code)
+										}
+									>
+										Quản lý môn học
+									</Button>
+								</div>
+							</CardContent>
+						</Card>
+					))}
+				</div>
+			)}
+
+			<Dialog
+				open={managingCode != null}
+				onOpenChange={(open) => !open && setManagingCode(null)}
+			>
+				<DialogContent className='max-h-[90vh] max-w-6xl overflow-y-auto'>
+					<DialogHeader>
+						<DialogTitle>
+							Quản lý môn học — {managedFaculty?.code}{' '}
+							{managedFaculty?.name}
+						</DialogTitle>
+					</DialogHeader>
+					<div className='flex items-center justify-between gap-3'>
+						<p className='text-muted-foreground text-sm'>
+							{managedSubjects.length} môn học thuộc khoa
+						</p>
+						{canManage && (
+							<Button size='sm' onClick={openCreateSubject}>
+								<Plus className='mr-2 h-4 w-4' /> Thêm môn học
+							</Button>
+						)}
+					</div>
+					<div className='overflow-x-auto rounded-md border'>
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Mã môn</TableHead>
+									<TableHead>Tên môn</TableHead>
+									<TableHead>Ngành đào tạo</TableHead>
+									<TableHead className='text-center'>
+										Tín chỉ
+									</TableHead>
+									<TableHead className='text-center'>
+										Số tiết
+									</TableHead>
+									{canManage && (
+										<TableHead className='text-right'>
+											Thao tác
+										</TableHead>
+									)}
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{managedSubjects.map((subject) => (
+									<TableRow key={subject.id}>
+										<TableCell>
+											<div className='font-mono font-medium'>
+												{subject.code}
+											</div>
+											{subject.baseCode && (
+												<div className='text-muted-foreground font-mono text-xs'>
+													Mã gốc: {subject.baseCode}
+												</div>
+											)}
+										</TableCell>
+										<TableCell className='font-medium'>
+											{subject.name}
+										</TableCell>
+										<TableCell>
+											<div>
+												{subject.majorName || '—'}
+											</div>
+											<div className='text-muted-foreground text-xs'>
+												{subject.majorCode || ''}
+											</div>
+										</TableCell>
+										<TableCell className='text-center'>
+											{subject.creditHours ?? 0}
+										</TableCell>
+										<TableCell className='text-center'>
+											{subject.lessonHours ?? 0}
+										</TableCell>
+										{canManage && (
+											<TableCell>
+												<div className='flex justify-end gap-1'>
+													<Button
+														size='icon'
+														variant='ghost'
+														title='Sửa môn học'
+														onClick={() =>
+															openEditSubject(
+																subject
+															)
+														}
+													>
+														<Pencil className='h-4 w-4' />
+													</Button>
+													<Button
+														size='icon'
+														variant='ghost'
+														title='Xóa môn học'
+														onClick={() => {
+															if (
+																window.confirm(
+																	`Xóa môn ${subject.name}?`
+																)
+															)
+																removeSubject.mutate(
+																	subject.id
+																)
+														}}
+													>
+														<Trash2 className='h-4 w-4 text-destructive' />
+													</Button>
+												</div>
+											</TableCell>
+										)}
+									</TableRow>
+								))}
+								{!managedSubjects.length && (
+									<TableRow>
+										<TableCell
+											colSpan={canManage ? 6 : 5}
+											className='text-muted-foreground h-24 text-center'
+										>
+											Khoa chưa có môn học.
+										</TableCell>
+									</TableRow>
+								)}
+							</TableBody>
+						</Table>
+					</div>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog
+				open={subjectEditorOpen}
+				onOpenChange={setSubjectEditorOpen}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>
+							{editingSubjectId == null
+								? 'Thêm môn học'
+								: 'Sửa môn học'}
+						</DialogTitle>
+					</DialogHeader>
+					<div className='grid gap-4 py-2 md:grid-cols-2'>
+						<div className='space-y-2'>
+							<Label>Mã môn *</Label>
+							<Input
+								value={subjectForm.baseCode}
+								onChange={(event) =>
+									setSubjectForm((old) => ({
+										...old,
+										baseCode:
+											event.target.value.toUpperCase()
+									}))
+								}
+								placeholder='M001K1'
+							/>
+						</div>
+						<div className='space-y-2'>
+							<Label>Tên môn *</Label>
+							<Input
+								value={subjectForm.name}
+								onChange={(event) =>
+									setSubjectForm((old) => ({
+										...old,
+										name: event.target.value
+									}))
+								}
+							/>
+						</div>
+						<div className='space-y-2'>
+							<Label>Số tín chỉ</Label>
+							<Input
+								type='number'
+								min='0'
+								value={subjectForm.creditHours}
+								onChange={(event) =>
+									setSubjectForm((old) => ({
+										...old,
+										creditHours: event.target.value
+									}))
+								}
+							/>
+						</div>
+						<div className='space-y-2'>
+							<Label>Số tiết</Label>
+							<Input
+								type='number'
+								min='0'
+								value={subjectForm.lessonHours}
+								onChange={(event) =>
+									setSubjectForm((old) => ({
+										...old,
+										lessonHours: event.target.value
+									}))
+								}
+							/>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button
+							variant='outline'
+							onClick={() => setSubjectEditorOpen(false)}
+						>
+							Hủy
+						</Button>
+						<Button
+							disabled={
+								saveSubject.isPending ||
+								!subjectForm.baseCode.trim() ||
+								!subjectForm.name.trim()
+							}
+							onClick={() => saveSubject.mutate()}
+						>
+							{saveSubject.isPending
+								? 'Đang lưu…'
+								: 'Lưu môn học'}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog
+				open={editingCode != null}
+				onOpenChange={(open) => !open && setEditingCode(null)}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>
+							Sửa khoa và phân công Chủ nhiệm khoa
+						</DialogTitle>
+					</DialogHeader>
+					<div className='space-y-3'>
+						<div>
+							<Label>Mã khoa</Label>
+							<Input
+								value={form.code}
+								onChange={(e) =>
+									setForm((old) => ({
+										...old,
+										code: e.target.value.toUpperCase()
+									}))
+								}
+							/>
+						</div>
+						<div>
+							<Label>Tên khoa</Label>
+							<Input
+								value={form.name}
+								onChange={(e) =>
+									setForm((old) => ({
+										...old,
+										name: e.target.value
+									}))
+								}
+							/>
+						</div>
+						<div>
+							<Label>Chủ nhiệm khoa</Label>
+							<Select
+								value={form.headUserId}
+								onValueChange={(v) =>
+									setForm((old) => ({
+										...old,
+										headUserId: v
+									}))
+								}
+							>
+								<SelectTrigger>
+									<SelectValue placeholder='Chọn giáo viên' />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value='none'>
+										Chưa phân công
+									</SelectItem>
+									{(teachersQ.data || [])
+										.filter(
+											(teacher) =>
+												teacher.facultyCode ===
+												editingCode
+										)
+										.map((teacher) => (
+											<SelectItem
+												key={teacher.userId}
+												value={String(teacher.userId)}
+											>
+												{teacher.displayName ||
+													teacher.username}{' '}
+												·{' '}
+												{teacher.facultyName ||
+													teacher.facultyCode}
+											</SelectItem>
+										))}
+								</SelectContent>
+							</Select>
+							<p className='mt-1 text-xs text-muted-foreground'>
+								Có thể thay đổi khi phân công nhân sự theo năm.
+							</p>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button
+							variant='outline'
+							onClick={() => setEditingCode(null)}
+						>
+							Hủy
+						</Button>
+						<Button
+							disabled={
+								save.isPending ||
+								!form.code.trim() ||
+								!form.name.trim()
+							}
+							onClick={() => save.mutate()}
+						>
+							{save.isPending && (
+								<Loader2 className='mr-2 h-4 w-4 animate-spin' />
+							)}
+							Lưu
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</div>
+	)
+}

--- a/apps/web/src/components/exam/ExamTeachersPage.tsx
+++ b/apps/web/src/components/exam/ExamTeachersPage.tsx
@@ -8,18 +8,22 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Loader2, Plus, Trash2, Pencil, Users } from 'lucide-react'
 import { toast } from 'sonner'
 import {
+	CreateExamAcademicTitle,
 	CreateExamTeacherCatalog,
+	DeleteExamAcademicTitle,
 	DeleteExamTeacherCatalog,
+	ListExamAcademicTitles,
 	ListExamFacultyOptions,
 	ListExamTeacherCandidates,
 	ListExamTeacherCatalog,
+	UpdateExamAcademicTitle,
 	UpdateExamTeacherCatalog
 } from '@/api/exam'
 import {
 	canManageTeachingAssignments,
 	canViewTeachingAssignments
 } from '@/lib/exam-roles'
-import { canSeeUsernames } from '@/lib/utils'
+import { canSeeUsernames, isSuperAdmin } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import {
 	Card,
@@ -81,6 +85,9 @@ export default function ExamTeachersPage() {
 	const [filterFac, setFilterFac] = useState<string>('all')
 	const [keyword, setKeyword] = useState('')
 	const [open, setOpen] = useState(false)
+	const [titlesOpen, setTitlesOpen] = useState(false)
+	const [titleEditId, setTitleEditId] = useState<number | null>(null)
+	const [titleForm, setTitleForm] = useState({ name: '', percentage: '100' })
 	const [editId, setEditId] = useState<number | null>(null)
 	/** new_account | existing */
 	const [mode, setMode] = useState<'new_account' | 'existing'>('new_account')
@@ -90,7 +97,8 @@ export default function ExamTeachersPage() {
 		username: '',
 		password: 'User@123',
 		userId: '',
-		note: ''
+		note: '',
+		academicTitleId: ''
 	})
 
 	const facultiesQ = useQuery({
@@ -112,10 +120,16 @@ export default function ExamTeachersPage() {
 		queryFn: () => ListExamTeacherCandidates(),
 		enabled: canView && canManage && open && mode === 'existing'
 	})
+	const titlesQ = useQuery({
+		queryKey: ['exam-academic-titles'],
+		queryFn: ListExamAcademicTitles,
+		enabled: canView
+	})
 
 	const faculties = facultiesQ.data || []
 	const teachers = catalogQ.data || []
 	const candidates = candidatesQ.data || []
+	const titles = titlesQ.data || []
 
 	const byFaculty = useMemo(() => {
 		const map = new Map<string, number>()
@@ -132,7 +146,8 @@ export default function ExamTeachersPage() {
 			username: '',
 			password: 'User@123',
 			userId: '',
-			note: ''
+			note: '',
+			academicTitleId: ''
 		})
 		setMode('new_account')
 		setEditId(null)
@@ -141,6 +156,7 @@ export default function ExamTeachersPage() {
 	const createMut = useMutation({
 		mutationFn: () => {
 			if (!form.facultyCode) throw new Error('Chọn khoa')
+			if (!form.academicTitleId) throw new Error('Chọn chức danh')
 			if (mode === 'new_account') {
 				const name = form.displayName.trim()
 				if (!name) throw new Error('Nhập họ tên giáo viên')
@@ -154,6 +170,7 @@ export default function ExamTeachersPage() {
 					password: form.password,
 					displayName: name.startsWith('GV') ? name : `GV — ${name}`,
 					facultyCode: form.facultyCode,
+					academicTitleId: Number(form.academicTitleId),
 					note: form.note || undefined
 				})
 			}
@@ -162,6 +179,7 @@ export default function ExamTeachersPage() {
 				userId: Number(form.userId),
 				displayName: form.displayName.trim() || undefined,
 				facultyCode: form.facultyCode,
+				academicTitleId: Number(form.academicTitleId),
 				note: form.note || undefined
 			})
 		},
@@ -186,8 +204,10 @@ export default function ExamTeachersPage() {
 			const name = form.displayName.trim()
 			if (!name) throw new Error('Nhập họ tên')
 			if (!form.facultyCode) throw new Error('Chọn khoa')
+			if (!form.academicTitleId) throw new Error('Chọn chức danh')
 			return UpdateExamTeacherCatalog(editId, {
 				facultyCode: form.facultyCode,
+				academicTitleId: Number(form.academicTitleId),
 				displayName: name.startsWith('GV') ? name : `GV — ${name}`,
 				note: form.note || null
 			})
@@ -198,6 +218,44 @@ export default function ExamTeachersPage() {
 			resetForm()
 			void qc.invalidateQueries({ queryKey: ['exam-teacher-catalog'] })
 			void qc.invalidateQueries({ queryKey: ['exam-teachers'] })
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	const saveTitleMut = useMutation({
+		mutationFn: () => {
+			const name = titleForm.name.trim()
+			const percentage = Number(titleForm.percentage)
+			if (!name) throw new Error('Nhập tên chức danh')
+			if (
+				!Number.isFinite(percentage) ||
+				percentage < 0 ||
+				percentage > 100
+			)
+				throw new Error('Tỷ lệ phải từ 0 đến 100%')
+			return titleEditId == null
+				? CreateExamAcademicTitle({
+						name,
+						percentage,
+						sortOrder: titles.length * 10 + 10
+					})
+				: UpdateExamAcademicTitle(titleEditId, { name, percentage })
+		},
+		onSuccess: () => {
+			toast.success(
+				titleEditId == null ? 'Đã thêm chức danh' : 'Đã sửa chức danh'
+			)
+			setTitleEditId(null)
+			setTitleForm({ name: '', percentage: '100' })
+			void qc.invalidateQueries({ queryKey: ['exam-academic-titles'] })
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+	const deleteTitleMut = useMutation({
+		mutationFn: DeleteExamAcademicTitle,
+		onSuccess: () => {
+			toast.success('Đã xóa chức danh')
+			void qc.invalidateQueries({ queryKey: ['exam-academic-titles'] })
 		},
 		onError: (e: Error) => toast.error(e.message)
 	})
@@ -237,19 +295,29 @@ export default function ExamTeachersPage() {
 						khi phân công môn giảng dạy.
 					</p>
 				</div>
-				{canManage ? (
-					<Button
-						onClick={() => {
-							resetForm()
-							setOpen(true)
-						}}
-					>
-						<Plus className='mr-2 h-4 w-4' />
-						Thêm giáo viên
-					</Button>
-				) : (
-					<Badge variant='secondary'>Chỉ xem</Badge>
-				)}
+				<div className='flex gap-2'>
+					{isSuperAdmin() && (
+						<Button
+							variant='outline'
+							onClick={() => setTitlesOpen(true)}
+						>
+							Danh mục chức danh
+						</Button>
+					)}
+					{canManage ? (
+						<Button
+							onClick={() => {
+								resetForm()
+								setOpen(true)
+							}}
+						>
+							<Plus className='mr-2 h-4 w-4' />
+							Thêm giáo viên
+						</Button>
+					) : (
+						<Badge variant='secondary'>Chỉ xem</Badge>
+					)}
+				</div>
 			</div>
 
 			<div className='flex flex-wrap gap-2'>
@@ -318,6 +386,7 @@ export default function ExamTeachersPage() {
 										<TableHead>Tài khoản</TableHead>
 									)}
 									<TableHead>Khoa</TableHead>
+									<TableHead>Chức danh</TableHead>
 									<TableHead>Ghi chú</TableHead>
 									{canManage && (
 										<TableHead className='w-28' />
@@ -340,6 +409,11 @@ export default function ExamTeachersPage() {
 										)}
 										<TableCell>
 											{t.facultyName || t.facultyCode}
+										</TableCell>
+										<TableCell className='text-xs'>
+											{t.academicTitleName
+												? `${t.academicTitleName} (${t.academicTitlePercentage}%)`
+												: '—'}
 										</TableCell>
 										<TableCell className='text-muted-foreground text-xs'>
 											{t.note || '—'}
@@ -369,7 +443,14 @@ export default function ExamTeachersPage() {
 																	t.userId
 																),
 																note:
-																	t.note || ''
+																	t.note ||
+																	'',
+																academicTitleId:
+																	t.academicTitleId
+																		? String(
+																				t.academicTitleId
+																			)
+																		: ''
 															})
 															setOpen(true)
 														}}
@@ -402,7 +483,7 @@ export default function ExamTeachersPage() {
 									<TableRow>
 										<TableCell
 											colSpan={
-												(canSeeUsernames() ? 4 : 3) +
+												(canSeeUsernames() ? 5 : 4) +
 												(canManage ? 1 : 0)
 											}
 											className='text-muted-foreground text-center'
@@ -472,6 +553,32 @@ export default function ExamTeachersPage() {
 									{faculties.map((f) => (
 										<SelectItem key={f.code} value={f.code}>
 											{f.name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+						<div>
+							<Label>Chức danh *</Label>
+							<Select
+								value={form.academicTitleId || undefined}
+								onValueChange={(v) =>
+									setForm((f) => ({
+										...f,
+										academicTitleId: v
+									}))
+								}
+							>
+								<SelectTrigger>
+									<SelectValue placeholder='Chọn chức danh' />
+								</SelectTrigger>
+								<SelectContent>
+									{titles.map((title) => (
+										<SelectItem
+											key={title.id}
+											value={String(title.id)}
+										>
+											{title.name} ({title.percentage}%)
 										</SelectItem>
 									))}
 								</SelectContent>
@@ -618,6 +725,92 @@ export default function ExamTeachersPage() {
 								<Loader2 className='mr-2 h-4 w-4 animate-spin' />
 							)}
 							{editId != null ? 'Lưu' : 'Thêm vào khoa'}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog open={titlesOpen} onOpenChange={setTitlesOpen}>
+				<DialogContent className='max-w-2xl'>
+					<DialogHeader>
+						<DialogTitle>Danh mục chức danh</DialogTitle>
+					</DialogHeader>
+					<div className='grid gap-2 sm:grid-cols-[1fr_8rem_auto]'>
+						<Input
+							placeholder='Tên chức danh'
+							value={titleForm.name}
+							onChange={(e) =>
+								setTitleForm((f) => ({
+									...f,
+									name: e.target.value
+								}))
+							}
+						/>
+						<Input
+							type='number'
+							min={0}
+							max={100}
+							placeholder='Tỷ lệ %'
+							value={titleForm.percentage}
+							onChange={(e) =>
+								setTitleForm((f) => ({
+									...f,
+									percentage: e.target.value
+								}))
+							}
+						/>
+						<Button
+							onClick={() => saveTitleMut.mutate()}
+							disabled={saveTitleMut.isPending}
+						>
+							{titleEditId == null ? 'Thêm' : 'Lưu'}
+						</Button>
+					</div>
+					<div className='max-h-[55vh] overflow-auto rounded-md border'>
+						{titles.map((title) => (
+							<div
+								key={title.id}
+								className='flex items-center gap-2 border-b p-2 last:border-b-0'
+							>
+								<div className='min-w-0 flex-1 text-sm'>
+									{title.name}
+								</div>
+								<Badge variant='outline'>
+									{title.percentage}%
+								</Badge>
+								<Button
+									size='icon'
+									variant='ghost'
+									onClick={() => {
+										setTitleEditId(title.id)
+										setTitleForm({
+											name: title.name,
+											percentage: String(title.percentage)
+										})
+									}}
+								>
+									<Pencil className='h-4 w-4' />
+								</Button>
+								<Button
+									size='icon'
+									variant='ghost'
+									onClick={() =>
+										confirm(
+											`Xóa chức danh «${title.name}»?`
+										) && deleteTitleMut.mutate(title.id)
+									}
+								>
+									<Trash2 className='h-4 w-4 text-destructive' />
+								</Button>
+							</div>
+						))}
+					</div>
+					<DialogFooter>
+						<Button
+							variant='outline'
+							onClick={() => setTitlesOpen(false)}
+						>
+							Đóng
 						</Button>
 					</DialogFooter>
 				</DialogContent>

--- a/apps/web/src/components/exam/ExamTrainingCatalogPage.tsx
+++ b/apps/web/src/components/exam/ExamTrainingCatalogPage.tsx
@@ -1,0 +1,954 @@
+import {
+	CreateExamMajor,
+	CreateExamSubject,
+	DeleteExamMajor,
+	DeleteExamSubject,
+	type ExamMajor,
+	type ExamSubject,
+	ListExamFaculties,
+	ListExamMajors,
+	ListExamSubjects,
+	ListExamSystems,
+	UpdateExamMajor,
+	UpdateExamSubject
+} from '@/api/exam'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle
+} from '@/components/ui/card'
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue
+} from '@/components/ui/select'
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow
+} from '@/components/ui/table'
+import { canManageExamCatalog } from '@/lib/exam-roles'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+	BookOpen,
+	ChevronRight,
+	Loader2,
+	Pencil,
+	Plus,
+	Search,
+	Trash2
+} from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { toast } from 'sonner'
+
+const QUALIFICATION_OPTIONS = ['Sơ cấp', 'Trung cấp', 'Cao đẳng']
+const TRAINING_DURATION_OPTIONS = [
+	'6 tháng',
+	'1 năm',
+	'2 năm',
+	'2,5 năm',
+	'3 năm'
+]
+const TRAINING_FORM_OPTIONS = ['Chính quy', 'Liên thông', 'Chuyển loại']
+
+export default function ExamTrainingCatalogPage() {
+	const qc = useQueryClient()
+	const canManage = canManageExamCatalog()
+	const [majorOpen, setMajorOpen] = useState(false)
+	const [editingId, setEditingId] = useState<number | null>(null)
+	const [subjectOpen, setSubjectOpen] = useState(false)
+	const [editingSubjectId, setEditingSubjectId] = useState<number | null>(
+		null
+	)
+	const [subjectMajorId, setSubjectMajorId] = useState<number | null>(null)
+	const [majorSearch, setMajorSearch] = useState('')
+	const [form, setForm] = useState({
+		systemId: 0,
+		nationalMajorCode: '',
+		name: '',
+		qualification: '',
+		trainingDuration: '',
+		trainingForm: ''
+	})
+	const [subjectForm, setSubjectForm] = useState({
+		sourceSubjectId: 0,
+		baseCode: '',
+		name: '',
+		facultyId: 0,
+		creditHours: '0',
+		lessonHours: '0'
+	})
+	const systemsQ = useQuery({
+		queryKey: ['exam-systems'],
+		queryFn: () => ListExamSystems()
+	})
+	const majorsQ = useQuery({
+		queryKey: ['exam-majors'],
+		queryFn: () => ListExamMajors()
+	})
+	const subjectsQ = useQuery({
+		queryKey: ['exam-subjects'],
+		queryFn: () => ListExamSubjects()
+	})
+	const facultiesQ = useQuery({
+		queryKey: ['exam-faculties'],
+		queryFn: () => ListExamFaculties()
+	})
+	const systems = systemsQ.data || []
+	const majors = majorsQ.data || []
+	const subjects = subjectsQ.data || []
+	const faculties = facultiesQ.data || []
+	const selectedSystem = systems.find((system) => system.id === form.systemId)
+	const generatedCatalogNumber =
+		selectedSystem && form.nationalMajorCode.trim()
+			? `${selectedSystem.letter.toUpperCase()}.${form.nationalMajorCode.trim()}`
+			: ''
+	const loading =
+		systemsQ.isLoading ||
+		majorsQ.isLoading ||
+		subjectsQ.isLoading ||
+		facultiesQ.isLoading
+	const error =
+		systemsQ.error || majorsQ.error || subjectsQ.error || facultiesQ.error
+	const officialMajors = majors.filter((major) => major.catalogNumber)
+	const visibleMajors = useMemo(() => {
+		const keyword = majorSearch.trim().toLocaleLowerCase('vi')
+		if (!keyword) return officialMajors
+		return officialMajors.filter((major) =>
+			[
+				major.catalogNumber,
+				major.nationalMajorCode,
+				major.name,
+				major.qualification,
+				major.trainingForm
+			].some((value) =>
+				(value || '').toLocaleLowerCase('vi').includes(keyword)
+			)
+		)
+	}, [officialMajors, majorSearch])
+	const facultyDirectory = useMemo(() => {
+		const byCode = new Map<string, (typeof faculties)[number]>()
+		for (const faculty of faculties) {
+			const code = faculty.code.trim().toUpperCase()
+			if (!byCode.has(code)) byCode.set(code, faculty)
+		}
+		return [...byCode.values()].sort((a, b) =>
+			a.name.localeCompare(b.name, 'vi')
+		)
+	}, [faculties])
+	const selectedFacultyCode = faculties.find(
+		(faculty) => faculty.id === subjectForm.facultyId
+	)?.code
+	const subjectOptions = useMemo(() => {
+		if (!selectedFacultyCode) return []
+		const bySubject = new Map<string, ExamSubject>()
+		for (const subject of subjects) {
+			if (
+				subject.facultyCode?.toUpperCase() !==
+				selectedFacultyCode.toUpperCase()
+			)
+				continue
+			const key = `${subject.baseCode || subject.code}|${subject.name}`
+			if (!bySubject.has(key)) bySubject.set(key, subject)
+		}
+		return [...bySubject.values()].sort((a, b) =>
+			a.name.localeCompare(b.name, 'vi')
+		)
+	}, [selectedFacultyCode, subjects])
+
+	const majorsBySystem = useMemo(
+		() =>
+			new Map(
+				systems.map((system) => [
+					system.id,
+					officialMajors.filter(
+						(major) => major.systemId === system.id
+					)
+				])
+			),
+		[systems, officialMajors]
+	)
+
+	const openCreate = () => {
+		setEditingId(null)
+		setForm({
+			systemId: systems[0]?.id || 0,
+			nationalMajorCode: '',
+			name: '',
+			qualification: '',
+			trainingDuration: '',
+			trainingForm: 'Chính quy'
+		})
+		setMajorOpen(true)
+	}
+
+	const openEdit = (major: ExamMajor) => {
+		setEditingId(major.id)
+		setForm({
+			systemId: major.systemId,
+			nationalMajorCode: major.nationalMajorCode || '',
+			name: major.name,
+			qualification: major.qualification || '',
+			trainingDuration: major.trainingDuration || '',
+			trainingForm: major.trainingForm || ''
+		})
+		setMajorOpen(true)
+	}
+
+	const saveMajor = useMutation({
+		mutationFn: () => {
+			const body = {
+				systemId: form.systemId,
+				code: generatedCatalogNumber,
+				catalogNumber: generatedCatalogNumber,
+				nationalMajorCode: form.nationalMajorCode,
+				name: form.name,
+				qualification: form.qualification,
+				trainingDuration: form.trainingDuration,
+				trainingForm: form.trainingForm
+			}
+			return editingId == null
+				? CreateExamMajor(body)
+				: UpdateExamMajor(editingId, body)
+		},
+		onSuccess: () => {
+			toast.success(
+				editingId == null ? 'Đã thêm ngành' : 'Đã cập nhật ngành'
+			)
+			setMajorOpen(false)
+			void qc.invalidateQueries({ queryKey: ['exam-majors'] })
+		},
+		onError: (error: Error) => toast.error(error.message)
+	})
+
+	const removeMajor = useMutation({
+		mutationFn: (id: number) => DeleteExamMajor(id),
+		onSuccess: () => {
+			toast.success('Đã xóa ngành')
+			void qc.invalidateQueries({ queryKey: ['exam-majors'] })
+		},
+		onError: (error: Error) => toast.error(error.message)
+	})
+
+	const openCreateSubject = (major: ExamMajor) => {
+		setEditingSubjectId(null)
+		setSubjectMajorId(major.id)
+		setSubjectForm({
+			sourceSubjectId: 0,
+			baseCode: '',
+			name: '',
+			facultyId: 0,
+			creditHours: '0',
+			lessonHours: '0'
+		})
+		setSubjectOpen(true)
+	}
+
+	const openEditSubject = (subject: ExamSubject) => {
+		const directoryFaculty = facultyDirectory.find(
+			(faculty) => faculty.code === subject.facultyCode
+		)
+		setEditingSubjectId(subject.id)
+		setSubjectMajorId(subject.majorId)
+		setSubjectForm({
+			sourceSubjectId: subject.id,
+			baseCode: subject.baseCode || subject.code.split('_').pop() || '',
+			name: subject.name,
+			facultyId: directoryFaculty?.id || subject.facultyId,
+			creditHours: String(subject.creditHours || 0),
+			lessonHours: String(subject.lessonHours || 0)
+		})
+		setSubjectOpen(true)
+	}
+
+	const saveSubject = useMutation({
+		mutationFn: () => {
+			const sourceSubject = subjects.find(
+				(subject) => subject.id === subjectForm.sourceSubjectId
+			)
+			const editingSubject = subjects.find(
+				(subject) => subject.id === editingSubjectId
+			)
+			const body = {
+				name: sourceSubject?.name || subjectForm.name,
+				facultyId: editingSubject?.facultyId || subjectForm.facultyId,
+				baseCode:
+					sourceSubject?.baseCode ||
+					sourceSubject?.code.split('_').pop() ||
+					subjectForm.baseCode,
+				creditHours:
+					sourceSubject?.creditHours ??
+					(Number(subjectForm.creditHours) || 0),
+				lessonHours:
+					sourceSubject?.lessonHours ??
+					(Number(subjectForm.lessonHours) || 0)
+			}
+			return editingSubjectId == null
+				? CreateExamSubject({
+						...body,
+						majorId: subjectMajorId || undefined,
+						sourceSubjectId: subjectForm.sourceSubjectId
+					})
+				: UpdateExamSubject(editingSubjectId, body)
+		},
+		onSuccess: () => {
+			toast.success(
+				editingSubjectId == null
+					? 'Đã thêm môn học'
+					: 'Đã cập nhật môn học'
+			)
+			setSubjectOpen(false)
+			void qc.invalidateQueries({ queryKey: ['exam-subjects'] })
+		},
+		onError: (error: Error) => toast.error(error.message)
+	})
+
+	const removeSubject = useMutation({
+		mutationFn: (id: number) => DeleteExamSubject(id),
+		onSuccess: () => {
+			toast.success('Đã xóa môn học')
+			void qc.invalidateQueries({ queryKey: ['exam-subjects'] })
+		},
+		onError: (error: Error) => toast.error(error.message)
+	})
+
+	return (
+		<div className='space-y-6 p-4 md:p-6'>
+			<div>
+				<h1 className='text-2xl font-semibold tracking-tight'>
+					Danh mục đào tạo
+				</h1>
+				<p className='text-muted-foreground text-sm'>
+					Cấu trúc: Hệ đào tạo → Ngành đào tạo → Môn học trong ngành.
+				</p>
+			</div>
+			{error && (
+				<div className='rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive'>
+					{error.message}
+				</div>
+			)}
+			<Card>
+				<CardHeader className='gap-4 pb-3'>
+					<div className='flex flex-col justify-between gap-3 lg:flex-row lg:items-start'>
+						<div>
+							<CardTitle>DANH MỤC NGÀNH ĐÀO TẠO</CardTitle>
+							<CardDescription>
+								Danh mục mã số, trình độ, thời gian và hình thức
+								đào tạo chính thức.
+							</CardDescription>
+						</div>
+						{canManage && (
+							<Button className='shrink-0' onClick={openCreate}>
+								<Plus className='mr-2 h-4 w-4' /> Thêm ngành
+							</Button>
+						)}
+					</div>
+					<div className='relative max-w-md'>
+						<Search className='text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2' />
+						<Input
+							value={majorSearch}
+							onChange={(event) =>
+								setMajorSearch(event.target.value)
+							}
+							placeholder='Tìm theo mã số, mã ngành hoặc tên…'
+							className='h-9 pl-9'
+						/>
+					</div>
+				</CardHeader>
+				<CardContent className='overflow-x-auto pt-0'>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Mã đào tạo</TableHead>
+								<TableHead>Tên ngành</TableHead>
+								<TableHead>Trình độ / Thời gian</TableHead>
+								<TableHead>Hình thức đào tạo</TableHead>
+								{canManage && (
+									<TableHead className='w-20 text-right'>
+										Thao tác
+									</TableHead>
+								)}
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{['B', 'A'].map((letter) => {
+								const rows = visibleMajors.filter(
+									(major) => major.systemLetter === letter
+								)
+								if (!rows.length) return null
+								return [
+									<TableRow key={`${letter}-heading`}>
+										<TableCell
+											colSpan={canManage ? 5 : 4}
+											className='bg-muted/50 h-9 py-2 text-center font-bold text-red-600'
+										>
+											{letter === 'B'
+												? 'HỆ DÂN SỰ'
+												: 'HỆ QUÂN SỰ'}
+										</TableCell>
+									</TableRow>,
+									...rows.map((major) => (
+										<TableRow
+											key={major.id}
+											className='text-sm'
+										>
+											<TableCell className='py-2.5 font-mono font-medium'>
+												<div>{major.catalogNumber}</div>
+												<div className='text-muted-foreground mt-0.5 text-xs'>
+													{major.nationalMajorCode}
+												</div>
+											</TableCell>
+											<TableCell className='py-2.5 font-medium'>
+												{major.name}
+											</TableCell>
+											<TableCell className='py-2.5'>
+												<div>{major.qualification}</div>
+												<div className='text-muted-foreground mt-0.5 text-xs'>
+													{major.trainingDuration}
+												</div>
+											</TableCell>
+											<TableCell className='py-2.5'>
+												{major.trainingForm}
+											</TableCell>
+											{canManage && (
+												<TableCell className='py-2.5'>
+													<div className='flex justify-end gap-0.5'>
+														<Button
+															size='icon'
+															variant='ghost'
+															onClick={() =>
+																openEdit(major)
+															}
+															title='Sửa ngành'
+														>
+															<Pencil className='h-4 w-4' />
+														</Button>
+														<Button
+															size='icon'
+															variant='ghost'
+															title='Xóa ngành'
+															onClick={() => {
+																if (
+																	window.confirm(
+																		`Xóa ngành ${major.name}?`
+																	)
+																)
+																	removeMajor.mutate(
+																		major.id
+																	)
+															}}
+														>
+															<Trash2 className='h-4 w-4 text-destructive' />
+														</Button>
+													</div>
+												</TableCell>
+											)}
+										</TableRow>
+									))
+								]
+							})}
+							{!visibleMajors.length && (
+								<TableRow>
+									<TableCell
+										colSpan={canManage ? 5 : 4}
+										className='text-muted-foreground h-24 text-center'
+									>
+										Không tìm thấy ngành phù hợp.
+									</TableCell>
+								</TableRow>
+							)}
+						</TableBody>
+					</Table>
+				</CardContent>
+			</Card>
+			<Card>
+				<CardHeader>
+					<CardTitle className='flex items-center gap-2'>
+						<BookOpen className='h-5 w-5' /> Các môn đào tạo trong
+						ngành
+					</CardTitle>
+					<CardDescription>
+						Danh sách môn học của {officialMajors.length} ngành
+						trong bảng trên · {subjects.length} môn
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					{loading ? (
+						<div className='flex justify-center py-12'>
+							<Loader2 className='h-8 w-8 animate-spin' />
+						</div>
+					) : (
+						<div className='space-y-3'>
+							{systems.map((system) => (
+								<details
+									key={system.id}
+									open
+									className='group overflow-hidden rounded-lg border'
+								>
+									<summary className='bg-muted/50 flex cursor-pointer list-none items-center gap-2 px-3 py-2.5'>
+										<ChevronRight className='h-4 w-4 transition-transform group-open:rotate-90' />
+										<strong>{system.name}</strong>
+										<Badge variant='outline'>
+											{system.letter}
+										</Badge>
+										<Badge variant='secondary'>
+											{
+												(
+													majorsBySystem.get(
+														system.id
+													) || []
+												).length
+											}{' '}
+											ngành
+										</Badge>
+									</summary>
+									<div className='space-y-2 border-t p-3'>
+										{(
+											majorsBySystem.get(system.id) || []
+										).map((major) => {
+											const majorSubjects =
+												subjects.filter(
+													(subject) =>
+														subject.majorId ===
+														major.id
+												)
+											return (
+												<details
+													key={major.id}
+													className='group rounded-md border'
+												>
+													<summary className='flex cursor-pointer list-none items-center gap-2 px-3 py-2'>
+														<ChevronRight className='h-4 w-4 transition-transform group-open:rotate-90' />
+														<span className='font-mono text-xs font-semibold'>
+															{
+																major.catalogNumber
+															}
+														</span>
+														<span className='font-medium'>
+															{major.name}
+														</span>
+														<Badge variant='secondary'>
+															{
+																majorSubjects.length
+															}{' '}
+															môn
+														</Badge>
+														{canManage && (
+															<Button
+																type='button'
+																size='sm'
+																variant='outline'
+																className='ml-auto h-7'
+																onClick={(
+																	event
+																) => {
+																	event.preventDefault()
+																	openCreateSubject(
+																		major
+																	)
+																}}
+															>
+																<Plus className='mr-1 h-3.5 w-3.5' />{' '}
+																Thêm môn
+															</Button>
+														)}
+													</summary>
+													<div className='grid gap-1.5 border-t p-3 md:grid-cols-2'>
+														{majorSubjects.length ? (
+															majorSubjects.map(
+																(subject) => (
+																	<div
+																		key={
+																			subject.id
+																		}
+																		className='rounded-md border px-3 py-2 text-sm'
+																	>
+																		<div className='flex items-center gap-2 font-medium'>
+																			<BookOpen className='h-3.5 w-3.5' />
+																			{
+																				subject.name
+																			}
+																			{canManage && (
+																				<div className='ml-auto flex gap-0.5'>
+																					<Button
+																						type='button'
+																						size='icon'
+																						variant='ghost'
+																						className='h-7 w-7'
+																						title='Sửa môn học'
+																						onClick={() =>
+																							openEditSubject(
+																								subject
+																							)
+																						}
+																					>
+																						<Pencil className='h-3.5 w-3.5' />
+																					</Button>
+																					<Button
+																						type='button'
+																						size='icon'
+																						variant='ghost'
+																						className='h-7 w-7'
+																						title='Xóa môn học'
+																						onClick={() => {
+																							if (
+																								window.confirm(
+																									`Xóa môn ${subject.name}?`
+																								)
+																							)
+																								removeSubject.mutate(
+																									subject.id
+																								)
+																						}}
+																					>
+																						<Trash2 className='h-3.5 w-3.5 text-destructive' />
+																					</Button>
+																				</div>
+																			)}
+																		</div>
+																		<div className='text-muted-foreground mt-1 font-mono text-xs'>
+																			{
+																				subject.code
+																			}
+																		</div>
+																	</div>
+																)
+															)
+														) : (
+															<p className='text-muted-foreground text-sm'>
+																Chưa có môn
+																trong ngành.
+															</p>
+														)}
+													</div>
+												</details>
+											)
+										})}
+									</div>
+								</details>
+							))}
+						</div>
+					)}
+				</CardContent>
+			</Card>
+			<Dialog open={subjectOpen} onOpenChange={setSubjectOpen}>
+				<DialogContent className='max-w-xl'>
+					<DialogHeader>
+						<DialogTitle>
+							{editingSubjectId == null
+								? 'Thêm môn học vào ngành'
+								: 'Sửa môn học'}
+						</DialogTitle>
+					</DialogHeader>
+					<div className='grid gap-4 py-2 md:grid-cols-2'>
+						<div className='space-y-2 md:col-span-2'>
+							<Label>Ngành đào tạo</Label>
+							<Input
+								value={
+									majors.find(
+										(major) => major.id === subjectMajorId
+									)?.name || ''
+								}
+								disabled
+							/>
+						</div>
+						<div className='space-y-2 md:col-span-2'>
+							<Label>Khoa phụ trách *</Label>
+							<Select
+								value={String(subjectForm.facultyId || '')}
+								disabled={editingSubjectId != null}
+								onValueChange={(value) =>
+									setSubjectForm((old) => ({
+										...old,
+										facultyId: Number(value),
+										sourceSubjectId: 0,
+										baseCode: '',
+										name: '',
+										creditHours: '0',
+										lessonHours: '0'
+									}))
+								}
+							>
+								<SelectTrigger>
+									<SelectValue placeholder='Chọn khoa phụ trách' />
+								</SelectTrigger>
+								<SelectContent>
+									{facultyDirectory.map((faculty) => (
+										<SelectItem
+											key={faculty.id}
+											value={String(faculty.id)}
+										>
+											{faculty.code} — {faculty.name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+						<div className='space-y-2 md:col-span-2'>
+							<Label>Môn học của khoa *</Label>
+							<Select
+								value={String(
+									subjectForm.sourceSubjectId || ''
+								)}
+								onValueChange={(value) => {
+									const subject = subjects.find(
+										(item) => item.id === Number(value)
+									)
+									if (!subject) return
+									setSubjectForm((old) => ({
+										...old,
+										sourceSubjectId: subject.id,
+										baseCode:
+											subject.baseCode ||
+											subject.code.split('_').pop() ||
+											'',
+										name: subject.name,
+										creditHours: String(
+											subject.creditHours || 0
+										),
+										lessonHours: String(
+											subject.lessonHours || 0
+										)
+									}))
+								}}
+							>
+								<SelectTrigger>
+									<SelectValue placeholder='Chọn hoặc tìm môn trong khoa' />
+								</SelectTrigger>
+								<SelectContent>
+									{subjectOptions.map((subject) => (
+										<SelectItem
+											key={subject.id}
+											value={String(subject.id)}
+										>
+											{subject.baseCode || subject.code} —{' '}
+											{subject.name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+							{subjectForm.facultyId > 0 &&
+								subjectOptions.length === 0 && (
+									<p className='text-muted-foreground text-sm'>
+										Khoa này chưa có môn học trong danh mục.
+									</p>
+								)}
+						</div>
+						<div className='space-y-2'>
+							<Label>Số tín chỉ</Label>
+							<Input
+								type='number'
+								min='0'
+								value={subjectForm.creditHours}
+								disabled
+							/>
+						</div>
+						<div className='space-y-2'>
+							<Label>Số tiết</Label>
+							<Input
+								type='number'
+								min='0'
+								value={subjectForm.lessonHours}
+								disabled
+							/>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button
+							variant='outline'
+							onClick={() => setSubjectOpen(false)}
+						>
+							Hủy
+						</Button>
+						<Button
+							disabled={
+								saveSubject.isPending ||
+								!subjectForm.facultyId ||
+								!subjectForm.sourceSubjectId
+							}
+							onClick={() => saveSubject.mutate()}
+						>
+							{saveSubject.isPending
+								? 'Đang lưu…'
+								: 'Lưu môn học'}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+			<Dialog open={majorOpen} onOpenChange={setMajorOpen}>
+				<DialogContent className='max-w-2xl'>
+					<DialogHeader>
+						<DialogTitle>
+							{editingId == null
+								? 'Thêm ngành đào tạo'
+								: 'Sửa ngành đào tạo'}
+						</DialogTitle>
+					</DialogHeader>
+					<div className='grid gap-4 py-2 md:grid-cols-2'>
+						<div className='space-y-2'>
+							<Label>Hệ đào tạo *</Label>
+							<Select
+								value={String(form.systemId || '')}
+								onValueChange={(value) =>
+									setForm((old) => ({
+										...old,
+										systemId: Number(value)
+									}))
+								}
+							>
+								<SelectTrigger>
+									<SelectValue placeholder='Chọn hệ' />
+								</SelectTrigger>
+								<SelectContent>
+									{systems.map((system) => (
+										<SelectItem
+											key={system.id}
+											value={String(system.id)}
+										>
+											{system.name} ({system.letter})
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+						<div className='space-y-2'>
+							<Label>Mã ngành *</Label>
+							<Input
+								value={form.nationalMajorCode}
+								onChange={(e) =>
+									setForm((old) => ({
+										...old,
+										nationalMajorCode: e.target.value
+									}))
+								}
+								placeholder='6720301'
+							/>
+						</div>
+						<div className='space-y-2'>
+							<Label>Tên ngành *</Label>
+							<Input
+								value={form.name}
+								onChange={(e) =>
+									setForm((old) => ({
+										...old,
+										name: e.target.value
+									}))
+								}
+							/>
+						</div>
+						<div className='space-y-2'>
+							<Label>Trình độ đào tạo *</Label>
+							<Select
+								value={form.qualification}
+								onValueChange={(value) =>
+									setForm((old) => ({
+										...old,
+										qualification: value
+									}))
+								}
+							>
+								<SelectTrigger>
+									<SelectValue placeholder='Chọn trình độ' />
+								</SelectTrigger>
+								<SelectContent>
+									{QUALIFICATION_OPTIONS.map((option) => (
+										<SelectItem key={option} value={option}>
+											{option}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+						<div className='space-y-2'>
+							<Label>Thời gian đào tạo *</Label>
+							<Select
+								value={form.trainingDuration}
+								onValueChange={(value) =>
+									setForm((old) => ({
+										...old,
+										trainingDuration: value
+									}))
+								}
+							>
+								<SelectTrigger>
+									<SelectValue placeholder='Chọn thời gian' />
+								</SelectTrigger>
+								<SelectContent>
+									{TRAINING_DURATION_OPTIONS.map((option) => (
+										<SelectItem key={option} value={option}>
+											{option}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+						<div className='space-y-2'>
+							<Label>Hình thức đào tạo *</Label>
+							<Select
+								value={form.trainingForm}
+								onValueChange={(value) =>
+									setForm((old) => ({
+										...old,
+										trainingForm: value
+									}))
+								}
+							>
+								<SelectTrigger>
+									<SelectValue placeholder='Chọn hình thức' />
+								</SelectTrigger>
+								<SelectContent>
+									{TRAINING_FORM_OPTIONS.map((option) => (
+										<SelectItem key={option} value={option}>
+											{option}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button
+							variant='outline'
+							onClick={() => setMajorOpen(false)}
+						>
+							Hủy
+						</Button>
+						<Button
+							disabled={
+								saveMajor.isPending ||
+								!form.systemId ||
+								!generatedCatalogNumber ||
+								!form.nationalMajorCode.trim() ||
+								!form.name.trim() ||
+								!form.qualification.trim() ||
+								!form.trainingDuration.trim() ||
+								!form.trainingForm.trim()
+							}
+							onClick={() => saveMajor.mutate()}
+						>
+							{saveMajor.isPending ? 'Đang lưu…' : 'Lưu'}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</div>
+	)
+}

--- a/apps/web/src/components/user-table/user-form.tsx
+++ b/apps/web/src/components/user-table/user-form.tsx
@@ -28,6 +28,7 @@ import { AssignRolesToUser, CreateUser, GetRoles, UpdateUser } from '@/api'
 import { AssignUserNganh, GetAssetCatalog } from '@/api/asset'
 import {
 	CreateExamTeacherCatalog,
+	ListExamAcademicTitles,
 	ListExamFacultyOptions,
 	UpsertExamFacultyHead
 } from '@/api/exam'
@@ -61,6 +62,11 @@ export default function UserForm({ onSuccess, open, setOpen }: UserFormProps) {
 		queryFn: () => ListExamFacultyOptions(),
 		enabled: open
 	})
+	const titlesQ = useQuery({
+		queryKey: ['exam-academic-titles'],
+		queryFn: ListExamAcademicTitles,
+		enabled: open
+	})
 
 	const [accountKind, setAccountKind] = useState<AccountKind | ''>('')
 	const [username, setUsername] = useState('')
@@ -71,6 +77,7 @@ export default function UserForm({ onSuccess, open, setOpen }: UserFormProps) {
 	const [nganhCode, setNganhCode] = useState('')
 	/** CNK / GV: 1 khoa */
 	const [facultyCode, setFacultyCode] = useState('')
+	const [academicTitleId, setAcademicTitleId] = useState('')
 	/** Role / phân quyền chọn từ danh sách hiện có */
 	const [roleId, setRoleId] = useState('')
 	const [pending, setPending] = useState(false)
@@ -187,6 +194,7 @@ export default function UserForm({ onSuccess, open, setOpen }: UserFormProps) {
 		setUnitId('')
 		setNganhCode('')
 		setFacultyCode('')
+		setAcademicTitleId('')
 		setRoleId('')
 	}
 
@@ -219,6 +227,10 @@ export default function UserForm({ onSuccess, open, setOpen }: UserFormProps) {
 			!facultyCode
 		) {
 			toast.error('Chọn khoa (K1…K8)')
+			return
+		}
+		if (accountKind === 'giang_vien' && !academicTitleId) {
+			toast.error('Chọn chức danh cho giáo viên')
 			return
 		}
 		if (!roleId) {
@@ -280,7 +292,8 @@ export default function UserForm({ onSuccess, open, setOpen }: UserFormProps) {
 				await CreateExamTeacherCatalog({
 					userId: created.id,
 					displayName: displayName.trim(),
-					facultyCode: facultyCode.toUpperCase()
+					facultyCode: facultyCode.toUpperCase(),
+					academicTitleId: Number(academicTitleId)
 				})
 			}
 
@@ -508,6 +521,37 @@ export default function UserForm({ onSuccess, open, setOpen }: UserFormProps) {
 									className='h-11 text-base'
 								/>
 							</div>
+							{accountKind === 'giang_vien' && (
+								<div className='space-y-2'>
+									<Label>
+										Chức danh{' '}
+										<span className='text-destructive'>
+											*
+										</span>
+									</Label>
+									<Select
+										value={academicTitleId || undefined}
+										onValueChange={setAcademicTitleId}
+									>
+										<SelectTrigger>
+											<SelectValue placeholder='Chọn chức danh' />
+										</SelectTrigger>
+										<SelectContent>
+											{(titlesQ.data || []).map(
+												(title) => (
+													<SelectItem
+														key={title.id}
+														value={String(title.id)}
+													>
+														{title.name} (
+														{title.percentage}%)
+													</SelectItem>
+												)
+											)}
+										</SelectContent>
+									</Select>
+								</div>
+							)}
 							<div className='rounded-md border bg-background/60 px-3 py-2 text-sm'>
 								<span className='text-muted-foreground'>
 									Chức vụ (gắn tài khoản, không sửa sau):{' '}

--- a/apps/web/src/hooks/useAssignRoles.ts
+++ b/apps/web/src/hooks/useAssignRoles.ts
@@ -1,7 +1,7 @@
 import { AssignRolesToUser } from '@/api'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
-import { AssignRoleRequest } from '@/types'
+import type { AssignRoleRequest } from '@/types'
 
 export default function useAssignRoles() {
 	const queryClient = useQueryClient()

--- a/apps/web/src/lib/exam-roles.ts
+++ b/apps/web/src/lib/exam-roles.ts
@@ -139,7 +139,7 @@ export function canDrawExams(): boolean {
 
 /** Danh mục đào tạo (khoa / ngành ĐT / lớp / môn) — GV không quản */
 export function canManageExamCatalog(): boolean {
-	return isSuperAdmin() || isExamNganhOperator() || isExamOffice()
+	return isSuperAdmin() || isExamNganhOperator()
 }
 
 /**
@@ -171,6 +171,7 @@ export type ExamNavKey =
 	| 'overview'
 	| 'catalog'
 	| 'classes'
+	| 'faculties'
 	| 'teachers'
 	| 'assign'
 	| 'mine'
@@ -180,6 +181,31 @@ export type ExamNavKey =
 
 export function examNavAllowed(key: ExamNavKey): boolean {
 	if (isSuperAdmin()) return true
+	// CNK được cấp tự động từ chức danh: chỉ các màn hình phục vụ quản lý/duyệt khoa.
+	if (rolesLower().includes('exam_dept_head')) {
+		return [
+			'overview',
+			'catalog',
+			'classes',
+			'faculties',
+			'teachers',
+			'assign',
+			'approve',
+			'bank'
+		].includes(key)
+	}
+	// Ban Khảo thí chỉ xem danh mục; vận hành duyệt, ngân hàng và rút đề.
+	if (isExamOffice()) {
+		return [
+			'overview',
+			'catalog',
+			'classes',
+			'teachers',
+			'approve',
+			'bank',
+			'draw'
+		].includes(key)
+	}
 	// GV thuần: chỉ Tổng quan + Đề của tôi
 	const pureLecturer =
 		isExamLecturerRoleOnly() &&

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -46,6 +46,7 @@ import { Route as DeThiQrRouteImport } from './routes/de-thi/qr'
 import { Route as DeThiPhanCongRouteImport } from './routes/de-thi/phan-cong'
 import { Route as DeThiNganHangRouteImport } from './routes/de-thi/ngan-hang'
 import { Route as DeThiLopRouteImport } from './routes/de-thi/lop'
+import { Route as DeThiKhoaRouteImport } from './routes/de-thi/khoa'
 import { Route as DeThiGiaoVienRouteImport } from './routes/de-thi/giao-vien'
 import { Route as DeThiDuyetRouteImport } from './routes/de-thi/duyet'
 import { Route as DeThiDanhMucRouteImport } from './routes/de-thi/danh-muc'
@@ -242,6 +243,11 @@ const DeThiLopRoute = DeThiLopRouteImport.update({
   path: '/de-thi/lop',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DeThiKhoaRoute = DeThiKhoaRouteImport.update({
+  id: '/de-thi/khoa',
+  path: '/de-thi/khoa',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DeThiGiaoVienRoute = DeThiGiaoVienRouteImport.update({
   id: '/de-thi/giao-vien',
   path: '/de-thi/giao-vien',
@@ -317,6 +323,7 @@ export interface FileRoutesByFullPath {
   '/de-thi/danh-muc': typeof DeThiDanhMucRoute
   '/de-thi/duyet': typeof DeThiDuyetRoute
   '/de-thi/giao-vien': typeof DeThiGiaoVienRoute
+  '/de-thi/khoa': typeof DeThiKhoaRoute
   '/de-thi/lop': typeof DeThiLopRoute
   '/de-thi/ngan-hang': typeof DeThiNganHangRoute
   '/de-thi/phan-cong': typeof DeThiPhanCongRoute
@@ -366,6 +373,7 @@ export interface FileRoutesByTo {
   '/de-thi/danh-muc': typeof DeThiDanhMucRoute
   '/de-thi/duyet': typeof DeThiDuyetRoute
   '/de-thi/giao-vien': typeof DeThiGiaoVienRoute
+  '/de-thi/khoa': typeof DeThiKhoaRoute
   '/de-thi/lop': typeof DeThiLopRoute
   '/de-thi/ngan-hang': typeof DeThiNganHangRoute
   '/de-thi/phan-cong': typeof DeThiPhanCongRoute
@@ -416,6 +424,7 @@ export interface FileRoutesById {
   '/de-thi/danh-muc': typeof DeThiDanhMucRoute
   '/de-thi/duyet': typeof DeThiDuyetRoute
   '/de-thi/giao-vien': typeof DeThiGiaoVienRoute
+  '/de-thi/khoa': typeof DeThiKhoaRoute
   '/de-thi/lop': typeof DeThiLopRoute
   '/de-thi/ngan-hang': typeof DeThiNganHangRoute
   '/de-thi/phan-cong': typeof DeThiPhanCongRoute
@@ -467,6 +476,7 @@ export interface FileRouteTypes {
     | '/de-thi/danh-muc'
     | '/de-thi/duyet'
     | '/de-thi/giao-vien'
+    | '/de-thi/khoa'
     | '/de-thi/lop'
     | '/de-thi/ngan-hang'
     | '/de-thi/phan-cong'
@@ -516,6 +526,7 @@ export interface FileRouteTypes {
     | '/de-thi/danh-muc'
     | '/de-thi/duyet'
     | '/de-thi/giao-vien'
+    | '/de-thi/khoa'
     | '/de-thi/lop'
     | '/de-thi/ngan-hang'
     | '/de-thi/phan-cong'
@@ -565,6 +576,7 @@ export interface FileRouteTypes {
     | '/de-thi/danh-muc'
     | '/de-thi/duyet'
     | '/de-thi/giao-vien'
+    | '/de-thi/khoa'
     | '/de-thi/lop'
     | '/de-thi/ngan-hang'
     | '/de-thi/phan-cong'
@@ -615,6 +627,7 @@ export interface RootRouteChildren {
   DeThiDanhMucRoute: typeof DeThiDanhMucRoute
   DeThiDuyetRoute: typeof DeThiDuyetRoute
   DeThiGiaoVienRoute: typeof DeThiGiaoVienRoute
+  DeThiKhoaRoute: typeof DeThiKhoaRoute
   DeThiLopRoute: typeof DeThiLopRoute
   DeThiNganHangRoute: typeof DeThiNganHangRoute
   DeThiPhanCongRoute: typeof DeThiPhanCongRoute
@@ -902,6 +915,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DeThiLopRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/de-thi/khoa': {
+      id: '/de-thi/khoa'
+      path: '/de-thi/khoa'
+      fullPath: '/de-thi/khoa'
+      preLoaderRoute: typeof DeThiKhoaRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/de-thi/giao-vien': {
       id: '/de-thi/giao-vien'
       path: '/de-thi/giao-vien'
@@ -999,6 +1019,7 @@ const rootRouteChildren: RootRouteChildren = {
   DeThiDanhMucRoute: DeThiDanhMucRoute,
   DeThiDuyetRoute: DeThiDuyetRoute,
   DeThiGiaoVienRoute: DeThiGiaoVienRoute,
+  DeThiKhoaRoute: DeThiKhoaRoute,
   DeThiLopRoute: DeThiLopRoute,
   DeThiNganHangRoute: DeThiNganHangRoute,
   DeThiPhanCongRoute: DeThiPhanCongRoute,

--- a/apps/web/src/routes/de-thi/index.tsx
+++ b/apps/web/src/routes/de-thi/index.tsx
@@ -30,6 +30,13 @@ function RouteComponent() {
 			show: examNavAllowed('catalog')
 		},
 		{
+			title: 'Danh mục khoa',
+			desc: 'Môn học · Giáo viên · Chủ nhiệm khoa',
+			to: '/de-thi/khoa' as const,
+			icon: Layers,
+			show: examNavAllowed('catalog')
+		},
+		{
 			title: 'Danh mục lớp',
 			desc: 'Lớp thuộc hệ + ngành đào tạo',
 			to: '/de-thi/lop' as const,

--- a/apps/web/src/routes/de-thi/khoa.tsx
+++ b/apps/web/src/routes/de-thi/khoa.tsx
@@ -1,13 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import ExamRoleGuard from '@/components/exam/ExamRoleGuard'
-import ExamTrainingCatalogPage from '@/components/exam/ExamTrainingCatalogPage'
+import ExamFacultiesPage from '@/components/exam/ExamFacultiesPage'
 
-export const Route = createFileRoute('/de-thi/danh-muc')({
+export const Route = createFileRoute('/de-thi/khoa')({
 	component: () => (
 		<ProtectedRoute>
 			<ExamRoleGuard navKey='catalog'>
-				<ExamTrainingCatalogPage />
+				<ExamFacultiesPage />
 			</ExamRoleGuard>
 		</ProtectedRoute>
 	)


### PR DESCRIPTION
## Tổng quan
- Mở rộng danh mục đề thi tự luận: hệ đào tạo, ngành đào tạo chính thức, khoa, môn học, lớp thi, giáo viên và chức danh.
- Thêm trang Các môn đào tạo trong ngành với thao tác thêm, sửa, xóa môn.
- Khi thêm môn vào ngành: chọn khoa dùng chung rồi dò môn thuộc khoa; backend tự liên kết khoa tương ứng với ngành theo schema hiện tại.
- Nút Quản lý môn học tại trang khoa mở bảng đầy đủ mã môn, tên môn, ngành, tín chỉ, số tiết và CRUD tại chỗ.
- Mở rộng phân công giảng dạy, nhật ký, phân quyền theo khoa và luồng rút đề.
- Đồng bộ mã danh mục ngành, mã môn và dữ liệu log liên quan.

## Tương thích và sửa lỗi
- Rebase trên origin/main và giữ bộ chọn tháng đa trình duyệt, tương thích Firefox 151.0.1 trở lên.
- Frontend gửi trainingTypeId; backend có giá trị mặc định cho bundle cũ bị cache để tránh lỗi missing field khi rollout.
- Sửa import type AssignRoleRequest để production build không lỗi Rollup.
- Sáu migration đề thi nối liên tục từ 0042 đến 0047; không có migration hay mã nguồn quản lý phép trong PR.

## Kiểm tra
- Production web build: đạt, 3790 modules transformed.
- Encore application graph và khởi động: đạt.
- Migration trên SQLite sạch: đạt, 48 migration; có đủ exam_academic_titles, exam_classes, exam_subjects và exam_teaching_assignments.
- git diff --check: đạt.
- Firefox trên máy kiểm tra là 153.0; mã và build target tương thích Firefox 151.0.1.