### PR TITLE
feat(leave): add database schema foundation

### DIFF
--- a/apps/api/migrations/0042_lying_greymalkin.sql
+++ b/apps/api/migrations/0042_lying_greymalkin.sql
@@ -1,0 +1,871 @@
+CREATE TABLE `account_audit_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`action` text NOT NULL,
+	`actor_user_id` integer,
+	`actor_username` text,
+	`actor_display_name` text,
+	`actor_is_admin` integer DEFAULT 0 NOT NULL,
+	`room_id` integer,
+	`room_code` text,
+	`room_name` text,
+	`address` text,
+	`floor_name` text,
+	`building_code` text,
+	`building_name` text,
+	`account_label` text,
+	`summary` text NOT NULL,
+	`details` text
+);
+--> statement-breakpoint
+CREATE TABLE `asset_broken_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`event_type` text NOT NULL,
+	`source_type` text DEFAULT 'OTHER' NOT NULL,
+	`source_id` integer,
+	`proposal_id` integer,
+	`repair_request_id` integer,
+	`room_asset_id` integer,
+	`source_asset_id` integer,
+	`asset_code` text,
+	`original_code` text,
+	`asset_name` text NOT NULL,
+	`category` text,
+	`quantity` integer DEFAULT 1 NOT NULL,
+	`original_grade` integer,
+	`grade_after` integer,
+	`status_after` text,
+	`room_id` integer,
+	`room_code` text,
+	`room_name` text,
+	`floor_name` text,
+	`building_code` text,
+	`building_name` text,
+	`unit_name` text,
+	`nganh_code` text,
+	`reason` text,
+	`result_note` text,
+	`performer` text,
+	`event_at` text NOT NULL,
+	`actor_user_id` integer,
+	`actor_username` text,
+	`actor_display_name` text
+);
+--> statement-breakpoint
+CREATE TABLE `asset_movement_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`room_asset_id` integer,
+	`movement_type` text NOT NULL,
+	`executed_at` text NOT NULL,
+	`executing_unit` text,
+	`install_address` text,
+	`asset_code` text,
+	`asset_name` text NOT NULL,
+	`quantity` integer DEFAULT 0 NOT NULL,
+	`quantity_before` integer DEFAULT 0 NOT NULL,
+	`quantity_after` integer DEFAULT 0 NOT NULL,
+	`grade` integer DEFAULT 1 NOT NULL,
+	`manufacture_year` integer,
+	`usage_year` integer,
+	`reason_code` text,
+	`reason_other` text,
+	`decision_date` text,
+	`decision_number` text,
+	`signer` text,
+	`performer` text,
+	`explanation` text,
+	`note` text,
+	`building_code` text,
+	`building_name` text,
+	`room_code` text,
+	`room_name` text,
+	`floor_name` text,
+	FOREIGN KEY (`room_asset_id`) REFERENCES `room_assets`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE TABLE `asset_proposal_items` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`proposal_id` integer NOT NULL,
+	`material_id` integer,
+	`material_code` text,
+	`material_name` text NOT NULL,
+	`room_asset_id` integer,
+	`source_asset_id` integer,
+	`original_grade` integer,
+	`original_code` text,
+	`quantity` integer DEFAULT 1 NOT NULL,
+	`unit` text,
+	`category` text,
+	`nganh_code` text,
+	`chuyen_nganh_code` text,
+	`note` text,
+	`from_room_id` integer,
+	`from_room_code` text,
+	`from_room_name` text,
+	`location_note` text,
+	`target_room_id` integer,
+	`target_room_code` text,
+	`target_room_name` text
+);
+--> statement-breakpoint
+CREATE TABLE `asset_proposal_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`proposal_id` integer,
+	`action` text NOT NULL,
+	`proposal_type` text,
+	`summary` text NOT NULL,
+	`details` text,
+	`actor_user_id` integer,
+	`actor_username` text,
+	`actor_display_name` text,
+	`actor_is_admin` integer DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `asset_proposals` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`proposal_type` text NOT NULL,
+	`status` text DEFAULT 'PENDING' NOT NULL,
+	`title` text NOT NULL,
+	`description` text,
+	`unit_id` integer,
+	`unit_name` text,
+	`nganh_code` text,
+	`proposed_by_user_id` integer,
+	`proposed_by_username` text,
+	`proposed_by_display_name` text,
+	`admin_note` text,
+	`decision_number` text,
+	`decision_nganh_code` text,
+	`decision_issuing_level` text,
+	`decision_signer` text,
+	`decision_at` text,
+	`decided_by_user_id` integer,
+	`decided_by_username` text,
+	`decided_by_display_name` text,
+	`completed_at` text
+);
+--> statement-breakpoint
+CREATE TABLE `buildings` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`manager_code` text,
+	`area` text,
+	`address` text,
+	`description` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `buildings_code_unique` ON `buildings` (`code`);--> statement-breakpoint
+CREATE TABLE `catalog_audit_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`action` text NOT NULL,
+	`entity_type` text NOT NULL,
+	`actor_user_id` integer,
+	`actor_username` text,
+	`actor_display_name` text,
+	`actor_is_admin` integer DEFAULT 0 NOT NULL,
+	`entity_id` integer,
+	`entity_code` text,
+	`entity_name` text,
+	`parent_code` text,
+	`parent_name` text,
+	`summary` text NOT NULL,
+	`details` text
+);
+--> statement-breakpoint
+CREATE TABLE `catalog_stock_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`movement_type` text NOT NULL,
+	`executed_at` text NOT NULL,
+	`material_id` integer,
+	`material_code` text,
+	`material_name` text NOT NULL,
+	`nganh_code` text NOT NULL,
+	`chuyen_nganh_code` text,
+	`chuyen_nganh_name` text,
+	`quantity` integer DEFAULT 0 NOT NULL,
+	`quantity_before` integer DEFAULT 0 NOT NULL,
+	`quantity_after` integer DEFAULT 0 NOT NULL,
+	`unit` text,
+	`is_new_material` integer DEFAULT 0 NOT NULL,
+	`reason` text,
+	`note` text,
+	`actor_user_id` integer,
+	`actor_username` text,
+	`actor_display_name` text,
+	`actor_is_admin` integer DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `categories` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`description` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `categories_code_unique` ON `categories` (`code`);--> statement-breakpoint
+CREATE TABLE `exam_classes` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`major_id` integer,
+	`faculty_id` integer,
+	`cohort` text,
+	`description` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `exam_classes_code_unique` ON `exam_classes` (`code`);--> statement-breakpoint
+CREATE TABLE `exam_draw_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`draw_id` integer,
+	`action` text NOT NULL,
+	`summary` text NOT NULL,
+	`details` text,
+	`actor_user_id` integer,
+	`actor_username` text,
+	`actor_display_name` text
+);
+--> statement-breakpoint
+CREATE TABLE `exam_draws` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`draw_code` text NOT NULL,
+	`exam_id` integer NOT NULL,
+	`exam_code` text,
+	`paper_number` integer,
+	`subject_id` integer,
+	`major_id` integer,
+	`draw_type` text NOT NULL,
+	`class_id` integer,
+	`class_name` text,
+	`drawn_by_user_id` integer,
+	`drawn_by_username` text,
+	`drawn_by_display_name` text,
+	`drawn_at` text NOT NULL,
+	`printed_at` text,
+	`printed_by_user_id` integer,
+	`printed_by_username` text,
+	`print_blocked` integer DEFAULT false NOT NULL,
+	`print_blocked_at` text,
+	`print_blocked_reason` text,
+	`exam_date` text,
+	`exam_time` text,
+	`location` text,
+	`note` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `exam_draws_draw_code_unique` ON `exam_draws` (`draw_code`);--> statement-breakpoint
+CREATE TABLE `exam_faculties` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`major_id` integer NOT NULL,
+	`description` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `exam_faculties_major_code_uq` ON `exam_faculties` (`major_id`,`code`);--> statement-breakpoint
+CREATE TABLE `exam_faculty_heads` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL,
+	`faculty_code` text NOT NULL,
+	`faculty_name` text,
+	`user_id` integer NOT NULL,
+	`username` text,
+	`display_name` text,
+	`note` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `exam_faculty_heads_user_fac_uq` ON `exam_faculty_heads` (`user_id`,`faculty_code`);--> statement-breakpoint
+CREATE TABLE `exam_major_heads` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL,
+	`major_id` integer NOT NULL,
+	`user_id` integer NOT NULL,
+	`username` text,
+	`display_name` text,
+	`note` text
+);
+--> statement-breakpoint
+CREATE TABLE `exam_majors` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`system_id` integer NOT NULL,
+	`level_code` text,
+	`short_code` text,
+	`description` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `exam_majors_code_unique` ON `exam_majors` (`code`);--> statement-breakpoint
+CREATE TABLE `exam_questions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`exam_id` integer NOT NULL,
+	`question_number` integer DEFAULT 1 NOT NULL,
+	`content` text NOT NULL,
+	`answer` text,
+	`points` integer DEFAULT 1 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `exam_subjects` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`base_code` text,
+	`name` text NOT NULL,
+	`credit_hours` integer DEFAULT 0,
+	`lesson_hours` integer DEFAULT 0,
+	`faculty_id` integer NOT NULL,
+	`major_id` integer NOT NULL,
+	`description` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `exam_subjects_code_unique` ON `exam_subjects` (`code`);--> statement-breakpoint
+CREATE TABLE `exam_systems` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`letter` text NOT NULL,
+	`description` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `exam_systems_code_unique` ON `exam_systems` (`code`);--> statement-breakpoint
+CREATE UNIQUE INDEX `exam_systems_letter_unique` ON `exam_systems` (`letter`);--> statement-breakpoint
+CREATE TABLE `exam_teachers` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`user_id` integer NOT NULL,
+	`username` text,
+	`display_name` text,
+	`faculty_code` text NOT NULL,
+	`faculty_name` text,
+	`note` text,
+	`created_by_user_id` integer,
+	`created_by_username` text,
+	`created_by_display_name` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `exam_teachers_user_uq` ON `exam_teachers` (`user_id`);--> statement-breakpoint
+CREATE TABLE `exam_teaching_assignment_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`action` text NOT NULL,
+	`subject_id` integer,
+	`subject_code` text,
+	`subject_name` text,
+	`major_id` integer,
+	`major_code` text,
+	`faculty_id` integer,
+	`faculty_code` text,
+	`class_id` integer,
+	`class_code` text,
+	`class_name` text,
+	`teacher_user_id` integer,
+	`teacher_username` text,
+	`teacher_display_name` text,
+	`note` text,
+	`actor_user_id` integer,
+	`actor_username` text,
+	`actor_display_name` text,
+	`summary` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `exam_teaching_assignments` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`subject_id` integer NOT NULL,
+	`class_id` integer,
+	`user_id` integer NOT NULL,
+	`username` text,
+	`display_name` text,
+	`note` text,
+	`teaching_start` text,
+	`teaching_end` text,
+	`assigned_by_user_id` integer,
+	`assigned_by_username` text,
+	`assigned_by_display_name` text
+);
+--> statement-breakpoint
+CREATE TABLE `exam_workflow_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`exam_id` integer NOT NULL,
+	`action` text NOT NULL,
+	`from_status` text,
+	`to_status` text,
+	`note` text,
+	`actor_user_id` integer,
+	`actor_username` text,
+	`actor_display_name` text
+);
+--> statement-breakpoint
+CREATE TABLE `exams` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`title` text NOT NULL,
+	`subject_id` integer NOT NULL,
+	`paper_number` integer,
+	`status` text DEFAULT 'DRAFT' NOT NULL,
+	`created_by_user_id` integer,
+	`created_by_username` text,
+	`created_by_display_name` text,
+	`approved_by_user_id` integer,
+	`approved_by_username` text,
+	`approved_by_display_name` text,
+	`approved_at` text,
+	`approved_by_rank` text,
+	`approved_by_position` text,
+	`approved_by_signature_url` text,
+	`approved_by_title` text,
+	`dept_head_user_id` integer,
+	`dept_head_username` text,
+	`dept_head_display_name` text,
+	`dept_head_rank` text,
+	`dept_head_signature_url` text,
+	`dept_head_approved_at` text,
+	`qr_code` text,
+	`locked` integer DEFAULT false NOT NULL,
+	`class_id` integer,
+	`class_name` text,
+	`duration_minutes` integer DEFAULT 60,
+	`question_file_url` text,
+	`question_file_name` text,
+	`answer_file_url` text,
+	`answer_file_name` text,
+	`note` text,
+	`return_note` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `exams_code_unique` ON `exams` (`code`);--> statement-breakpoint
+CREATE TABLE `floors` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`building_id` integer NOT NULL,
+	`code` text,
+	`floor_number` integer NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	FOREIGN KEY (`building_id`) REFERENCES `buildings`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `rooms` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`floor_id` integer NOT NULL,
+	`room_code` text NOT NULL,
+	`room_name` text NOT NULL,
+	`room_type` text,
+	`manager` text,
+	`manager_code` text,
+	`account_password` text,
+	`capacity` integer DEFAULT 0 NOT NULL,
+	`status` text DEFAULT 'ACTIVE' NOT NULL,
+	`description` text,
+	`class_id` integer,
+	FOREIGN KEY (`floor_id`) REFERENCES `floors`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`class_id`) REFERENCES `classes`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `rooms_room_code_unique` ON `rooms` (`room_code`);--> statement-breakpoint
+CREATE TABLE `room_images` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`room_id` integer NOT NULL,
+	`image_url` text NOT NULL,
+	`title` text,
+	`description` text,
+	FOREIGN KEY (`room_id`) REFERENCES `rooms`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `room_assets` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`room_id` integer NOT NULL,
+	`code` text,
+	`name` text NOT NULL,
+	`category` text NOT NULL,
+	`quantity` integer DEFAULT 1 NOT NULL,
+	`broken_quantity` integer DEFAULT 0 NOT NULL,
+	`unit` text,
+	`holding_unit_id` integer,
+	`grade` integer DEFAULT 1 NOT NULL,
+	`manufacture_year` integer,
+	`usage_year` integer,
+	`install_address` text,
+	`status` text DEFAULT 'NORMAL' NOT NULL,
+	`purchase_date` text,
+	`expiry_date` text,
+	`broken_at` text,
+	`repair_started_at` text,
+	`repair_completed_at` text,
+	`repair_performer` text,
+	`description` text,
+	FOREIGN KEY (`room_id`) REFERENCES `rooms`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`holding_unit_id`) REFERENCES `units`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `room_assets_code_unique` ON `room_assets` (`code`);--> statement-breakpoint
+CREATE TABLE `repair_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`room_asset_id` integer NOT NULL,
+	`repair_date` text NOT NULL,
+	`content` text NOT NULL,
+	`cost` integer DEFAULT 0 NOT NULL,
+	`performer` text,
+	`note` text,
+	FOREIGN KEY (`room_asset_id`) REFERENCES `room_assets`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `inventory_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`room_asset_id` integer NOT NULL,
+	`inventory_date` text NOT NULL,
+	`actual_quantity` integer DEFAULT 0 NOT NULL,
+	`expected_quantity` integer DEFAULT 0 NOT NULL,
+	`result` text,
+	`note` text,
+	FOREIGN KEY (`room_asset_id`) REFERENCES `room_assets`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `replacement_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`room_asset_id` integer NOT NULL,
+	`replacement_date` text NOT NULL,
+	`old_asset` text NOT NULL,
+	`new_asset` text NOT NULL,
+	`reason` text,
+	`performer` text,
+	`note` text,
+	FOREIGN KEY (`room_asset_id`) REFERENCES `room_assets`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `user_nganh` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`user_id` integer NOT NULL,
+	`nganh_code` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `user_nganh_user_nganh_uq` ON `user_nganh` (`user_id`,`nganh_code`);--> statement-breakpoint
+CREATE TABLE `repair_requests` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`room_id` integer NOT NULL,
+	`room_asset_id` integer,
+	`source_asset_id` integer,
+	`quantity` integer DEFAULT 1 NOT NULL,
+	`original_grade` integer,
+	`asset_name` text NOT NULL,
+	`category` text,
+	`description` text,
+	`status` text DEFAULT 'PENDING' NOT NULL,
+	`broken_at` text NOT NULL,
+	`reported_by_name` text NOT NULL,
+	`reported_by_user_id` integer,
+	`assigned_to_name` text,
+	`assigned_at` text,
+	`assigned_by_name` text,
+	`repair_started_at` text,
+	`completed_at` text,
+	`admin_note` text,
+	FOREIGN KEY (`room_id`) REFERENCES `rooms`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`room_asset_id`) REFERENCES `room_assets`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`source_asset_id`) REFERENCES `room_assets`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`reported_by_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE TABLE `suppliers` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`phone` text,
+	`email` text,
+	`address` text,
+	`contact_person` text,
+	`description` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `suppliers_code_unique` ON `suppliers` (`code`);--> statement-breakpoint
+CREATE TABLE `materials` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`category_id` integer NOT NULL,
+	`supplier_id` integer,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`unit` text NOT NULL,
+	`quantity` integer DEFAULT 0 NOT NULL,
+	`min_quantity` integer DEFAULT 0 NOT NULL,
+	`price` real DEFAULT 0,
+	`status` text DEFAULT 'ACTIVE' NOT NULL,
+	`description` text,
+	FOREIGN KEY (`category_id`) REFERENCES `categories`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`supplier_id`) REFERENCES `suppliers`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `materials_code_unique` ON `materials` (`code`);--> statement-breakpoint
+CREATE TABLE `warehouses` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`location` text,
+	`manager` text,
+	`phone` text,
+	`description` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `warehouses_code_unique` ON `warehouses` (`code`);--> statement-breakpoint
+CREATE TABLE `warehouse_items` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`warehouse_id` integer NOT NULL,
+	`material_id` integer NOT NULL,
+	`quantity` integer DEFAULT 0 NOT NULL,
+	`min_quantity` integer DEFAULT 0 NOT NULL,
+	FOREIGN KEY (`warehouse_id`) REFERENCES `warehouses`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`material_id`) REFERENCES `materials`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_actions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`name` text NOT NULL,
+	`display_name` text NOT NULL,
+	`description` text
+);
+--> statement-breakpoint
+INSERT INTO `__new_actions`("id", "createdAt", "updatedAt", "name", "display_name", "description") SELECT "id", "createdAt", "updatedAt", "name", "display_name", "description" FROM `actions`;--> statement-breakpoint
+DROP TABLE `actions`;--> statement-breakpoint
+ALTER TABLE `__new_actions` RENAME TO `actions`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `actions_name_unique` ON `actions` (`name`);--> statement-breakpoint
+CREATE TABLE `__new_classes` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`name` text NOT NULL,
+	`description` text DEFAULT '',
+	`graduatedAt` text,
+	`status` text DEFAULT 'ongoing',
+	`unitId` integer NOT NULL,
+	FOREIGN KEY (`unitId`) REFERENCES `units`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_classes`("id", "createdAt", "updatedAt", "name", "description", "graduatedAt", "status", "unitId") SELECT "id", "createdAt", "updatedAt", "name", "description", "graduatedAt", "status", "unitId" FROM `classes`;--> statement-breakpoint
+DROP TABLE `classes`;--> statement-breakpoint
+ALTER TABLE `__new_classes` RENAME TO `classes`;--> statement-breakpoint
+CREATE UNIQUE INDEX `class_unit_unique_constraint` ON `classes` (`name`,`unitId`);--> statement-breakpoint
+CREATE TABLE `__new_notification_items` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`notifiableType` text NOT NULL,
+	`notifiableId` integer NOT NULL,
+	`notificationId` text NOT NULL,
+	FOREIGN KEY (`notificationId`) REFERENCES `notifications`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_notification_items`("id", "createdAt", "updatedAt", "notifiableType", "notifiableId", "notificationId") SELECT "id", "createdAt", "updatedAt", "notifiableType", "notifiableId", "notificationId" FROM `notification_items`;--> statement-breakpoint
+DROP TABLE `notification_items`;--> statement-breakpoint
+ALTER TABLE `__new_notification_items` RENAME TO `notification_items`;--> statement-breakpoint
+CREATE INDEX `notification_items_notification_idx` ON `notification_items` (`notificationId`);--> statement-breakpoint
+CREATE INDEX `notification_items_item_idx` ON `notification_items` (`notifiableType`,`notifiableId`);--> statement-breakpoint
+CREATE TABLE `__new_permissions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`name` text NOT NULL,
+	`display_name` text NOT NULL,
+	`description` text,
+	`resource_id` integer NOT NULL,
+	`action_id` integer NOT NULL,
+	FOREIGN KEY (`resource_id`) REFERENCES `resources`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`action_id`) REFERENCES `actions`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_permissions`("id", "createdAt", "updatedAt", "name", "display_name", "description", "resource_id", "action_id") SELECT "id", "createdAt", "updatedAt", "name", "display_name", "description", "resource_id", "action_id" FROM `permissions`;--> statement-breakpoint
+DROP TABLE `permissions`;--> statement-breakpoint
+ALTER TABLE `__new_permissions` RENAME TO `permissions`;--> statement-breakpoint
+CREATE UNIQUE INDEX `permissions_name_unique` ON `permissions` (`name`);--> statement-breakpoint
+CREATE TABLE `__new_resources` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`name` text NOT NULL,
+	`display_name` text NOT NULL,
+	`description` text
+);
+--> statement-breakpoint
+INSERT INTO `__new_resources`("id", "createdAt", "updatedAt", "name", "display_name", "description") SELECT "id", "createdAt", "updatedAt", "name", "display_name", "description" FROM `resources`;--> statement-breakpoint
+DROP TABLE `resources`;--> statement-breakpoint
+ALTER TABLE `__new_resources` RENAME TO `resources`;--> statement-breakpoint
+CREATE UNIQUE INDEX `resources_name_unique` ON `resources` (`name`);--> statement-breakpoint
+CREATE TABLE `__new_roles` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`name` text NOT NULL,
+	`description` text
+);
+--> statement-breakpoint
+INSERT INTO `__new_roles`("id", "createdAt", "updatedAt", "name", "description") SELECT "id", "createdAt", "updatedAt", "name", "description" FROM `roles`;--> statement-breakpoint
+DROP TABLE `roles`;--> statement-breakpoint
+ALTER TABLE `__new_roles` RENAME TO `roles`;--> statement-breakpoint
+CREATE UNIQUE INDEX `roles_name_unique` ON `roles` (`name`);--> statement-breakpoint
+CREATE TABLE `__new_students` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`fullName` text DEFAULT '',
+	`birthPlace` text DEFAULT '',
+	`address` text DEFAULT '',
+	`dob` text DEFAULT '',
+	`rank` text DEFAULT '',
+	`previousUnit` text DEFAULT '',
+	`previousPosition` text DEFAULT '',
+	`position` text DEFAULT 'Học viên',
+	`ethnic` text DEFAULT '',
+	`religion` text DEFAULT 'Không',
+	`enlistmentPeriod` text DEFAULT '',
+	`politicalOrg` text NOT NULL,
+	`politicalOrgOfficialDate` text DEFAULT '',
+	`cpvId` text,
+	`educationLevel` text DEFAULT '',
+	`schoolName` text DEFAULT '',
+	`major` text DEFAULT '',
+	`isGraduated` integer DEFAULT false,
+	`talent` text DEFAULT 'Không',
+	`shortcoming` text DEFAULT 'Không',
+	`policyBeneficiaryGroup` text DEFAULT 'Không',
+	`fatherName` text DEFAULT '',
+	`fatherDob` text DEFAULT '',
+	`fatherPhoneNumber` text DEFAULT '',
+	`fatherJob` text DEFAULT '',
+	`motherName` text DEFAULT '',
+	`motherDob` text DEFAULT '',
+	`motherPhoneNumber` text DEFAULT '',
+	`motherJob` text DEFAULT '',
+	`isMarried` integer DEFAULT false,
+	`spouseName` text DEFAULT '',
+	`spouseDob` text DEFAULT '',
+	`spouseJob` text DEFAULT '',
+	`spousePhoneNumber` text DEFAULT '',
+	`childrenInfos` text DEFAULT '[]',
+	`familySize` integer,
+	`familyBackground` text DEFAULT 'Không',
+	`familyBirthOrder` text DEFAULT '',
+	`achievement` text DEFAULT 'Không',
+	`disciplinaryHistory` text DEFAULT 'Không',
+	`phone` text DEFAULT '',
+	`classId` integer NOT NULL,
+	`cpvOfficialAt` text,
+	`avatar` text,
+	`siblings` text DEFAULT '[]',
+	`contactPerson` text DEFAULT '{}',
+	`studentId` text,
+	`relatedDocumentations` text,
+	`status` text DEFAULT 'pending' NOT NULL,
+	FOREIGN KEY (`classId`) REFERENCES `classes`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_students`("id", "createdAt", "updatedAt", "fullName", "birthPlace", "address", "dob", "rank", "previousUnit", "previousPosition", "position", "ethnic", "religion", "enlistmentPeriod", "politicalOrg", "politicalOrgOfficialDate", "cpvId", "educationLevel", "schoolName", "major", "isGraduated", "talent", "shortcoming", "policyBeneficiaryGroup", "fatherName", "fatherDob", "fatherPhoneNumber", "fatherJob", "motherName", "motherDob", "motherPhoneNumber", "motherJob", "isMarried", "spouseName", "spouseDob", "spouseJob", "spousePhoneNumber", "childrenInfos", "familySize", "familyBackground", "familyBirthOrder", "achievement", "disciplinaryHistory", "phone", "classId", "cpvOfficialAt", "avatar", "siblings", "contactPerson", "studentId", "relatedDocumentations", "status") SELECT "id", "createdAt", "updatedAt", "fullName", "birthPlace", "address", "dob", "rank", "previousUnit", "previousPosition", "position", "ethnic", "religion", "enlistmentPeriod", "politicalOrg", "politicalOrgOfficialDate", "cpvId", "educationLevel", "schoolName", "major", "isGraduated", "talent", "shortcoming", "policyBeneficiaryGroup", "fatherName", "fatherDob", "fatherPhoneNumber", "fatherJob", "motherName", "motherDob", "motherPhoneNumber", "motherJob", "isMarried", "spouseName", "spouseDob", "spouseJob", "spousePhoneNumber", "childrenInfos", "familySize", "familyBackground", "familyBirthOrder", "achievement", "disciplinaryHistory", "phone", "classId", "cpvOfficialAt", "avatar", "siblings", "contactPerson", "studentId", "relatedDocumentations", "status" FROM `students`;--> statement-breakpoint
+DROP TABLE `students`;--> statement-breakpoint
+ALTER TABLE `__new_students` RENAME TO `students`;--> statement-breakpoint
+CREATE TABLE `__new_units` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`alias` text NOT NULL,
+	`name` text NOT NULL,
+	`level` integer NOT NULL,
+	`parentId` integer,
+	FOREIGN KEY (`parentId`) REFERENCES `units`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_units`("id", "createdAt", "updatedAt", "alias", "name", "level", "parentId") SELECT "id", "createdAt", "updatedAt", "alias", "name", "level", "parentId" FROM `units`;--> statement-breakpoint
+DROP TABLE `units`;--> statement-breakpoint
+ALTER TABLE `__new_units` RENAME TO `units`;--> statement-breakpoint
+CREATE UNIQUE INDEX `units_alias_unique` ON `units` (`alias`);--> statement-breakpoint
+CREATE UNIQUE INDEX `units_name_unique` ON `units` (`name`);--> statement-breakpoint
+CREATE TABLE `__new_users` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`username` text NOT NULL,
+	`password` text NOT NULL,
+	`displayName` text DEFAULT '' NOT NULL,
+	`isSuperUser` integer DEFAULT false NOT NULL,
+	`unitId` integer,
+	`status` text DEFAULT 'pending',
+	`rank` text,
+	`position` text,
+	`alias` text,
+	`signature_url` text,
+	FOREIGN KEY (`unitId`) REFERENCES `units`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_users`("id", "createdAt", "updatedAt", "username", "password", "displayName", "isSuperUser", "unitId", "status", "rank", "position", "alias", "signature_url") SELECT "id", "createdAt", "updatedAt", "username", "password", "displayName", "isSuperUser", "unitId", "status", "rank", "position", "alias", "signature_url" FROM `users`;--> statement-breakpoint
+DROP TABLE `users`;--> statement-breakpoint
+ALTER TABLE `__new_users` RENAME TO `users`;--> statement-breakpoint
+CREATE UNIQUE INDEX `users_username_unique` ON `users` (`username`);

--- a/apps/api/migrations/0043_leave_management.sql
+++ b/apps/api/migrations/0043_leave_management.sql
@@ -1,0 +1,117 @@
+CREATE TABLE IF NOT EXISTS `leave_object_types` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `code` text NOT NULL UNIQUE, `name` text NOT NULL,
+	`sort_order` integer DEFAULT 0 NOT NULL, `is_active` integer DEFAULT 1 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_units` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `code` text, `name` text NOT NULL,
+	`level` text, `parent_id` integer, `is_active` integer DEFAULT 1 NOT NULL,
+	`commander_user_id` integer, `commander_name` text,
+	`management_area` text DEFAULT 'cán_bộ' NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_extra_standards` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `code` text NOT NULL UNIQUE, `label` text NOT NULL,
+	`days` integer NOT NULL, `sort_order` integer DEFAULT 0 NOT NULL, `is_active` integer DEFAULT 1 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_classes` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `unit_id` integer NOT NULL,
+	`name` text NOT NULL, `is_active` integer DEFAULT 1 NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `leave_classes_unit_name_unique` ON `leave_classes` (`unit_id`,`name`);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_personnel` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `code` text NOT NULL UNIQUE, `full_name` text NOT NULL,
+	`enlistment_date` text, `recruitment` text, `object_type` text NOT NULL, `rank` text, `position` text, `class_id` integer,
+	`unit_id` integer, `unit_name` text, `hometown` text, `permanent_residence` text, `user_id` integer,
+	`email` text, `commander_user_id` integer, `commander_name` text,
+	`class_name` text, `management_area` text DEFAULT 'cán_bộ' NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_localities` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `name` text NOT NULL, `level` text NOT NULL,
+	`parent_id` integer, `code` text
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_regulations` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `leave_type` text NOT NULL, `object_type` text,
+	`min_years` integer, `max_years` integer, `base_days` integer NOT NULL, `label` text,
+	`description` text, `is_active` integer DEFAULT 1 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_requests` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `leave_type` text NOT NULL,
+	`request_scope` text DEFAULT 'OTHER' NOT NULL, `class_id` integer, `class_name` text,
+	`status` text DEFAULT 'PENDING' NOT NULL,
+	`personnel_id` integer, `personnel_code` text, `personnel_name` text, `object_type` text NOT NULL,
+	`rank` text, `position` text, `enlistment_date` text, `unit_id` integer, `unit_name` text,
+	`service_years` integer DEFAULT 0 NOT NULL, `base_days` integer DEFAULT 0 NOT NULL,
+	`travel_days` integer DEFAULT 0 NOT NULL, `extra_days` integer DEFAULT 0 NOT NULL,
+	`extra_reasons` text DEFAULT '[]', `total_days` integer DEFAULT 0 NOT NULL, `start_date` text,
+	`end_date` text, `leave_year` text, `locality_id` integer, `locality_path` text, `note` text,
+	`proposed_by_user_id` integer, `proposed_by_username` text, `proposed_by_display_name` text,
+	`proposer_email` text, `commander_user_id` integer, `commander_name` text, `admin_note` text,
+	`decided_by_user_id` integer, `decided_by_username` text, `decided_at` text
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_mail_log` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `request_id` integer, `to_email` text NOT NULL,
+	`subject` text NOT NULL, `body` text, `mode` text, `ok` integer DEFAULT 0 NOT NULL, `error` text,
+	`preview_url` text, `kind` text
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_alerts` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `user_id` integer NOT NULL, `request_id` integer NOT NULL,
+	`kind` text NOT NULL, `title` text NOT NULL, `message` text NOT NULL, `read_at` text
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_records` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `request_id` integer NOT NULL, `status` text DEFAULT 'PENDING' NOT NULL,
+	`leave_type` text NOT NULL, `personnel_id` integer, `personnel_code` text, `personnel_name` text,
+	`object_type` text NOT NULL, `rank` text, `position` text, `enlistment_date` text, `unit_id` integer,
+	`unit_name` text, `service_years` integer DEFAULT 0 NOT NULL, `base_days` integer DEFAULT 0 NOT NULL,
+	`travel_days` integer DEFAULT 0 NOT NULL, `extra_days` integer DEFAULT 0 NOT NULL,
+	`extra_reasons` text DEFAULT '[]', `total_days` integer DEFAULT 0 NOT NULL, `start_date` text,
+	`end_date` text, `leave_year` text, `locality_id` integer, `locality_path` text, `note` text,
+	`admin_note` text, `proposed_by_user_id` integer, `proposed_by_username` text,
+	`proposed_by_display_name` text, `decided_by_user_id` integer, `decided_by_username` text,
+	`decided_at` text, `archived_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `leave_records_request_id_unique` ON `leave_records` (`request_id`);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_batches` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updated_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `request_id` integer NOT NULL, `personnel_id` integer,
+	`personnel_code` text, `personnel_name` text, `object_type` text NOT NULL, `leave_type` text NOT NULL,
+	`batch_index` integer DEFAULT 1 NOT NULL, `batch_label` text DEFAULT '' NOT NULL, `start_date` text,
+	`end_date` text, `total_days` integer DEFAULT 0 NOT NULL, `note` text, `created_by_user_id` integer
+);
+--> statement-breakpoint
+INSERT OR IGNORE INTO `leave_object_types` (`code`,`name`,`sort_order`) VALUES
+('SQ','Sĩ quan',1),('QNCN','Quân nhân chuyên nghiệp',2),('CNQP','Công nhân quốc phòng',3),
+('VCQP','Viên chức quốc phòng',4),('HSQBS','Hạ sĩ quan, binh sĩ',5),('HV','Học viên',6),('KHAC','Khác',7);
+--> statement-breakpoint
+INSERT OR IGNORE INTO `leave_extra_standards` (`code`,`label`,`days`,`sort_order`) VALUES
+('01','Đóng quân xa gia đình',5,1),('02','Gia đình ở vùng đặc biệt khó khăn',5,2),
+('03','Có cha mẹ già yếu',5,3),('04','Vợ hoặc chồng công tác xa',5,4),
+('05','Có con nhỏ dưới 12 tháng',5,5),('06','Trường hợp đặc biệt khác',5,6);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_positions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `name` text NOT NULL UNIQUE,
+	`sort_order` integer DEFAULT 0 NOT NULL, `is_active` integer DEFAULT 1 NOT NULL
+);

--- a/apps/api/migrations/0044_restore_leave_structure.sql
+++ b/apps/api/migrations/0044_restore_leave_structure.sql
@@ -1,0 +1,30 @@
+ALTER TABLE `leave_units` ADD `level` text;
+--> statement-breakpoint
+ALTER TABLE `leave_units` ADD `commander_user_id` integer;
+--> statement-breakpoint
+ALTER TABLE `leave_units` ADD `commander_name` text;
+--> statement-breakpoint
+ALTER TABLE `leave_units` ADD `management_area` text DEFAULT 'cán_bộ' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `leave_personnel` ADD `class_name` text;
+--> statement-breakpoint
+ALTER TABLE `leave_personnel` ADD `management_area` text DEFAULT 'cán_bộ' NOT NULL;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_classes` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`unit_id` integer NOT NULL,
+	`name` text NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `leave_classes_unit_name_unique` ON `leave_classes` (`unit_id`, `name`);
+--> statement-breakpoint
+ALTER TABLE `leave_personnel` ADD `class_id` integer;
+--> statement-breakpoint
+ALTER TABLE `leave_requests` ADD `request_scope` text DEFAULT 'OTHER' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `leave_requests` ADD `class_id` integer;
+--> statement-breakpoint
+ALTER TABLE `leave_requests` ADD `class_name` text;

