### PR TITLE
fix(ci): use repository-specific container images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,7 +97,7 @@ jobs:
               id: meta
               uses: docker/metadata-action@v5
               with:
-                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/qlhv-api
+                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/quan-ly-phep-api
                   tags: |
                       type=raw,value=latest
                       type=sha,prefix={{branch}}-
@@ -143,7 +143,7 @@ jobs:
               id: meta
               uses: docker/metadata-action@v5
               with:
-                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/qlhv-web
+                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/quan-ly-phep-web
                   tags: |
                       type=raw,value=latest
                       type=sha,prefix={{branch}}-
@@ -186,7 +186,7 @@ jobs:
               id: meta
               uses: docker/metadata-action@v5
               with:
-                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/sms-api
+                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/quan-ly-phep-sms-api
                   tags: |
                       type=raw,value=latest
                       type=sha,prefix={{branch}}-
@@ -229,7 +229,7 @@ jobs:
               id: meta
               uses: docker/metadata-action@v5
               with:
-                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/sms-web
+                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/quan-ly-phep-sms-web
                   tags: |
                       type=raw,value=${{ matrix.env }}-latest
                       type=sha,prefix=${{ matrix.env }}-


### PR DESCRIPTION
## Mục tiêu

Điều chỉnh CI để build và phát hành container bằng đúng tên image của repository này.

## Phạm vi

PR này chỉ chứa nhóm thay đổi tương ứng được tách từ #185; không kèm toàn bộ các PR trước.

## Thứ tự merge

Độc lập, có thể merge trực tiếp vào `main`.

## Lưu ý kiểm thử

Trạng thái tích hợp đầy đủ đã chạy được generate, migrate database sạch, Encore check và frontend build. Các lỗi TypeScript/lint và tình trạng thiếu automated tests đã được ghi nhận riêng, không được che giấu trong PR này.