--- a/apps/api/migrations/0045_leave_user_account_fields.sql
+++ b/apps/api/migrations/0045_leave_user_account_fields.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `users` ADD `leave_unit_id` integer;
+--> statement-breakpoint
+ALTER TABLE `users` ADD `management_area` text;

--- a/apps/api/migrations/0046_restore_roles_and_leave_roles.sql
+++ b/apps/api/migrations/0046_restore_roles_and_leave_roles.sql
@@ -1,0 +1,75 @@
+-- Khôi phục danh mục RBAC nếu database cũ đã có schema nhưng thiếu dữ liệu seed.
+INSERT OR IGNORE INTO actions (name, display_name, description) VALUES
+('create', 'Tạo', 'Tạo dữ liệu'),
+('read', 'Xem', 'Xem dữ liệu'),
+('update', 'Cập nhật', 'Cập nhật dữ liệu'),
+('delete', 'Xóa', 'Xóa dữ liệu');
+--> statement-breakpoint
+
+INSERT OR IGNORE INTO resources (name, display_name, description) VALUES
+('actions', 'Hành vi', 'Quản lý hành vi'),
+('resources', 'Tài nguyên', 'Quản lý tài nguyên'),
+('users', 'Người dùng', 'Quản lý người dùng'),
+('permissions', 'Quyền', 'Quản lý quyền'),
+('roles', 'Vai trò', 'Quản lý vai trò'),
+('classes', 'Lớp', 'Quản lý lớp'),
+('students', 'Học viên', 'Quản lý học viên'),
+('units', 'Đơn vị', 'Quản lý đơn vị'),
+('leave_management', 'Quản lý phép', 'Phân hệ quản lý nghỉ phép');
+--> statement-breakpoint
+
+INSERT OR IGNORE INTO roles (name, description) VALUES
+('super_admin', 'Siêu quản trị viên — toàn quyền hệ thống'),
+('admin', 'Quản trị viên — toàn quyền quản lý'),
+('battalion_commander', 'Chỉ huy tiểu đoàn'),
+('company_commander', 'Chỉ huy đại đội'),
+('viewer', 'Người xem'),
+('user_don_vi', 'Người dùng đơn vị'),
+('user_nganh', 'Người dùng ngành'),
+('exam_lecturer', 'Giảng viên soạn đề thi'),
+('exam_dept_head', 'Chủ nhiệm khoa duyệt đề thi'),
+('exam_office', 'Ban Khảo thí'),
+('leave_admin', 'Quản trị phép — toàn quyền phân hệ phép'),
+('leave_commander', 'Chỉ huy cơ quan — quản lý, đề xuất và duyệt phép trong đơn vị'),
+('leave_agency', 'Cơ quan quản lý — quản lý và duyệt phép, không được đề xuất');
+--> statement-breakpoint
+
+INSERT OR IGNORE INTO permissions
+	(resource_id, action_id, name, display_name, description)
+SELECT
+	r.id,
+	a.id,
+	r.name || ':' || a.name,
+	a.display_name || ' - ' || r.display_name,
+	a.display_name || ' ' || r.display_name
+FROM resources r
+CROSS JOIN actions a;
+--> statement-breakpoint
+
+INSERT OR IGNORE INTO role_permissions (role_id, permission_id)
+SELECT roles.id, permissions.id
+FROM roles CROSS JOIN permissions
+WHERE roles.name IN ('super_admin', 'admin', 'leave_admin');
+--> statement-breakpoint
+
+INSERT OR IGNORE INTO role_permissions (role_id, permission_id)
+SELECT roles.id, permissions.id
+FROM roles
+CROSS JOIN permissions
+WHERE roles.name = 'leave_commander'
+	AND permissions.name IN (
+		'leave_management:create',
+		'leave_management:read',
+		'leave_management:update'
+	);
+--> statement-breakpoint
+
+INSERT OR IGNORE INTO role_permissions (role_id, permission_id)
+SELECT roles.id, permissions.id
+FROM roles
+CROSS JOIN permissions
+WHERE roles.name = 'leave_agency'
+	AND permissions.name IN (
+		'leave_management:read',
+		'leave_management:update'
+	);

--- a/apps/api/migrations/0047_add_leave_personnel_role.sql
+++ b/apps/api/migrations/0047_add_leave_personnel_role.sql
@@ -1,0 +1,16 @@
+INSERT OR IGNORE INTO roles (name, description)
+VALUES (
+	'leave_personnel',
+	'Quân nhân — tự đề xuất nghỉ phép và xem quy định phép'
+);
+--> statement-breakpoint
+
+INSERT OR IGNORE INTO role_permissions (role_id, permission_id)
+SELECT roles.id, permissions.id
+FROM roles
+CROSS JOIN permissions
+WHERE roles.name = 'leave_personnel'
+	AND permissions.name IN (
+		'leave_management:create',
+		'leave_management:read'
+	);

--- a/apps/api/migrations/0048_leave_audit_logs.sql
+++ b/apps/api/migrations/0048_leave_audit_logs.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS `leave_audit_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`user_id` integer,
+	`action` text NOT NULL,
+	`entity_type` text NOT NULL,
+	`entity_id` integer,
+	`details` text
+);

--- a/apps/api/migrations/0049_backfill_approved_leave_data.sql
+++ b/apps/api/migrations/0049_backfill_approved_leave_data.sql
@@ -1,0 +1,19 @@
+UPDATE `leave_records`
+SET `leave_year` = substr(`start_date`, 1, 4)
+WHERE (`leave_year` IS NULL OR `leave_year` = '')
+  AND `start_date` IS NOT NULL;
+--> statement-breakpoint
+INSERT INTO `leave_batches` (
+	`request_id`, `personnel_id`, `personnel_code`, `personnel_name`,
+	`object_type`, `leave_type`, `batch_index`, `batch_label`,
+	`start_date`, `end_date`, `total_days`, `note`, `created_by_user_id`
+)
+SELECT
+	r.`id`, r.`personnel_id`, r.`personnel_code`,
+	CASE WHEN r.`request_scope` = 'CLASS' THEN COALESCE(r.`class_name`, r.`personnel_name`) ELSE r.`personnel_name` END,
+	r.`object_type`, r.`leave_type`, 1,
+	CASE WHEN r.`request_scope` = 'CLASS' THEN 'Đợt nghỉ ' || COALESCE(r.`class_name`, 'lớp') ELSE 'Đợt nghỉ theo đơn đã duyệt' END,
+	r.`start_date`, r.`end_date`, r.`total_days`, r.`note`, r.`decided_by_user_id`
+FROM `leave_requests` r
+WHERE r.`status` = 'APPROVED'
+  AND NOT EXISTS (SELECT 1 FROM `leave_batches` b WHERE b.`request_id` = r.`id`);

--- a/apps/api/migrations/0050_restore_leave_regulations.sql
+++ b/apps/api/migrations/0050_restore_leave_regulations.sql
@@ -1,0 +1,30 @@
+-- Tiêu chuẩn phép hằng năm mặc định.
+-- SQ/QNCN/CNQP/VCQP: dưới 15 năm = 20 ngày; 15-<25 = 25; từ 25 = 30.
+INSERT INTO `leave_regulations` (`leave_type`,`object_type`,`min_years`,`max_years`,`base_days`,`label`,`description`,`is_active`)
+SELECT 'ANNUAL', v.object_type, v.min_years, v.max_years, v.base_days, v.label, v.description, 1
+FROM (
+	SELECT 'SQ' object_type, 0 min_years, 15 max_years, 20 base_days, 'Sỹ quan dưới 15 năm công tác' label, 'Tiêu chuẩn phép hằng năm' description UNION ALL
+	SELECT 'SQ', 15, 25, 25, 'Sỹ quan từ 15 đến dưới 25 năm', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'SQ', 25, NULL, 30, 'Sỹ quan từ 25 năm trở lên', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'QNCN', 0, 15, 20, 'QNCN dưới 15 năm công tác', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'QNCN', 15, 25, 25, 'QNCN từ 15 đến dưới 25 năm', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'QNCN', 25, NULL, 30, 'QNCN từ 25 năm trở lên', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'CNQP', 0, 15, 20, 'Công nhân QP dưới 15 năm công tác', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'CNQP', 15, 25, 25, 'Công nhân QP từ 15 đến dưới 25 năm', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'CNQP', 25, NULL, 30, 'Công nhân QP từ 25 năm trở lên', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'VCQP', 0, 15, 20, 'Viên chức QP dưới 15 năm công tác', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'VCQP', 15, 25, 25, 'Viên chức QP từ 15 đến dưới 25 năm', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'VCQP', 25, NULL, 30, 'Viên chức QP từ 25 năm trở lên', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'HSQBS', 0, NULL, 10, 'Hạ sỹ quan, binh sỹ', 'Tiêu chuẩn 10 ngày phép hằng năm'
+) v
+WHERE NOT EXISTS (
+	SELECT 1 FROM `leave_regulations` r
+	WHERE r.`leave_type` = 'ANNUAL' AND r.`object_type` = v.object_type
+	  AND COALESCE(r.`min_years`, -1) = COALESCE(v.min_years, -1)
+	  AND COALESCE(r.`max_years`, -1) = COALESCE(v.max_years, -1)
+);
+--> statement-breakpoint
+-- MS 01–03 thuộc nhóm nghỉ thêm 10 ngày; MS 04–06 thuộc nhóm 5 ngày.
+UPDATE `leave_extra_standards` SET `days` = 10 WHERE `code` IN ('01','02','03');
+--> statement-breakpoint
+UPDATE `leave_extra_standards` SET `days` = 5 WHERE `code` IN ('04','05','06');

--- a/apps/api/migrations/0051_seed_leave_objects_and_extra_standards.sql
+++ b/apps/api/migrations/0051_seed_leave_objects_and_extra_standards.sql
@@ -1,0 +1,34 @@
+INSERT INTO `leave_object_types` (`code`,`name`,`sort_order`,`is_active`)
+SELECT v.code, v.name, v.sort_order, 1 FROM (
+	SELECT 'SQ' code, 'Sĩ quan' name, 1 sort_order UNION ALL
+	SELECT 'QNCN', 'Quân nhân chuyên nghiệp', 2 UNION ALL
+	SELECT 'CNQP', 'Công nhân quốc phòng', 3 UNION ALL
+	SELECT 'VCQP', 'Viên chức quốc phòng', 4 UNION ALL
+	SELECT 'HSQBS', 'Hạ sĩ quan, binh sĩ', 5 UNION ALL
+	SELECT 'HV', 'Học viên', 6 UNION ALL
+	SELECT 'KHAC', 'Đối tượng khác', 7
+) v
+WHERE NOT EXISTS (SELECT 1 FROM `leave_object_types` o WHERE o.`code` = v.code);
+--> statement-breakpoint
+INSERT INTO `leave_extra_standards` (`code`,`label`,`days`,`sort_order`,`is_active`)
+SELECT v.code, v.label, v.days, v.sort_order, 1 FROM (
+	SELECT '01' code, 'Đóng quân ở đơn vị xa nơi đăng ký nghỉ phép từ 500 km trở lên' label, 10 days, 1 sort_order UNION ALL
+	SELECT '02', 'Đóng quân ở địa bàn đặc biệt khó khăn, vùng sâu, vùng xa, biên giới cách nơi đăng ký nghỉ phép từ 300 km trở lên', 10, 2 UNION ALL
+	SELECT '03', 'Đóng quân tại các đảo thuộc quần đảo Trường Sa và Nhà giàn DK', 10, 3 UNION ALL
+	SELECT '04', 'Đơn vị đóng quân cách nơi đăng ký nghỉ phép từ 300 km đến dưới 500 km', 5, 4 UNION ALL
+	SELECT '05', 'Đóng quân ở vùng sâu, vùng xa, biên giới cách nơi đăng ký nghỉ phép từ 200 km đến dưới 300 km', 5, 5 UNION ALL
+	SELECT '06', 'Đóng quân tại các đảo được hưởng phụ cấp khu vực', 5, 6
+) v
+WHERE NOT EXISTS (SELECT 1 FROM `leave_extra_standards` e WHERE e.`code` = v.code);
+--> statement-breakpoint
+UPDATE `leave_extra_standards` SET `label` = 'Đóng quân ở đơn vị xa nơi đăng ký nghỉ phép từ 500 km trở lên', `days` = 10, `sort_order` = 1, `is_active` = 1 WHERE `code` = '01';
+--> statement-breakpoint
+UPDATE `leave_extra_standards` SET `label` = 'Đóng quân ở địa bàn đặc biệt khó khăn, vùng sâu, vùng xa, biên giới cách nơi đăng ký nghỉ phép từ 300 km trở lên', `days` = 10, `sort_order` = 2, `is_active` = 1 WHERE `code` = '02';
+--> statement-breakpoint
+UPDATE `leave_extra_standards` SET `label` = 'Đóng quân tại các đảo thuộc quần đảo Trường Sa và Nhà giàn DK', `days` = 10, `sort_order` = 3, `is_active` = 1 WHERE `code` = '03';
+--> statement-breakpoint
+UPDATE `leave_extra_standards` SET `label` = 'Đơn vị đóng quân cách nơi đăng ký nghỉ phép từ 300 km đến dưới 500 km', `days` = 5, `sort_order` = 4, `is_active` = 1 WHERE `code` = '04';
+--> statement-breakpoint
+UPDATE `leave_extra_standards` SET `label` = 'Đóng quân ở vùng sâu, vùng xa, biên giới cách nơi đăng ký nghỉ phép từ 200 km đến dưới 300 km', `days` = 5, `sort_order` = 5, `is_active` = 1 WHERE `code` = '05';
+--> statement-breakpoint
+UPDATE `leave_extra_standards` SET `label` = 'Đóng quân tại các đảo được hưởng phụ cấp khu vực', `days` = 5, `sort_order` = 6, `is_active` = 1 WHERE `code` = '06';

--- a/apps/api/migrations/meta/0042_snapshot.json
+++ b/apps/api/migrations/meta/0042_snapshot.json
@@ -1,0 +1,5848 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "486386d6-5317-4c8e-a7fe-01df6b7b7355",
+	"prevId": "a5c20505-8e51-4f27-9505-000000000005",
+	"tables": {
+		"account_audit_logs": {
+			"name": "account_audit_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_is_admin": {
+					"name": "actor_is_admin",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_code": {
+					"name": "room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_name": {
+					"name": "room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"floor_name": {
+					"name": "floor_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_code": {
+					"name": "building_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_name": {
+					"name": "building_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"account_label": {
+					"name": "account_label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"details": {
+					"name": "details",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"actions": {
+			"name": "actions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"actions_name_unique": {
+					"name": "actions_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_broken_logs": {
+			"name": "asset_broken_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_type": {
+					"name": "source_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'OTHER'"
+				},
+				"source_id": {
+					"name": "source_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_request_id": {
+					"name": "repair_request_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source_asset_id": {
+					"name": "source_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_code": {
+					"name": "asset_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"original_code": {
+					"name": "original_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_name": {
+					"name": "asset_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"original_grade": {
+					"name": "original_grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"grade_after": {
+					"name": "grade_after",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status_after": {
+					"name": "status_after",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_code": {
+					"name": "room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_name": {
+					"name": "room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"floor_name": {
+					"name": "floor_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_code": {
+					"name": "building_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_name": {
+					"name": "building_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_name": {
+					"name": "unit_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"result_note": {
+					"name": "result_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"performer": {
+					"name": "performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"event_at": {
+					"name": "event_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_movement_logs": {
+			"name": "asset_movement_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"movement_type": {
+					"name": "movement_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"executed_at": {
+					"name": "executed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"executing_unit": {
+					"name": "executing_unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"install_address": {
+					"name": "install_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_code": {
+					"name": "asset_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_name": {
+					"name": "asset_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"quantity_before": {
+					"name": "quantity_before",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"quantity_after": {
+					"name": "quantity_after",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"grade": {
+					"name": "grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"manufacture_year": {
+					"name": "manufacture_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"usage_year": {
+					"name": "usage_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reason_code": {
+					"name": "reason_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reason_other": {
+					"name": "reason_other",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_date": {
+					"name": "decision_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_number": {
+					"name": "decision_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"signer": {
+					"name": "signer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"performer": {
+					"name": "performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"explanation": {
+					"name": "explanation",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_code": {
+					"name": "building_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_name": {
+					"name": "building_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_code": {
+					"name": "room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_name": {
+					"name": "room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"floor_name": {
+					"name": "floor_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"asset_movement_logs_room_asset_id_room_assets_id_fk": {
+					"name": "asset_movement_logs_room_asset_id_room_assets_id_fk",
+					"tableFrom": "asset_movement_logs",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_proposal_items": {
+			"name": "asset_proposal_items",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"material_id": {
+					"name": "material_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"material_code": {
+					"name": "material_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"material_name": {
+					"name": "material_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source_asset_id": {
+					"name": "source_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"original_grade": {
+					"name": "original_grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"original_code": {
+					"name": "original_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"unit": {
+					"name": "unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"chuyen_nganh_code": {
+					"name": "chuyen_nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"from_room_id": {
+					"name": "from_room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"from_room_code": {
+					"name": "from_room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"from_room_name": {
+					"name": "from_room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"location_note": {
+					"name": "location_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"target_room_id": {
+					"name": "target_room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"target_room_code": {
+					"name": "target_room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"target_room_name": {
+					"name": "target_room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_proposal_logs": {
+			"name": "asset_proposal_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"proposal_type": {
+					"name": "proposal_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"details": {
+					"name": "details",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_is_admin": {
+					"name": "actor_is_admin",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_proposals": {
+			"name": "asset_proposals",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"proposal_type": {
+					"name": "proposal_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'PENDING'"
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_id": {
+					"name": "unit_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_name": {
+					"name": "unit_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_user_id": {
+					"name": "proposed_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_username": {
+					"name": "proposed_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_display_name": {
+					"name": "proposed_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"admin_note": {
+					"name": "admin_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_number": {
+					"name": "decision_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_nganh_code": {
+					"name": "decision_nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_issuing_level": {
+					"name": "decision_issuing_level",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_signer": {
+					"name": "decision_signer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_at": {
+					"name": "decision_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_user_id": {
+					"name": "decided_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_username": {
+					"name": "decided_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_display_name": {
+					"name": "decided_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"buildings": {
+			"name": "buildings",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"manager_code": {
+					"name": "manager_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"area": {
+					"name": "area",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"buildings_code_unique": {
+					"name": "buildings_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"catalog_audit_logs": {
+			"name": "catalog_audit_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"entity_type": {
+					"name": "entity_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_is_admin": {
+					"name": "actor_is_admin",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"entity_id": {
+					"name": "entity_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"entity_code": {
+					"name": "entity_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"entity_name": {
+					"name": "entity_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"parent_code": {
+					"name": "parent_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"parent_name": {
+					"name": "parent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"details": {
+					"name": "details",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"catalog_stock_logs": {
+			"name": "catalog_stock_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"movement_type": {
+					"name": "movement_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"executed_at": {
+					"name": "executed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"material_id": {
+					"name": "material_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"material_code": {
+					"name": "material_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"material_name": {
+					"name": "material_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"chuyen_nganh_code": {
+					"name": "chuyen_nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"chuyen_nganh_name": {
+					"name": "chuyen_nganh_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"quantity_before": {
+					"name": "quantity_before",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"quantity_after": {
+					"name": "quantity_after",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"unit": {
+					"name": "unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_new_material": {
+					"name": "is_new_material",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_is_admin": {
+					"name": "actor_is_admin",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"categories": {
+			"name": "categories",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"categories_code_unique": {
+					"name": "categories_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"classes": {
+			"name": "classes",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"graduatedAt": {
+					"name": "graduatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'ongoing'"
+				},
+				"unitId": {
+					"name": "unitId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"class_unit_unique_constraint": {
+					"name": "class_unit_unique_constraint",
+					"columns": ["name", "unitId"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"classes_unitId_units_id_fk": {
+					"name": "classes_unitId_units_id_fk",
+					"tableFrom": "classes",
+					"tableTo": "units",
+					"columnsFrom": ["unitId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_classes": {
+			"name": "exam_classes",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"faculty_id": {
+					"name": "faculty_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"cohort": {
+					"name": "cohort",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_classes_code_unique": {
+					"name": "exam_classes_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_draw_logs": {
+			"name": "exam_draw_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"draw_id": {
+					"name": "draw_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"details": {
+					"name": "details",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_draws": {
+			"name": "exam_draws",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"draw_code": {
+					"name": "draw_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"exam_id": {
+					"name": "exam_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"exam_code": {
+					"name": "exam_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"paper_number": {
+					"name": "paper_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"subject_id": {
+					"name": "subject_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"draw_type": {
+					"name": "draw_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_name": {
+					"name": "class_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"drawn_by_user_id": {
+					"name": "drawn_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"drawn_by_username": {
+					"name": "drawn_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"drawn_by_display_name": {
+					"name": "drawn_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"drawn_at": {
+					"name": "drawn_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"printed_at": {
+					"name": "printed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"printed_by_user_id": {
+					"name": "printed_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"printed_by_username": {
+					"name": "printed_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"print_blocked": {
+					"name": "print_blocked",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"print_blocked_at": {
+					"name": "print_blocked_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"print_blocked_reason": {
+					"name": "print_blocked_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"exam_date": {
+					"name": "exam_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"exam_time": {
+					"name": "exam_time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"location": {
+					"name": "location",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_draws_draw_code_unique": {
+					"name": "exam_draws_draw_code_unique",
+					"columns": ["draw_code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_faculties": {
+			"name": "exam_faculties",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_faculties_major_code_uq": {
+					"name": "exam_faculties_major_code_uq",
+					"columns": ["major_id", "code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_faculty_heads": {
+			"name": "exam_faculty_heads",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"faculty_code": {
+					"name": "faculty_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"faculty_name": {
+					"name": "faculty_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_faculty_heads_user_fac_uq": {
+					"name": "exam_faculty_heads_user_fac_uq",
+					"columns": ["user_id", "faculty_code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_major_heads": {
+			"name": "exam_major_heads",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_majors": {
+			"name": "exam_majors",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"system_id": {
+					"name": "system_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"level_code": {
+					"name": "level_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"short_code": {
+					"name": "short_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_majors_code_unique": {
+					"name": "exam_majors_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_questions": {
+			"name": "exam_questions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"exam_id": {
+					"name": "exam_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"question_number": {
+					"name": "question_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"answer": {
+					"name": "answer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"points": {
+					"name": "points",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_subjects": {
+			"name": "exam_subjects",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"base_code": {
+					"name": "base_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"credit_hours": {
+					"name": "credit_hours",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 0
+				},
+				"lesson_hours": {
+					"name": "lesson_hours",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 0
+				},
+				"faculty_id": {
+					"name": "faculty_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_subjects_code_unique": {
+					"name": "exam_subjects_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_systems": {
+			"name": "exam_systems",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"letter": {
+					"name": "letter",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_systems_code_unique": {
+					"name": "exam_systems_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				},
+				"exam_systems_letter_unique": {
+					"name": "exam_systems_letter_unique",
+					"columns": ["letter"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_teachers": {
+			"name": "exam_teachers",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"faculty_code": {
+					"name": "faculty_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"faculty_name": {
+					"name": "faculty_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_user_id": {
+					"name": "created_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_username": {
+					"name": "created_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_display_name": {
+					"name": "created_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_teachers_user_uq": {
+					"name": "exam_teachers_user_uq",
+					"columns": ["user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_teaching_assignment_logs": {
+			"name": "exam_teaching_assignment_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"subject_id": {
+					"name": "subject_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"subject_code": {
+					"name": "subject_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"subject_name": {
+					"name": "subject_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"major_code": {
+					"name": "major_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"faculty_id": {
+					"name": "faculty_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"faculty_code": {
+					"name": "faculty_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_code": {
+					"name": "class_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_name": {
+					"name": "class_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teacher_user_id": {
+					"name": "teacher_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teacher_username": {
+					"name": "teacher_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teacher_display_name": {
+					"name": "teacher_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_teaching_assignments": {
+			"name": "exam_teaching_assignments",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"subject_id": {
+					"name": "subject_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teaching_start": {
+					"name": "teaching_start",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teaching_end": {
+					"name": "teaching_end",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_by_user_id": {
+					"name": "assigned_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_by_username": {
+					"name": "assigned_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_by_display_name": {
+					"name": "assigned_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_workflow_logs": {
+			"name": "exam_workflow_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"exam_id": {
+					"name": "exam_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"from_status": {
+					"name": "from_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"to_status": {
+					"name": "to_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exams": {
+			"name": "exams",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"subject_id": {
+					"name": "subject_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"paper_number": {
+					"name": "paper_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'DRAFT'"
+				},
+				"created_by_user_id": {
+					"name": "created_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_username": {
+					"name": "created_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_display_name": {
+					"name": "created_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_user_id": {
+					"name": "approved_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_username": {
+					"name": "approved_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_display_name": {
+					"name": "approved_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_at": {
+					"name": "approved_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_rank": {
+					"name": "approved_by_rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_position": {
+					"name": "approved_by_position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_signature_url": {
+					"name": "approved_by_signature_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_title": {
+					"name": "approved_by_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_user_id": {
+					"name": "dept_head_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_username": {
+					"name": "dept_head_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_display_name": {
+					"name": "dept_head_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_rank": {
+					"name": "dept_head_rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_signature_url": {
+					"name": "dept_head_signature_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_approved_at": {
+					"name": "dept_head_approved_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"qr_code": {
+					"name": "qr_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"locked": {
+					"name": "locked",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_name": {
+					"name": "class_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration_minutes": {
+					"name": "duration_minutes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 60
+				},
+				"question_file_url": {
+					"name": "question_file_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"question_file_name": {
+					"name": "question_file_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"answer_file_url": {
+					"name": "answer_file_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"answer_file_name": {
+					"name": "answer_file_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"return_note": {
+					"name": "return_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exams_code_unique": {
+					"name": "exams_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"floors": {
+			"name": "floors",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"building_id": {
+					"name": "building_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"floor_number": {
+					"name": "floor_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"floors_building_id_buildings_id_fk": {
+					"name": "floors_building_id_buildings_id_fk",
+					"tableFrom": "floors",
+					"tableTo": "buildings",
+					"columnsFrom": ["building_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"resources": {
+			"name": "resources",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"resources_name_unique": {
+					"name": "resources_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"permissions": {
+			"name": "permissions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"resource_id": {
+					"name": "resource_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"action_id": {
+					"name": "action_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"permissions_name_unique": {
+					"name": "permissions_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"permissions_resource_id_resources_id_fk": {
+					"name": "permissions_resource_id_resources_id_fk",
+					"tableFrom": "permissions",
+					"tableTo": "resources",
+					"columnsFrom": ["resource_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"permissions_action_id_actions_id_fk": {
+					"name": "permissions_action_id_actions_id_fk",
+					"tableFrom": "permissions",
+					"tableTo": "actions",
+					"columnsFrom": ["action_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"roles": {
+			"name": "roles",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"roles_name_unique": {
+					"name": "roles_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"role_permissions": {
+			"name": "role_permissions",
+			"columns": {
+				"role_id": {
+					"name": "role_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"permission_id": {
+					"name": "permission_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"role_permissions_role_id_roles_id_fk": {
+					"name": "role_permissions_role_id_roles_id_fk",
+					"tableFrom": "role_permissions",
+					"tableTo": "roles",
+					"columnsFrom": ["role_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"role_permissions_permission_id_permissions_id_fk": {
+					"name": "role_permissions_permission_id_permissions_id_fk",
+					"tableFrom": "role_permissions",
+					"tableTo": "permissions",
+					"columnsFrom": ["permission_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"role_permissions_role_id_permission_id_pk": {
+					"columns": ["role_id", "permission_id"],
+					"name": "role_permissions_role_id_permission_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_roles": {
+			"name": "user_roles",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role_id": {
+					"name": "role_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_roles_user_id_users_id_fk": {
+					"name": "user_roles_user_id_users_id_fk",
+					"tableFrom": "user_roles",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"user_roles_role_id_roles_id_fk": {
+					"name": "user_roles_role_id_roles_id_fk",
+					"tableFrom": "user_roles",
+					"tableTo": "roles",
+					"columnsFrom": ["role_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_roles_user_id_role_id_pk": {
+					"columns": ["user_id", "role_id"],
+					"name": "user_roles_user_id_role_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"displayName": {
+					"name": "displayName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"isSuperUser": {
+					"name": "isSuperUser",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"unitId": {
+					"name": "unitId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"rank": {
+					"name": "rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"position": {
+					"name": "position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"alias": {
+					"name": "alias",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"signature_url": {
+					"name": "signature_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"users_username_unique": {
+					"name": "users_username_unique",
+					"columns": ["username"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"users_unitId_units_id_fk": {
+					"name": "users_unitId_units_id_fk",
+					"tableFrom": "users",
+					"tableTo": "units",
+					"columnsFrom": ["unitId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"units": {
+			"name": "units",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"alias": {
+					"name": "alias",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"level": {
+					"name": "level",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parentId": {
+					"name": "parentId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"units_alias_unique": {
+					"name": "units_alias_unique",
+					"columns": ["alias"],
+					"isUnique": true
+				},
+				"units_name_unique": {
+					"name": "units_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"parent_id_fk": {
+					"name": "parent_id_fk",
+					"tableFrom": "units",
+					"tableTo": "units",
+					"columnsFrom": ["parentId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"students": {
+			"name": "students",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"fullName": {
+					"name": "fullName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"birthPlace": {
+					"name": "birthPlace",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"dob": {
+					"name": "dob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"rank": {
+					"name": "rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"previousUnit": {
+					"name": "previousUnit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"previousPosition": {
+					"name": "previousPosition",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"position": {
+					"name": "position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Học viên'"
+				},
+				"ethnic": {
+					"name": "ethnic",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"religion": {
+					"name": "religion",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"enlistmentPeriod": {
+					"name": "enlistmentPeriod",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"politicalOrg": {
+					"name": "politicalOrg",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"politicalOrgOfficialDate": {
+					"name": "politicalOrgOfficialDate",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"cpvId": {
+					"name": "cpvId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"educationLevel": {
+					"name": "educationLevel",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"schoolName": {
+					"name": "schoolName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"major": {
+					"name": "major",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"isGraduated": {
+					"name": "isGraduated",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": false
+				},
+				"talent": {
+					"name": "talent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"shortcoming": {
+					"name": "shortcoming",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"policyBeneficiaryGroup": {
+					"name": "policyBeneficiaryGroup",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"fatherName": {
+					"name": "fatherName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"fatherDob": {
+					"name": "fatherDob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"fatherPhoneNumber": {
+					"name": "fatherPhoneNumber",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"fatherJob": {
+					"name": "fatherJob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"motherName": {
+					"name": "motherName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"motherDob": {
+					"name": "motherDob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"motherPhoneNumber": {
+					"name": "motherPhoneNumber",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"motherJob": {
+					"name": "motherJob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"isMarried": {
+					"name": "isMarried",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": false
+				},
+				"spouseName": {
+					"name": "spouseName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"spouseDob": {
+					"name": "spouseDob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"spouseJob": {
+					"name": "spouseJob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"spousePhoneNumber": {
+					"name": "spousePhoneNumber",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"childrenInfos": {
+					"name": "childrenInfos",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"familySize": {
+					"name": "familySize",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"familyBackground": {
+					"name": "familyBackground",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"familyBirthOrder": {
+					"name": "familyBirthOrder",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"achievement": {
+					"name": "achievement",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"disciplinaryHistory": {
+					"name": "disciplinaryHistory",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"phone": {
+					"name": "phone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"classId": {
+					"name": "classId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cpvOfficialAt": {
+					"name": "cpvOfficialAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"avatar": {
+					"name": "avatar",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"siblings": {
+					"name": "siblings",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"contactPerson": {
+					"name": "contactPerson",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'{}'"
+				},
+				"studentId": {
+					"name": "studentId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"relatedDocumentations": {
+					"name": "relatedDocumentations",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"students_classId_classes_id_fk": {
+					"name": "students_classId_classes_id_fk",
+					"tableFrom": "students",
+					"tableTo": "classes",
+					"columnsFrom": ["classId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"rooms": {
+			"name": "rooms",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"floor_id": {
+					"name": "floor_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_code": {
+					"name": "room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_name": {
+					"name": "room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_type": {
+					"name": "room_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"manager": {
+					"name": "manager",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"manager_code": {
+					"name": "manager_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"account_password": {
+					"name": "account_password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"capacity": {
+					"name": "capacity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'ACTIVE'"
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"rooms_room_code_unique": {
+					"name": "rooms_room_code_unique",
+					"columns": ["room_code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"rooms_floor_id_floors_id_fk": {
+					"name": "rooms_floor_id_floors_id_fk",
+					"tableFrom": "rooms",
+					"tableTo": "floors",
+					"columnsFrom": ["floor_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"rooms_class_id_classes_id_fk": {
+					"name": "rooms_class_id_classes_id_fk",
+					"tableFrom": "rooms",
+					"tableTo": "classes",
+					"columnsFrom": ["class_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"room_images": {
+			"name": "room_images",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"image_url": {
+					"name": "image_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"room_images_room_id_rooms_id_fk": {
+					"name": "room_images_room_id_rooms_id_fk",
+					"tableFrom": "room_images",
+					"tableTo": "rooms",
+					"columnsFrom": ["room_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"room_assets": {
+			"name": "room_assets",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"broken_quantity": {
+					"name": "broken_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"unit": {
+					"name": "unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"holding_unit_id": {
+					"name": "holding_unit_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"grade": {
+					"name": "grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"manufacture_year": {
+					"name": "manufacture_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"usage_year": {
+					"name": "usage_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"install_address": {
+					"name": "install_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'NORMAL'"
+				},
+				"purchase_date": {
+					"name": "purchase_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expiry_date": {
+					"name": "expiry_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"broken_at": {
+					"name": "broken_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_started_at": {
+					"name": "repair_started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_completed_at": {
+					"name": "repair_completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_performer": {
+					"name": "repair_performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"room_assets_code_unique": {
+					"name": "room_assets_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"room_assets_room_id_rooms_id_fk": {
+					"name": "room_assets_room_id_rooms_id_fk",
+					"tableFrom": "room_assets",
+					"tableTo": "rooms",
+					"columnsFrom": ["room_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"room_assets_holding_unit_id_units_id_fk": {
+					"name": "room_assets_holding_unit_id_units_id_fk",
+					"tableFrom": "room_assets",
+					"tableTo": "units",
+					"columnsFrom": ["holding_unit_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"repair_logs": {
+			"name": "repair_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"repair_date": {
+					"name": "repair_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cost": {
+					"name": "cost",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"performer": {
+					"name": "performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"repair_logs_room_asset_id_room_assets_id_fk": {
+					"name": "repair_logs_room_asset_id_room_assets_id_fk",
+					"tableFrom": "repair_logs",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"inventory_logs": {
+			"name": "inventory_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"inventory_date": {
+					"name": "inventory_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actual_quantity": {
+					"name": "actual_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"expected_quantity": {
+					"name": "expected_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"result": {
+					"name": "result",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"inventory_logs_room_asset_id_room_assets_id_fk": {
+					"name": "inventory_logs_room_asset_id_room_assets_id_fk",
+					"tableFrom": "inventory_logs",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"replacement_logs": {
+			"name": "replacement_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"replacement_date": {
+					"name": "replacement_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"old_asset": {
+					"name": "old_asset",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"new_asset": {
+					"name": "new_asset",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"performer": {
+					"name": "performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"replacement_logs_room_asset_id_room_assets_id_fk": {
+					"name": "replacement_logs_room_asset_id_room_assets_id_fk",
+					"tableFrom": "replacement_logs",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_nganh": {
+			"name": "user_nganh",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_nganh_user_nganh_uq": {
+					"name": "user_nganh_user_nganh_uq",
+					"columns": ["user_id", "nganh_code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"user_nganh_user_id_users_id_fk": {
+					"name": "user_nganh_user_id_users_id_fk",
+					"tableFrom": "user_nganh",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"repair_requests": {
+			"name": "repair_requests",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source_asset_id": {
+					"name": "source_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"original_grade": {
+					"name": "original_grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_name": {
+					"name": "asset_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'PENDING'"
+				},
+				"broken_at": {
+					"name": "broken_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reported_by_name": {
+					"name": "reported_by_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reported_by_user_id": {
+					"name": "reported_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_to_name": {
+					"name": "assigned_to_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_at": {
+					"name": "assigned_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_by_name": {
+					"name": "assigned_by_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_started_at": {
+					"name": "repair_started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"admin_note": {
+					"name": "admin_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"repair_requests_room_id_rooms_id_fk": {
+					"name": "repair_requests_room_id_rooms_id_fk",
+					"tableFrom": "repair_requests",
+					"tableTo": "rooms",
+					"columnsFrom": ["room_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"repair_requests_room_asset_id_room_assets_id_fk": {
+					"name": "repair_requests_room_asset_id_room_assets_id_fk",
+					"tableFrom": "repair_requests",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"repair_requests_source_asset_id_room_assets_id_fk": {
+					"name": "repair_requests_source_asset_id_room_assets_id_fk",
+					"tableFrom": "repair_requests",
+					"tableTo": "room_assets",
+					"columnsFrom": ["source_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"repair_requests_reported_by_user_id_users_id_fk": {
+					"name": "repair_requests_reported_by_user_id_users_id_fk",
+					"tableFrom": "repair_requests",
+					"tableTo": "users",
+					"columnsFrom": ["reported_by_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"suppliers": {
+			"name": "suppliers",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"contact_person": {
+					"name": "contact_person",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"suppliers_code_unique": {
+					"name": "suppliers_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"materials": {
+			"name": "materials",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"category_id": {
+					"name": "category_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"supplier_id": {
+					"name": "supplier_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"unit": {
+					"name": "unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"min_quantity": {
+					"name": "min_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"price": {
+					"name": "price",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'ACTIVE'"
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"materials_code_unique": {
+					"name": "materials_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"materials_category_id_categories_id_fk": {
+					"name": "materials_category_id_categories_id_fk",
+					"tableFrom": "materials",
+					"tableTo": "categories",
+					"columnsFrom": ["category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"materials_supplier_id_suppliers_id_fk": {
+					"name": "materials_supplier_id_suppliers_id_fk",
+					"tableFrom": "materials",
+					"tableTo": "suppliers",
+					"columnsFrom": ["supplier_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"warehouses": {
+			"name": "warehouses",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"location": {
+					"name": "location",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"manager": {
+					"name": "manager",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"warehouses_code_unique": {
+					"name": "warehouses_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"warehouse_items": {
+			"name": "warehouse_items",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"warehouse_id": {
+					"name": "warehouse_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"material_id": {
+					"name": "material_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"min_quantity": {
+					"name": "min_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"warehouse_items_warehouse_id_warehouses_id_fk": {
+					"name": "warehouse_items_warehouse_id_warehouses_id_fk",
+					"tableFrom": "warehouse_items",
+					"tableTo": "warehouses",
+					"columnsFrom": ["warehouse_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"warehouse_items_material_id_materials_id_fk": {
+					"name": "warehouse_items_material_id_materials_id_fk",
+					"tableFrom": "warehouse_items",
+					"tableTo": "materials",
+					"columnsFrom": ["material_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"notification_items": {
+			"name": "notification_items",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"notifiableType": {
+					"name": "notifiableType",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"notifiableId": {
+					"name": "notifiableId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"notificationId": {
+					"name": "notificationId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"notification_items_notification_idx": {
+					"name": "notification_items_notification_idx",
+					"columns": ["notificationId"],
+					"isUnique": false
+				},
+				"notification_items_item_idx": {
+					"name": "notification_items_item_idx",
+					"columns": ["notifiableType", "notifiableId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"notification_items_notificationId_notifications_id_fk": {
+					"name": "notification_items_notificationId_notifications_id_fk",
+					"tableFrom": "notification_items",
+					"tableTo": "notifications",
+					"columnsFrom": ["notificationId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"notifications": {
+			"name": "notifications",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"readAt": {
+					"name": "readAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notificationType": {
+					"name": "notificationType",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'birthday'"
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"message": {
+					"name": "message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"isBatch": {
+					"name": "isBatch",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": false
+				},
+				"batchKey": {
+					"name": "batchKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"totalCount": {
+					"name": "totalCount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 1
+				},
+				"recipientId": {
+					"name": "recipientId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actorId": {
+					"name": "actorId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"recipient_idx": {
+					"name": "recipient_idx",
+					"columns": ["recipientId"],
+					"isUnique": false
+				},
+				"batch_idx": {
+					"name": "batch_idx",
+					"columns": ["batchKey"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"notifications_recipientId_users_id_fk": {
+					"name": "notifications_recipientId_users_id_fk",
+					"tableFrom": "notifications",
+					"tableTo": "users",
+					"columnsFrom": ["recipientId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"notifications_actorId_users_id_fk": {
+					"name": "notifications_actorId_users_id_fk",
+					"tableFrom": "notifications",
+					"tableTo": "users",
+					"columnsFrom": ["actorId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/apps/api/migrations/meta/_journal.json
+++ b/apps/api/migrations/meta/_journal.json
@@ -299,43 +299,57 @@
 		{
 			"idx": 42,
 			"version": "6",
-			"when": 1785552000000,
-			"tag": "0042_exam_academic_titles",
+			"when": 1785376116953,
+			"tag": "0042_lying_greymalkin",
 			"breakpoints": true
 		},
 		{
 			"idx": 43,
 			"version": "6",
-			"when": 1785552600000,
-			"tag": "0043_restore_exam_classes",
+			"when": 1785420000000,
+			"tag": "0043_leave_management",
 			"breakpoints": true
 		},
 		{
 			"idx": 44,
 			"version": "6",
-			"when": 1785553200000,
-			"tag": "0044_restore_exam_runtime_tables",
+			"when": 1785422100000,
+			"tag": "0046_restore_roles_and_leave_roles",
 			"breakpoints": true
 		},
 		{
 			"idx": 45,
 			"version": "6",
-			"when": 1785553800000,
-			"tag": "0045_exam_major_official_catalog",
+			"when": 1785422700000,
+			"tag": "0047_add_leave_personnel_role",
 			"breakpoints": true
 		},
 		{
 			"idx": 46,
 			"version": "6",
-			"when": 1785554400000,
-			"tag": "0046_use_catalog_number_as_major_code",
+			"when": 1785423300000,
+			"tag": "0048_leave_audit_logs",
 			"breakpoints": true
 		},
 		{
 			"idx": 47,
 			"version": "6",
-			"when": 1785555000000,
-			"tag": "0047_sync_exam_log_major_codes",
+			"when": 1785423900000,
+			"tag": "0049_backfill_approved_leave_data",
+			"breakpoints": true
+		},
+		{
+			"idx": 48,
+			"version": "6",
+			"when": 1785424500000,
+			"tag": "0050_restore_leave_regulations",
+			"breakpoints": true
+		},
+		{
+			"idx": 49,
+			"version": "6",
+			"when": 1785425100000,
+			"tag": "0051_seed_leave_objects_and_extra_standards",
 			"breakpoints": true
 		}
 	]

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -50,6 +50,7 @@
 		"jsonwebtoken": "^9.0.2",
 		"mysql2": "^3.12.0",
 		"node": "link:@libsql/client/node",
+		"nodemailer": "^9.0.3",
 		"uuid": "^11.1.0",
 		"valibot": "^1.1.0",
 		"xlsx-template": "^1.4.4"

--- a/apps/api/schema/index.ts
+++ b/apps/api/schema/index.ts
@@ -31,6 +31,7 @@ export * from './asset-movement-logs'
 export * from './account-audit-logs'
 export * from './catalog-audit-logs'
 export * from './catalog-stock-logs'
+export * from './leave-audit-logs'
 export * from './asset-broken-logs'
 export * from './user-nganh'
 export * from './asset-proposals'
@@ -51,3 +52,8 @@ export * from './notifications'
 
 // Đề thi tự luận
 export * from './exam-bank'
+
+// Quản lý nghỉ phép
+export * from './leave-management'
+export * from './leave-batches'
+export * from './leave-positions'

--- a/apps/api/schema/leave-audit-logs.ts
+++ b/apps/api/schema/leave-audit-logs.ts
@@ -1,0 +1,11 @@
+import { int, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { baseSchema } from './base'
+
+export const leaveAuditLogs = sqliteTable('leave_audit_logs', {
+	...baseSchema,
+	userId: int('user_id'),
+	action: text('action').notNull(),
+	entityType: text('entity_type').notNull(),
+	entityId: int('entity_id'),
+	details: text('details')
+})

--- a/apps/api/schema/leave-batches.ts
+++ b/apps/api/schema/leave-batches.ts
@@ -1,0 +1,62 @@
+import { int, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { sql } from 'drizzle-orm'
+import { Base } from './base'
+import type { LeaveObjectType, LeaveType } from './leave-management'
+
+export const leaveBatches = sqliteTable('leave_batches', {
+	id: int('id').primaryKey({ autoIncrement: true }),
+	createdAt: text('created_at')
+		.notNull()
+		.default(sql`CURRENT_TIMESTAMP`),
+	updatedAt: text('updated_at')
+		.notNull()
+		.default(sql`CURRENT_TIMESTAMP`),
+	requestId: int('request_id').notNull(),
+	personnelId: int('personnel_id'),
+	personnelCode: text('personnel_code'),
+	personnelName: text('personnel_name'),
+	objectType: text('object_type').notNull().$type<LeaveObjectType>(),
+	leaveType: text('leave_type').notNull().$type<LeaveType>(),
+	batchIndex: int('batch_index').notNull().default(1),
+	batchLabel: text('batch_label').notNull().default(''),
+	startDate: text('start_date'),
+	endDate: text('end_date'),
+	totalDays: int('total_days').notNull().default(0),
+	note: text('note'),
+	createdByUserId: int('created_by_user_id')
+})
+
+export interface LeaveBatchDB extends Base {
+	requestId: number
+	personnelId: number | null
+	personnelCode: string | null
+	personnelName: string | null
+	objectType: LeaveObjectType
+	leaveType: LeaveType
+	batchIndex: number
+	batchLabel: string
+	startDate: string | null
+	endDate: string | null
+	totalDays: number
+	note: string | null
+	createdByUserId: number | null
+}
+
+export interface LeaveBatchResponse {
+	id: number
+	createdAt: string
+	updatedAt: string
+	requestId: number
+	personnelId: number | null
+	personnelCode: string | null
+	personnelName: string | null
+	objectType: LeaveObjectType
+	leaveType: LeaveType
+	batchIndex: number
+	batchLabel: string
+	startDate: string | null
+	endDate: string | null
+	totalDays: number
+	note: string | null
+	createdByUserId: number | null
+}

--- a/apps/api/schema/leave-management.ts
+++ b/apps/api/schema/leave-management.ts
@@ -1,0 +1,401 @@
+import { int, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { Base, baseSchema } from './base'
+
+/**
+ * Mã đối tượng theo quy định (Ma_DT):
+ * SQ | QNCN | CNQP | VCQP | HSQBS | HV | KHAC
+ * Legacy (map khi đọc/ghi): QN→SQ, CN→CNQP, HSQ|BS→HSQBS
+ */
+export type LeaveObjectType =
+	| 'SQ'
+	| 'QNCN'
+	| 'CNQP'
+	| 'VCQP'
+	| 'HSQBS'
+	| 'HV'
+	| 'KHAC'
+	/** @deprecated dùng SQ */
+	| 'QN'
+	/** @deprecated dùng CNQP */
+	| 'CN'
+	/** @deprecated dùng HSQBS */
+	| 'HSQ'
+	/** @deprecated dùng HSQBS */
+	| 'BS'
+
+/** ANNUAL = phép hằng năm | SPECIAL = phép đặc biệt */
+export type LeaveType = 'ANNUAL' | 'SPECIAL'
+
+/** Cấp địa phương */
+export type LeaveLocalityLevel = 'province' | 'ward' | 'village'
+
+/**
+ * DRAFT — nháp
+ * PENDING_COMMANDER — chờ chỉ huy cơ quan duyệt
+ * PENDING_AGENCY — chờ cơ quan quản lý (in / BGH–quân lực ký)
+ * PENDING — legacy (= chờ duyệt, map như PENDING_COMMANDER)
+ * APPROVED — đã duyệt (sau khi ký)
+ * RETURNED — trả lại
+ * REJECTED — từ chối (legacy, map như RETURNED)
+ * CANCELLED — đã hủy
+ */
+export type LeaveRequestStatus =
+	| 'DRAFT'
+	| 'PENDING'
+	| 'PENDING_COMMANDER'
+	| 'PENDING_AGENCY'
+	| 'APPROVED'
+	| 'RETURNED'
+	| 'REJECTED'
+	| 'CANCELLED'
+
+/** Bảng đối tượng (Ma_DT, Tên_ĐT) */
+export const leaveObjectTypes = sqliteTable('leave_object_types', {
+	...baseSchema,
+	code: text('code').notNull().unique(),
+	name: text('name').notNull(),
+	sortOrder: int('sort_order').notNull().default(0),
+	isActive: int('is_active', { mode: 'boolean' }).notNull().default(true)
+})
+
+/** Danh mục đơn vị / đầu mối đơn vị trực thuộc */
+export const leaveUnits = sqliteTable('leave_units', {
+	...baseSchema,
+	code: text('code'),
+	name: text('name').notNull(),
+	level: text('level'),
+	parentId: int('parent_id'),
+	isActive: int('is_active', { mode: 'boolean' }).notNull().default(true),
+	commanderUserId: int('commander_user_id'),
+	commanderName: text('commander_name'),
+	managementArea: text('management_area').notNull().default('cán_bộ')
+})
+
+/** Lớp học viên thuộc đại đội (mỗi đại đội tối đa 2 lớp A1–A10). */
+export const leaveClasses = sqliteTable('leave_classes', {
+	...baseSchema,
+	unitId: int('unit_id').notNull(),
+	name: text('name').notNull(),
+	isActive: int('is_active', { mode: 'boolean' }).notNull().default(true)
+})
+
+/** Tiêu chuẩn phép thêm (MS 01–06) */
+export const leaveExtraStandards = sqliteTable('leave_extra_standards', {
+	...baseSchema,
+	code: text('code').notNull().unique(),
+	label: text('label').notNull(),
+	days: int('days').notNull(),
+	sortOrder: int('sort_order').notNull().default(0),
+	isActive: int('is_active', { mode: 'boolean' }).notNull().default(true)
+})
+
+/** Danh sách quân nhân (catalog phép) */
+export const leavePersonnel = sqliteTable('leave_personnel', {
+	...baseSchema,
+	code: text('code').notNull().unique(),
+	fullName: text('full_name').notNull(),
+	/** Ngày nhập ngũ YYYY-MM-DD */
+	enlistmentDate: text('enlistment_date'),
+	/** Tuyển dụng (đợt / hình thức) */
+	recruitment: text('recruitment'),
+	objectType: text('object_type').notNull().$type<LeaveObjectType>(),
+	rank: text('rank'),
+	position: text('position'),
+	classId: int('class_id'),
+	/** FK leave_units.id (ưu tiên) hoặc units.id */
+	unitId: int('unit_id'),
+	unitName: text('unit_name'),
+	hometown: text('hometown'),
+	permanentResidence: text('permanent_residence'),
+	/** Liên kết user đăng nhập (optional) */
+	userId: int('user_id'),
+	/** Email nhận thông báo duyệt / trả đơn */
+	email: text('email'),
+	/** Chỉ huy cơ quan (user id) — nhận đơn đề xuất bước 1 */
+	commanderUserId: int('commander_user_id'),
+	/** Tên chỉ huy (cache) */
+	commanderName: text('commander_name'),
+	className: text('class_name'),
+	managementArea: text('management_area').notNull().default('cán_bộ')
+})
+
+/** Cây địa phương: Tỉnh → Xã/Phường → Thôn */
+export const leaveLocalities = sqliteTable('leave_localities', {
+	...baseSchema,
+	name: text('name').notNull(),
+	level: text('level').notNull().$type<LeaveLocalityLevel>(),
+	parentId: int('parent_id'),
+	code: text('code')
+})
+
+/**
+ * Quy định / tiêu chuẩn phép hằng năm (và SPECIAL).
+ * ANNUAL: object_type + min/max service years → base days
+ * SPECIAL: rule riêng (base_days cấu hình)
+ */
+export const leaveRegulations = sqliteTable('leave_regulations', {
+	...baseSchema,
+	leaveType: text('leave_type').notNull().$type<LeaveType>(),
+	objectType: text('object_type').$type<LeaveObjectType | null>(),
+	/** Thâm niên từ (năm), inclusive; null = không giới hạn dưới */
+	minYears: int('min_years'),
+	/** Thâm niên đến (năm), exclusive; null = không giới hạn trên */
+	maxYears: int('max_years'),
+	baseDays: int('base_days').notNull(),
+	label: text('label'),
+	description: text('description'),
+	isActive: int('is_active', { mode: 'boolean' }).notNull().default(true)
+})
+
+/** Đơn / danh sách phép (workflow) */
+export const leaveRequests = sqliteTable('leave_requests', {
+	...baseSchema,
+	leaveType: text('leave_type').notNull().$type<LeaveType>(),
+	requestScope: text('request_scope').notNull().default('OTHER'),
+	classId: int('class_id'),
+	className: text('class_name'),
+	status: text('status')
+		.notNull()
+		.default('PENDING')
+		.$type<LeaveRequestStatus>(),
+	personnelId: int('personnel_id'),
+	personnelCode: text('personnel_code'),
+	personnelName: text('personnel_name'),
+	objectType: text('object_type').notNull().$type<LeaveObjectType>(),
+	rank: text('rank'),
+	/** Snapshot chức vụ từ hồ sơ QN */
+	position: text('position'),
+	/** Snapshot ngày nhập ngũ / tuyển dụng */
+	enlistmentDate: text('enlistment_date'),
+	unitId: int('unit_id'),
+	unitName: text('unit_name'),
+	/** Thâm niên (năm) tại thời điểm đề xuất (theo ngày bắt đầu nghỉ) */
+	serviceYears: int('service_years').notNull().default(0),
+	baseDays: int('base_days').notNull().default(0),
+	/** Ngày đi đường */
+	travelDays: int('travel_days').notNull().default(0),
+	/** 0 | 5 | 10 */
+	extraDays: int('extra_days').notNull().default(0),
+	/** JSON string[] reason codes */
+	extraReasons: text('extra_reasons').default('[]'),
+	totalDays: int('total_days').notNull().default(0),
+	startDate: text('start_date'),
+	endDate: text('end_date'),
+	leaveYear: text('leave_year'),
+	/** Nơi đăng ký nghỉ phép (thôn / xã / tỉnh) */
+	localityId: int('locality_id'),
+	localityPath: text('locality_path'),
+	note: text('note'),
+	proposedByUserId: int('proposed_by_user_id'),
+	proposedByUsername: text('proposed_by_username'),
+	proposedByDisplayName: text('proposed_by_display_name'),
+	/** Email người đề xuất (snapshot) */
+	proposerEmail: text('proposer_email'),
+	/** Chỉ huy cơ quan phụ trách đơn này */
+	commanderUserId: int('commander_user_id'),
+	commanderName: text('commander_name'),
+	adminNote: text('admin_note'),
+	decidedByUserId: int('decided_by_user_id'),
+	decidedByUsername: text('decided_by_username'),
+	decidedAt: text('decided_at')
+})
+
+/** Nhật ký gửi mail (để kiểm tra khi SMTP dev / lỗi) */
+export const leaveMailLog = sqliteTable('leave_mail_log', {
+	...baseSchema,
+	requestId: int('request_id'),
+	toEmail: text('to_email').notNull(),
+	subject: text('subject').notNull(),
+	body: text('body'),
+	mode: text('mode'),
+	ok: int('ok', { mode: 'boolean' }).notNull().default(false),
+	error: text('error'),
+	previewUrl: text('preview_url'),
+	/** DECISION | SUBMITTED | TEST | ... */
+	kind: text('kind')
+})
+
+/**
+ * Thông báo in-app cho chỉ huy / CQQL / người đề xuất (duyệt phép).
+ */
+export const leaveAlerts = sqliteTable('leave_alerts', {
+	...baseSchema,
+	userId: int('user_id').notNull(),
+	requestId: int('request_id').notNull(),
+	/** NEED_COMMANDER | NEED_AGENCY | DECIDED | RETURNED */
+	kind: text('kind').notNull(),
+	title: text('title').notNull(),
+	message: text('message').notNull(),
+	readAt: text('read_at')
+})
+
+/**
+ * Bảng lưu thông tin nghỉ phép (lưu trữ / tra cứu).
+ * Khi giải quyết phép (ký phê duyệt) → đẩy snapshot vào đây.
+ */
+export const leaveRecords = sqliteTable('leave_records', {
+	...baseSchema,
+	requestId: int('request_id').notNull(),
+	/** Snapshot trạng thái đơn (ghi khi gửi duyệt, cập nhật khi xử lý) */
+	status: text('status')
+		.notNull()
+		.default('PENDING')
+		.$type<LeaveRequestStatus>(),
+	leaveType: text('leave_type').notNull().$type<LeaveType>(),
+	personnelId: int('personnel_id'),
+	personnelCode: text('personnel_code'),
+	personnelName: text('personnel_name'),
+	objectType: text('object_type').notNull().$type<LeaveObjectType>(),
+	rank: text('rank'),
+	position: text('position'),
+	enlistmentDate: text('enlistment_date'),
+	unitId: int('unit_id'),
+	unitName: text('unit_name'),
+	serviceYears: int('service_years').notNull().default(0),
+	baseDays: int('base_days').notNull().default(0),
+	travelDays: int('travel_days').notNull().default(0),
+	extraDays: int('extra_days').notNull().default(0),
+	extraReasons: text('extra_reasons').default('[]'),
+	totalDays: int('total_days').notNull().default(0),
+	startDate: text('start_date'),
+	endDate: text('end_date'),
+	leaveYear: text('leave_year'),
+	localityId: int('locality_id'),
+	localityPath: text('locality_path'),
+	note: text('note'),
+	adminNote: text('admin_note'),
+	proposedByUserId: int('proposed_by_user_id'),
+	proposedByUsername: text('proposed_by_username'),
+	proposedByDisplayName: text('proposed_by_display_name'),
+	decidedByUserId: int('decided_by_user_id'),
+	decidedByUsername: text('decided_by_username'),
+	decidedAt: text('decided_at'),
+	archivedAt: text('archived_at').notNull()
+})
+
+export interface LeaveObjectTypeDB extends Base {
+	code: string
+	name: string
+	sortOrder: number
+	isActive: boolean
+}
+
+export interface LeaveUnitDB extends Base {
+	code: string | null
+	name: string
+	parentId: number | null
+	isActive: boolean
+}
+
+export interface LeaveExtraStandardDB extends Base {
+	code: string
+	label: string
+	days: number
+	sortOrder: number
+	isActive: boolean
+}
+
+export interface LeavePersonnelDB extends Base {
+	code: string
+	fullName: string
+	enlistmentDate: string | null
+	recruitment: string | null
+	objectType: LeaveObjectType
+	rank: string | null
+	position: string | null
+	unitId: number | null
+	unitName: string | null
+	hometown: string | null
+	permanentResidence: string | null
+	userId: number | null
+	email: string | null
+	commanderUserId: number | null
+	commanderName: string | null
+}
+
+export interface LeaveLocalityDB extends Base {
+	name: string
+	level: LeaveLocalityLevel
+	parentId: number | null
+	code: string | null
+}
+
+export interface LeaveRegulationDB extends Base {
+	leaveType: LeaveType
+	objectType: LeaveObjectType | null
+	minYears: number | null
+	maxYears: number | null
+	baseDays: number
+	label: string | null
+	description: string | null
+	isActive: boolean
+}
+
+export interface LeaveRequestDB extends Base {
+	leaveType: LeaveType
+	status: LeaveRequestStatus
+	personnelId: number | null
+	personnelCode: string | null
+	personnelName: string | null
+	objectType: LeaveObjectType
+	rank: string | null
+	position: string | null
+	enlistmentDate: string | null
+	unitId: number | null
+	unitName: string | null
+	serviceYears: number
+	baseDays: number
+	travelDays: number
+	extraDays: number
+	extraReasons: string | null
+	totalDays: number
+	startDate: string | null
+	endDate: string | null
+	localityId: number | null
+	localityPath: string | null
+	note: string | null
+	proposedByUserId: number | null
+	proposedByUsername: string | null
+	proposedByDisplayName: string | null
+	proposerEmail: string | null
+	commanderUserId: number | null
+	commanderName: string | null
+	adminNote: string | null
+	decidedByUserId: number | null
+	decidedByUsername: string | null
+	decidedAt: string | null
+}
+
+export interface LeaveRecordDB extends Base {
+	requestId: number
+	status: LeaveRequestStatus
+	leaveType: LeaveType
+	personnelId: number | null
+	personnelCode: string | null
+	personnelName: string | null
+	objectType: LeaveObjectType
+	rank: string | null
+	position: string | null
+	enlistmentDate: string | null
+	unitId: number | null
+	unitName: string | null
+	serviceYears: number
+	baseDays: number
+	travelDays: number
+	extraDays: number
+	extraReasons: string | null
+	totalDays: number
+	startDate: string | null
+	endDate: string | null
+	localityId: number | null
+	localityPath: string | null
+	note: string | null
+	adminNote: string | null
+	proposedByUserId: number | null
+	proposedByUsername: string | null
+	proposedByDisplayName: string | null
+	decidedByUserId: number | null
+	decidedByUsername: string | null
+	decidedAt: string | null
+	archivedAt: string
+}

--- a/apps/api/schema/leave-positions.ts
+++ b/apps/api/schema/leave-positions.ts
@@ -1,0 +1,9 @@
+import { int, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { baseSchema } from './base'
+
+export const leavePositions = sqliteTable('leave_positions', {
+	...baseSchema,
+	name: text('name').notNull().unique(),
+	sortOrder: int('sort_order').notNull().default(0),
+	isActive: int('is_active', { mode: 'boolean' }).notNull().default(true)
+})

--- a/apps/api/schema/users.ts
+++ b/apps/api/schema/users.ts
@@ -35,6 +35,8 @@ export const users = p.sqliteTable('users', {
 	rank: p.text(),
 	position: p.text(),
 	alias: p.text(),
+	leaveUnitId: p.int('leave_unit_id'),
+	managementArea: p.text('management_area'),
 	/** Ảnh chữ ký số (URL / data URL) — BGH dùng khi phê duyệt đề */
 	signatureUrl: p.text('signature_url')
 })
@@ -57,6 +59,8 @@ export interface UserDB extends Base {
 	rank?: string | null
 	position?: string | null
 	alias?: string | null
+	leaveUnitId?: number | null
+	managementArea?: string | null
 	signatureUrl?: string | null
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
             node:
                 specifier: link:@libsql/client/node
                 version: link:@libsql/client/node
+            nodemailer:
+                specifier: ^9.0.3
+                version: 9.0.3
             uuid:
                 specifier: ^11.1.0
                 version: 11.1.0
@@ -7009,6 +7012,13 @@ packages:
                 integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==
             }
 
+    nodemailer@9.0.3:
+        resolution:
+            {
+                integrity: sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==
+            }
+        engines: { node: '>=6.0.0' }
+
     normalize-path@3.0.0:
         resolution:
             {
@@ -13026,6 +13036,8 @@ snapshots:
     node-gyp-build@4.8.4: {}
 
     node-releases@2.0.19: {}
+
+    nodemailer@9.0.3: {}
 
     normalize-path@3.0.0: {}
 


### PR DESCRIPTION
## Mục tiêu

Tạo nền tảng quản lý phép: schema, migration, kiểu dữ liệu và cấu hình ban đầu.

## Phạm vi

PR này chỉ chứa nhóm thay đổi tương ứng được tách từ #185; không kèm toàn bộ các PR trước.

## Thứ tự merge

PR nền tảng của chuỗi tính năng; merge trước #188–#208.

## Lưu ý kiểm thử

Trạng thái tích hợp đầy đủ đã chạy được generate, migrate database sạch, Encore check và frontend build. Các lỗi TypeScript/lint và tình trạng thiếu automated tests đã được ghi nhận riêng, không được che giấu trong PR này.