### PR TITLE
feat(leave): add personnel and organization catalogs

### DIFF
--- a/apps/api/leave-management/access.ts
+++ b/apps/api/leave-management/access.ts
@@ -1,0 +1,153 @@
+/**
+ * Vai trò truy cập phân hệ phép: admin | commander | personnel
+ */
+import { api } from 'encore.dev/api'
+import { eq } from 'drizzle-orm'
+import { getAuthData } from '~encore/auth'
+import orm from '../database'
+import { users } from '../schema/users'
+import { leaveUnits } from '../schema/leave-management'
+import { leavePersonnel } from '../schema/leave-management'
+
+export type LeaveAccessRole =
+	| 'admin'
+	| 'commander'
+	| 'agency'
+	| 'personnel'
+	| 'none'
+
+export interface LeaveAccess {
+	role: LeaveAccessRole
+	isAdmin: boolean
+	/** Là chỉ huy CQ của ít nhất 1 đơn vị */
+	isCommander: boolean
+	/** Tài khoản Cơ quan quản lý (Cán bộ / Quân lực) */
+	isAgency: boolean
+	/** Có hồ sơ quân nhân liên kết */
+	isPersonnel: boolean
+	/** Được lập đề xuất phép (admin / chỉ huy / quân nhân, không áp dụng CQQL) */
+	canPropose: boolean
+	managementArea: string | null
+	/** Đơn vị được phụ trách (leave_units.id); admin = [] nghĩa là tất cả */
+	unitIds: number[]
+	/** Tên đơn vị phụ trách */
+	unitNames: string[]
+}
+
+/** Tính quyền leave cho user hiện tại (dùng trong API khác) */
+export async function resolveLeaveAccess(
+	userId: number,
+	isSuperAdmin: boolean
+): Promise<LeaveAccess> {
+	if (isSuperAdmin) {
+		return {
+			role: 'admin',
+			isAdmin: true,
+			isCommander: true,
+			isAgency: true,
+			isPersonnel: false,
+			canPropose: true,
+			managementArea: null,
+			unitIds: [],
+			unitNames: []
+		}
+	}
+
+	const asUnitCmd = await orm
+		.select()
+		.from(leaveUnits)
+		.where(eq(leaveUnits.commanderUserId, userId))
+	const account = await orm
+		.select({
+			position: users.position,
+			managementArea: users.managementArea
+		})
+		.from(users)
+		.where(eq(users.id, userId))
+		.limit(1)
+	const isAgency = account[0]?.position === 'Cơ quan quản lý'
+	const managementArea = account[0]?.managementArea ?? null
+
+	const unitIds = [
+		...new Set(
+			asUnitCmd.map((u) => u.id).filter((id): id is number => id != null)
+		)
+	]
+	const unitNames = asUnitCmd.map((u) => u.name)
+
+	// Cũng coi là chỉ huy nếu còn gán trên hồ sơ QN (dữ liệu cũ)
+	const asPersCmd = await orm
+		.select({ unitId: leavePersonnel.unitId })
+		.from(leavePersonnel)
+		.where(eq(leavePersonnel.commanderUserId, userId))
+	for (const p of asPersCmd) {
+		if (p.unitId != null && !unitIds.includes(p.unitId)) {
+			unitIds.push(p.unitId)
+		}
+	}
+	const isCommander = unitIds.length > 0
+	if (isAgency && managementArea) {
+		const managedUnits = await orm
+			.select({ id: leaveUnits.id, name: leaveUnits.name })
+			.from(leaveUnits)
+			.where(eq(leaveUnits.managementArea, managementArea))
+		for (const unit of managedUnits) {
+			if (!unitIds.includes(unit.id)) unitIds.push(unit.id)
+			if (!unitNames.includes(unit.name)) unitNames.push(unit.name)
+		}
+	}
+
+	const myPersonnel = await orm
+		.select({ id: leavePersonnel.id })
+		.from(leavePersonnel)
+		.where(eq(leavePersonnel.userId, userId))
+		.limit(1)
+
+	const isPersonnel = !!myPersonnel[0]
+
+	let role: LeaveAccessRole = 'none'
+	if (isAgency) role = 'agency'
+	else if (isCommander) role = 'commander'
+	else if (isPersonnel) role = 'personnel'
+
+	return {
+		role,
+		isAdmin: false,
+		isCommander,
+		isAgency,
+		isPersonnel,
+		canPropose: (isCommander || isPersonnel) && !isAgency,
+		managementArea,
+		unitIds,
+		unitNames
+	}
+}
+
+export const GetLeaveMyAccess = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/my-access'
+	},
+	async (): Promise<{ data: LeaveAccess }> => {
+		const auth = getAuthData()!
+		const uid = Number(auth.userID)
+		const data = await resolveLeaveAccess(uid, !!auth.isSuperAdmin)
+		// super admin: check if also has personnel
+		if (data.isAdmin) {
+			const p = await orm
+				.select({ id: leavePersonnel.id })
+				.from(leavePersonnel)
+				.where(eq(leavePersonnel.userId, uid))
+				.limit(1)
+			return {
+				data: {
+					...data,
+					isPersonnel: !!p[0]
+				}
+			}
+		}
+		return { data }
+	}
+)

--- a/apps/api/leave-management/accounts.ts
+++ b/apps/api/leave-management/accounts.ts
@@ -1,0 +1,106 @@
+import { api, APIError } from 'encore.dev/api'
+import { eq } from 'drizzle-orm'
+import { getAuthData } from '~encore/auth'
+import orm from '../database'
+import { users } from '../schema/users'
+import { leavePersonnel, leaveUnits } from '../schema/leave-management'
+
+type LeaveAccountKind = 'personnel' | 'commander' | 'management'
+
+export const AssignLeaveAccount = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/accounts/assign'
+	},
+	async (body: {
+		userId: number
+		kind: LeaveAccountKind
+		personnelId?: number
+		unitId?: number
+		managementArea?: 'cán_bộ' | 'quân_lực'
+	}): Promise<{ ok: boolean }> => {
+		if (!getAuthData()?.isSuperAdmin) {
+			throw APIError.permissionDenied(
+				'Chỉ admin được gán loại tài khoản phép'
+			)
+		}
+		const user = await orm
+			.select()
+			.from(users)
+			.where(eq(users.id, body.userId))
+			.limit(1)
+		if (!user[0]) throw APIError.notFound('Không tìm thấy tài khoản')
+
+		if (body.kind === 'personnel') {
+			if (!body.personnelId)
+				throw APIError.invalidArgument('Chọn quân nhân')
+			const p = await orm
+				.select()
+				.from(leavePersonnel)
+				.where(eq(leavePersonnel.id, body.personnelId))
+				.limit(1)
+			if (!p[0]) throw APIError.notFound('Không tìm thấy quân nhân')
+			if (p[0].userId && p[0].userId !== body.userId) {
+				throw APIError.alreadyExists('Quân nhân đã có tài khoản')
+			}
+			await orm
+				.update(leavePersonnel)
+				.set({ userId: body.userId, email: p[0].email })
+				.where(eq(leavePersonnel.id, body.personnelId))
+			await orm
+				.update(users)
+				.set({
+					position: 'Quân nhân',
+					leaveUnitId: p[0].unitId,
+					managementArea: p[0].managementArea
+				})
+				.where(eq(users.id, body.userId))
+		} else if (body.kind === 'commander') {
+			if (!body.unitId)
+				throw APIError.invalidArgument('Chọn cơ quan chỉ huy')
+			const u = await orm
+				.select()
+				.from(leaveUnits)
+				.where(eq(leaveUnits.id, body.unitId))
+				.limit(1)
+			if (!u[0]) throw APIError.notFound('Không tìm thấy cơ quan')
+			await orm
+				.update(leaveUnits)
+				.set({
+					commanderUserId: body.userId,
+					commanderName: user[0].displayName
+				})
+				.where(eq(leaveUnits.id, body.unitId))
+			await orm
+				.update(users)
+				.set({
+					position: 'Chỉ huy cơ quan',
+					leaveUnitId: body.unitId,
+					managementArea: u[0].managementArea
+				})
+				.where(eq(users.id, body.userId))
+			await orm
+				.update(leavePersonnel)
+				.set({
+					commanderUserId: body.userId,
+					commanderName: user[0].displayName
+				})
+				.where(eq(leavePersonnel.unitId, body.unitId))
+		} else {
+			if (!body.managementArea) {
+				throw APIError.invalidArgument('Chọn Cán bộ hoặc Quân lực')
+			}
+			await orm
+				.update(users)
+				.set({
+					position: 'Cơ quan quản lý',
+					leaveUnitId: null,
+					managementArea: body.managementArea
+				})
+				.where(eq(users.id, body.userId))
+		}
+		return { ok: true }
+	}
+)

--- a/apps/api/leave-management/localities.ts
+++ b/apps/api/leave-management/localities.ts
@@ -1,0 +1,430 @@
+/**
+ * CRUD danh sách địa phương: Tỉnh → Xã/Phường → Thôn
+ */
+import { api, APIError, Query } from 'encore.dev/api'
+import { and, asc, eq, isNull } from 'drizzle-orm'
+import orm from '../database'
+import {
+	leaveLocalities,
+	type LeaveLocalityLevel
+} from '../schema/leave-management'
+
+export interface LocalityResponse {
+	id: number
+	createdAt: string
+	updatedAt: string
+	name: string
+	level: LeaveLocalityLevel
+	parentId: number | null
+	code: string | null
+	children?: LocalityResponse[]
+}
+
+function mapRow(r: typeof leaveLocalities.$inferSelect): LocalityResponse {
+	return {
+		id: r.id,
+		createdAt: r.createdAt ?? '',
+		updatedAt: r.updatedAt ?? '',
+		name: r.name,
+		level: r.level as LeaveLocalityLevel,
+		parentId: r.parentId,
+		code: r.code
+	}
+}
+
+const LEVELS: LeaveLocalityLevel[] = ['province', 'ward', 'village']
+
+function isLevel(v: string): v is LeaveLocalityLevel {
+	return LEVELS.includes(v as LeaveLocalityLevel)
+}
+
+export const ListLeaveLocalities = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/localities'
+	},
+	async (q: {
+		level?: Query<string>
+		parentId?: Query<number>
+		tree?: Query<boolean>
+	}): Promise<{ data: LocalityResponse[] }> => {
+		if (q.tree) {
+			const all = await orm
+				.select()
+				.from(leaveLocalities)
+				.orderBy(asc(leaveLocalities.name))
+			const mapped = all.map(mapRow)
+			const byParent = new Map<number | null, LocalityResponse[]>()
+			for (const row of mapped) {
+				const key = row.parentId
+				if (!byParent.has(key)) byParent.set(key, [])
+				byParent.get(key)!.push(row)
+			}
+			const attach = (node: LocalityResponse): LocalityResponse => {
+				const kids = byParent.get(node.id) || []
+				return {
+					...node,
+					children: kids.map(attach)
+				}
+			}
+			const roots = (byParent.get(null) || []).map(attach)
+			return { data: roots }
+		}
+
+		const conditions = []
+		if (q.level && isLevel(String(q.level))) {
+			conditions.push(
+				eq(leaveLocalities.level, q.level as LeaveLocalityLevel)
+			)
+		}
+		if (q.parentId != null && Number(q.parentId) > 0) {
+			conditions.push(eq(leaveLocalities.parentId, Number(q.parentId)))
+		} else if (
+			q.parentId === 0 ||
+			(q.level && String(q.level) === 'province')
+		) {
+			// provinces: parent null
+			if (!q.parentId || Number(q.parentId) === 0) {
+				if (String(q.level || '') === 'province' || q.parentId === 0) {
+					conditions.push(isNull(leaveLocalities.parentId))
+				}
+			}
+		}
+
+		const rows = await orm
+			.select()
+			.from(leaveLocalities)
+			.where(conditions.length ? and(...conditions) : undefined)
+			.orderBy(asc(leaveLocalities.name))
+		return { data: rows.map(mapRow) }
+	}
+)
+
+interface CreateLocalityBody {
+	name: string
+	level: string
+	parentId?: number | null
+	code?: string | null
+}
+
+export const CreateLeaveLocality = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/localities'
+	},
+	async (body: CreateLocalityBody): Promise<{ data: LocalityResponse }> => {
+		if (!body.name?.trim()) {
+			throw APIError.invalidArgument('Tên địa phương là bắt buộc')
+		}
+		if (!isLevel(body.level)) {
+			throw APIError.invalidArgument(
+				'Cấp phải là province | ward | village'
+			)
+		}
+		if (body.level === 'province' && body.parentId) {
+			throw APIError.invalidArgument('Tỉnh không có đơn vị cha')
+		}
+		if (body.level !== 'province') {
+			if (!body.parentId) {
+				throw APIError.invalidArgument('Cần chọn địa phương cha')
+			}
+			const parent = await orm
+				.select()
+				.from(leaveLocalities)
+				.where(eq(leaveLocalities.id, body.parentId))
+				.limit(1)
+			if (!parent[0]) throw APIError.invalidArgument('Không tìm thấy cha')
+			const expectedParent = body.level === 'ward' ? 'province' : 'ward'
+			if (parent[0].level !== expectedParent) {
+				throw APIError.invalidArgument(
+					`Cấp cha phải là ${expectedParent}`
+				)
+			}
+		}
+		const inserted = await orm
+			.insert(leaveLocalities)
+			.values({
+				name: body.name.trim(),
+				level: body.level as LeaveLocalityLevel,
+				parentId: body.parentId ?? null,
+				code: body.code || null
+			})
+			.returning()
+		return { data: mapRow(inserted[0]!) }
+	}
+)
+
+export const UpdateLeaveLocality = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'PATCH',
+		path: '/leave/localities/:id'
+	},
+	async ({
+		id,
+		name,
+		code
+	}: {
+		id: number
+		name?: string
+		code?: string | null
+	}): Promise<{ data: LocalityResponse }> => {
+		const existing = await orm
+			.select()
+			.from(leaveLocalities)
+			.where(eq(leaveLocalities.id, id))
+			.limit(1)
+		if (!existing[0]) throw APIError.notFound('Không tìm thấy địa phương')
+		const updated = await orm
+			.update(leaveLocalities)
+			.set({
+				...(name != null ? { name: name.trim() } : {}),
+				...(code !== undefined ? { code: code || null } : {})
+			})
+			.where(eq(leaveLocalities.id, id))
+			.returning()
+		return { data: mapRow(updated[0]!) }
+	}
+)
+
+export const DeleteLeaveLocality = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'DELETE',
+		path: '/leave/localities/:id'
+	},
+	async ({ id }: { id: number }): Promise<{ ok: boolean }> => {
+		const children = await orm
+			.select()
+			.from(leaveLocalities)
+			.where(eq(leaveLocalities.parentId, id))
+			.limit(1)
+		if (children[0]) {
+			throw APIError.failedPrecondition(
+				'Còn địa phương con — xóa con trước'
+			)
+		}
+		const res = await orm
+			.delete(leaveLocalities)
+			.where(eq(leaveLocalities.id, id))
+			.returning()
+		if (!res[0]) throw APIError.notFound('Không tìm thấy địa phương')
+		return { ok: true }
+	}
+)
+
+/** Build path "Tỉnh > Xã > Thôn" */
+export async function resolveLocalityPath(
+	localityId: number | null | undefined
+): Promise<string | null> {
+	if (!localityId) return null
+	const parts: string[] = []
+	let currentId: number | null = localityId
+	for (let i = 0; i < 5 && currentId; i++) {
+		const rows = await orm
+			.select()
+			.from(leaveLocalities)
+			.where(eq(leaveLocalities.id, currentId))
+			.limit(1)
+		if (!rows[0]) break
+		parts.unshift(rows[0].name)
+		currentId = rows[0].parentId
+	}
+	return parts.length ? parts.join(' > ') : null
+}
+
+export interface ImportLocalityItem {
+	/** Tên tỉnh (bắt buộc) */
+	province: string
+	/** Tên xã/phường (tuỳ chọn) */
+	ward?: string | null
+	/** Tên thôn (tuỳ chọn — cần ward) */
+	village?: string | null
+	provinceCode?: string | null
+	wardCode?: string | null
+	villageCode?: string | null
+}
+
+export interface ImportLocalityResult {
+	successCount: number
+	errorCount: number
+	totalCount: number
+	createdCount: number
+	skippedCount: number
+	errors: { row: number; message: string }[]
+}
+
+function cacheKey(
+	level: LeaveLocalityLevel,
+	parentId: number | null,
+	name: string
+): string {
+	return `${level}|${parentId ?? 'null'}|${name}`
+}
+
+function normalizeLocalityName(name: string): string {
+	return name.replace(/\s+/g, ' ').trim()
+}
+
+/**
+ * Import địa phương dạng phẳng (file 3321 xã/phường):
+ * mỗi dòng = Tỉnh/TP + Xã/Phường (+ tuỳ chọn Thôn).
+ * Cache in-memory để import ~3k dòng nhanh.
+ */
+export const ImportLeaveLocalities = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/localities/import'
+	},
+	async (body: {
+		items: ImportLocalityItem[]
+	}): Promise<{ data: ImportLocalityResult }> => {
+		const items = body.items || []
+		if (!items.length) {
+			throw APIError.invalidArgument('Danh sách import trống')
+		}
+		if (items.length > 10000) {
+			throw APIError.invalidArgument('Tối đa 10000 dòng mỗi lần import')
+		}
+
+		// Preload existing localities into cache
+		const all = await orm.select().from(leaveLocalities)
+		const byKey = new Map<string, { id: number; code: string | null }>()
+		for (const r of all) {
+			byKey.set(
+				cacheKey(
+					r.level as LeaveLocalityLevel,
+					r.parentId,
+					normalizeLocalityName(r.name)
+				),
+				{ id: r.id, code: r.code }
+			)
+		}
+
+		const findOrCreate = async (
+			name: string,
+			level: LeaveLocalityLevel,
+			parentId: number | null,
+			code?: string | null
+		): Promise<{ id: number; created: boolean }> => {
+			const n = normalizeLocalityName(name)
+			const key = cacheKey(level, parentId, n)
+			const hit = byKey.get(key)
+			if (hit) {
+				if (code && !hit.code) {
+					await orm
+						.update(leaveLocalities)
+						.set({ code })
+						.where(eq(leaveLocalities.id, hit.id))
+					hit.code = code
+				}
+				return { id: hit.id, created: false }
+			}
+			const inserted = await orm
+				.insert(leaveLocalities)
+				.values({
+					name: n,
+					level,
+					parentId,
+					code: code || null
+				})
+				.returning()
+			const id = inserted[0]!.id
+			byKey.set(key, { id, code: code || null })
+			return { id, created: true }
+		}
+
+		const errors: { row: number; message: string }[] = []
+		let successCount = 0
+		let createdCount = 0
+		let skippedCount = 0
+
+		for (let i = 0; i < items.length; i++) {
+			const row = i + 1
+			const item = items[i]!
+			const province = normalizeLocalityName(String(item.province || ''))
+			if (!province) {
+				errors.push({ row, message: 'Tên tỉnh/thành phố là bắt buộc' })
+				continue
+			}
+			const ward = item.ward
+				? normalizeLocalityName(String(item.ward))
+				: ''
+			const village = item.village
+				? normalizeLocalityName(String(item.village))
+				: ''
+			if (village && !ward) {
+				errors.push({
+					row,
+					message: 'Thôn cần có Xã/Phường'
+				})
+				continue
+			}
+
+			try {
+				let anyCreated = false
+				const p = await findOrCreate(
+					province,
+					'province',
+					null,
+					item.provinceCode
+						? String(item.provinceCode).trim() || null
+						: null
+				)
+				if (p.created) anyCreated = true
+
+				if (ward) {
+					const w = await findOrCreate(
+						ward,
+						'ward',
+						p.id,
+						item.wardCode
+							? String(item.wardCode).trim() || null
+							: null
+					)
+					if (w.created) anyCreated = true
+
+					if (village) {
+						const v = await findOrCreate(
+							village,
+							'village',
+							w.id,
+							item.villageCode
+								? String(item.villageCode).trim() || null
+								: null
+						)
+						if (v.created) anyCreated = true
+					}
+				}
+
+				successCount++
+				if (anyCreated) createdCount++
+				else skippedCount++
+			} catch (e: unknown) {
+				errors.push({
+					row,
+					message: String((e as Error)?.message || e)
+				})
+			}
+		}
+
+		return {
+			data: {
+				successCount,
+				errorCount: errors.length,
+				totalCount: items.length,
+				createdCount,
+				skippedCount,
+				errors
+			}
+		}
+	}
+)

--- a/apps/api/leave-management/personnel.ts
+++ b/apps/api/leave-management/personnel.ts
@@ -1,0 +1,529 @@
+/**
+ * CRUD danh sách quân nhân (catalog phép)
+ */
+import { api, APIError, Query } from 'encore.dev/api'
+import { and, eq, inArray, like, or, sql } from 'drizzle-orm'
+import { getAuthData } from '~encore/auth'
+import orm from '../database'
+import {
+	leaveClasses,
+	leavePersonnel,
+	type LeaveObjectType
+} from '../schema/leave-management'
+import { isLeaveObjectType, normalizeObjectType } from './helpers'
+import { resolveUnitCommander } from './units'
+import { resolveLeaveAccess } from './access'
+
+export interface PersonnelResponse {
+	id: number
+	createdAt: string
+	updatedAt: string
+	code: string
+	fullName: string
+	enlistmentDate: string | null
+	recruitment: string | null
+	objectType: LeaveObjectType
+	rank: string | null
+	position: string | null
+	classId: number | null
+	unitId: number | null
+	unitName: string | null
+	hometown: string | null
+	permanentResidence: string | null
+	userId: number | null
+	email: string | null
+	commanderUserId: number | null
+	commanderName: string | null
+	className: string | null
+	managementArea: string
+}
+
+function mapRow(r: typeof leavePersonnel.$inferSelect): PersonnelResponse {
+	return {
+		id: r.id,
+		createdAt: r.createdAt ?? '',
+		updatedAt: r.updatedAt ?? '',
+		code: r.code,
+		fullName: r.fullName,
+		enlistmentDate: r.enlistmentDate,
+		recruitment: r.recruitment,
+		objectType: r.objectType as LeaveObjectType,
+		rank: r.rank,
+		position: r.position,
+		classId: r.classId ?? null,
+		unitId: r.unitId,
+		unitName: r.unitName,
+		hometown: r.hometown,
+		permanentResidence: r.permanentResidence,
+		userId: r.userId,
+		email: r.email ?? null,
+		commanderUserId: r.commanderUserId ?? null,
+		commanderName: r.commanderName ?? null,
+		className: r.className ?? null,
+		managementArea: r.managementArea
+	}
+}
+
+export const ListLeavePersonnel = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/personnel'
+	},
+	async (q: {
+		search?: Query<string>
+		objectType?: Query<string>
+	}): Promise<{ data: PersonnelResponse[] }> => {
+		const auth = getAuthData()!
+		const access = await resolveLeaveAccess(
+			Number(auth.userID),
+			!!auth.isSuperAdmin
+		)
+		const conditions = []
+		if (!access.isAdmin) {
+			if (access.unitIds.length) {
+				conditions.push(inArray(leavePersonnel.unitId, access.unitIds))
+			} else {
+				conditions.push(eq(leavePersonnel.userId, Number(auth.userID)))
+			}
+		}
+		if (q.objectType && isLeaveObjectType(String(q.objectType))) {
+			conditions.push(
+				eq(leavePersonnel.objectType, q.objectType as LeaveObjectType)
+			)
+		}
+		if (q.search) {
+			const s = `%${String(q.search).trim()}%`
+			conditions.push(
+				or(
+					like(leavePersonnel.code, s),
+					like(leavePersonnel.fullName, s),
+					like(leavePersonnel.unitName, s)
+				)!
+			)
+		}
+		const rows = await orm
+			.select()
+			.from(leavePersonnel)
+			.where(conditions.length ? and(...conditions) : undefined)
+			.orderBy(sql`${leavePersonnel.id} desc`)
+		return { data: rows.map(mapRow) }
+	}
+)
+
+export const GetLeavePersonnel = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/personnel/:id'
+	},
+	async ({ id }: { id: number }): Promise<{ data: PersonnelResponse }> => {
+		const auth = getAuthData()!
+		const access = await resolveLeaveAccess(
+			Number(auth.userID),
+			!!auth.isSuperAdmin
+		)
+		const rows = await orm
+			.select()
+			.from(leavePersonnel)
+			.where(eq(leavePersonnel.id, id))
+			.limit(1)
+		if (!rows[0]) throw APIError.notFound('Không tìm thấy quân nhân')
+		if (
+			!access.isAdmin &&
+			rows[0].userId !== Number(auth.userID) &&
+			(rows[0].unitId == null || !access.unitIds.includes(rows[0].unitId))
+		) {
+			throw APIError.permissionDenied('Không có quyền xem quân nhân này')
+		}
+		return { data: mapRow(rows[0]) }
+	}
+)
+
+export const GetMyLeavePersonnel = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/my-personnel'
+	},
+	async (): Promise<{ data: PersonnelResponse | null }> => {
+		const { getAuthData } = await import('~encore/auth')
+		const auth = getAuthData()
+		if (!auth?.userID) return { data: null }
+		const uid = Number(auth.userID)
+		const rows = await orm
+			.select()
+			.from(leavePersonnel)
+			.where(eq(leavePersonnel.userId, uid))
+			.limit(1)
+		return { data: rows[0] ? mapRow(rows[0]) : null }
+	}
+)
+
+interface CreatePersonnelBody {
+	/** Bỏ trống → hệ thống tự sinh (QN-xxxxxx) */
+	code?: string | null
+	fullName: string
+	enlistmentDate?: string | null
+	recruitment?: string | null
+	objectType: string
+	rank?: string | null
+	position?: string | null
+	classId?: number | null
+	unitId?: number | null
+	unitName?: string | null
+	hometown?: string | null
+	permanentResidence?: string | null
+	userId?: number | null
+	email?: string | null
+	commanderUserId?: number | null
+	commanderName?: string | null
+	className?: string | null
+	managementArea?: string
+}
+
+async function generatePersonnelCode(): Promise<string> {
+	const rows = await orm
+		.select({ id: leavePersonnel.id })
+		.from(leavePersonnel)
+		.orderBy(sql`${leavePersonnel.id} desc`)
+		.limit(1)
+	const next = (rows[0]?.id ?? 0) + 1
+	const base = `QN-${String(next).padStart(6, '0')}`
+	// ensure unique even if ids were deleted
+	const clash = await orm
+		.select({ id: leavePersonnel.id })
+		.from(leavePersonnel)
+		.where(eq(leavePersonnel.code, base))
+		.limit(1)
+	if (!clash[0]) return base
+	return `QN-${Date.now().toString(36).toUpperCase()}`
+}
+
+export const CreateLeavePersonnel = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/personnel'
+	},
+	async (body: CreatePersonnelBody): Promise<{ data: PersonnelResponse }> => {
+		if (!body.fullName?.trim()) {
+			throw APIError.invalidArgument('Tên là bắt buộc')
+		}
+		if (!isLeaveObjectType(body.objectType)) {
+			throw APIError.invalidArgument('Đối tượng không hợp lệ')
+		}
+		const objectType = normalizeObjectType(body.objectType)!
+		const code = body.code?.trim()
+			? body.code.trim()
+			: await generatePersonnelCode()
+		// Chỉ huy CQ lấy cố định theo đơn vị
+		const unitId = body.unitId ?? null
+		const fromUnit = await resolveUnitCommander(unitId)
+		const commanderUserId =
+			fromUnit.commanderUserId ?? body.commanderUserId ?? null
+		const commanderName =
+			fromUnit.commanderName ?? (body.commanderName?.trim() || null)
+		try {
+			const inserted = await orm
+				.insert(leavePersonnel)
+				.values({
+					code,
+					fullName: body.fullName.trim(),
+					enlistmentDate: body.enlistmentDate || null,
+					recruitment: body.recruitment || null,
+					objectType,
+					rank: body.rank || null,
+					position: body.position || null,
+					classId: body.classId ?? null,
+					unitId,
+					unitName: body.unitName || null,
+					hometown: body.hometown || null,
+					permanentResidence: body.permanentResidence || null,
+					userId: body.userId ?? null,
+					email: body.email?.trim() || null,
+					commanderUserId,
+					commanderName,
+					className: body.className || null,
+					managementArea: body.managementArea || 'cán_bộ'
+				})
+				.returning()
+			return { data: mapRow(inserted[0]!) }
+		} catch (e: unknown) {
+			const msg = String((e as Error)?.message || e)
+			if (/unique|UNIQUE/i.test(msg)) {
+				throw APIError.alreadyExists('Mã quân nhân đã tồn tại')
+			}
+			throw e
+		}
+	}
+)
+
+export const UpdateLeavePersonnel = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'PATCH',
+		path: '/leave/personnel/:id'
+	},
+	async ({
+		id,
+		...body
+	}: { id: number } & Partial<CreatePersonnelBody>): Promise<{
+		data: PersonnelResponse
+	}> => {
+		const existing = await orm
+			.select()
+			.from(leavePersonnel)
+			.where(eq(leavePersonnel.id, id))
+			.limit(1)
+		if (!existing[0]) throw APIError.notFound('Không tìm thấy quân nhân')
+		if (body.objectType && !isLeaveObjectType(body.objectType)) {
+			throw APIError.invalidArgument('Đối tượng không hợp lệ')
+		}
+
+		// Khi đổi đơn vị → gán lại chỉ huy CQ theo đơn vị
+		const nextUnitId =
+			body.unitId !== undefined
+				? (body.unitId ?? null)
+				: existing[0].unitId
+		const fromUnit = await resolveUnitCommander(nextUnitId)
+		const commanderUserId =
+			fromUnit.commanderUserId ??
+			(body.commanderUserId !== undefined
+				? (body.commanderUserId ?? null)
+				: existing[0].commanderUserId)
+		const commanderName =
+			fromUnit.commanderName ??
+			(body.commanderName !== undefined
+				? body.commanderName?.trim() || null
+				: existing[0].commanderName)
+
+		const updated = await orm
+			.update(leavePersonnel)
+			.set({
+				...(body.code != null ? { code: body.code.trim() } : {}),
+				...(body.fullName != null
+					? { fullName: body.fullName.trim() }
+					: {}),
+				...(body.enlistmentDate !== undefined
+					? { enlistmentDate: body.enlistmentDate || null }
+					: {}),
+				...(body.recruitment !== undefined
+					? { recruitment: body.recruitment || null }
+					: {}),
+				...(body.objectType
+					? {
+							objectType:
+								normalizeObjectType(body.objectType) ||
+								(body.objectType as LeaveObjectType)
+						}
+					: {}),
+				...(body.rank !== undefined ? { rank: body.rank || null } : {}),
+				...(body.position !== undefined
+					? { position: body.position || null }
+					: {}),
+				...(body.classId !== undefined
+					? { classId: body.classId ?? null }
+					: {}),
+				...(body.unitId !== undefined
+					? { unitId: body.unitId ?? null }
+					: {}),
+				...(body.unitName !== undefined
+					? { unitName: body.unitName || null }
+					: {}),
+				...(body.hometown !== undefined
+					? { hometown: body.hometown || null }
+					: {}),
+				...(body.permanentResidence !== undefined
+					? { permanentResidence: body.permanentResidence || null }
+					: {}),
+				...(body.userId !== undefined
+					? { userId: body.userId ?? null }
+					: {}),
+				...(body.email !== undefined
+					? { email: body.email?.trim() || null }
+					: {}),
+				...(body.className !== undefined
+					? { className: body.className || null }
+					: {}),
+				...(body.managementArea !== undefined
+					? { managementArea: body.managementArea }
+					: {}),
+				commanderUserId,
+				commanderName
+			})
+			.where(eq(leavePersonnel.id, id))
+			.returning()
+		return { data: mapRow(updated[0]!) }
+	}
+)
+
+export const DeleteLeavePersonnel = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'DELETE',
+		path: '/leave/personnel/:id'
+	},
+	async ({ id }: { id: number }): Promise<{ ok: boolean }> => {
+		const res = await orm
+			.delete(leavePersonnel)
+			.where(eq(leavePersonnel.id, id))
+			.returning()
+		if (!res[0]) throw APIError.notFound('Không tìm thấy quân nhân')
+		return { ok: true }
+	}
+)
+
+export interface ImportPersonnelItem {
+	/** Bỏ trống → tự sinh */
+	code?: string | null
+	fullName: string
+	enlistmentDate?: string | null
+	recruitment?: string | null
+	objectType: string
+	rank?: string | null
+	position?: string | null
+	unitId?: number | null
+	unitName?: string | null
+	hometown?: string | null
+	permanentResidence?: string | null
+	userId?: number | null
+}
+
+export interface ImportPersonnelResult {
+	successCount: number
+	errorCount: number
+	totalCount: number
+	errors: { row: number; message: string }[]
+}
+
+/** Import hàng loạt — upsert theo mã (code). */
+export const ImportLeavePersonnel = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/personnel/import'
+	},
+	async (body: {
+		items: ImportPersonnelItem[]
+	}): Promise<{ data: ImportPersonnelResult }> => {
+		const items = body.items || []
+		if (!items.length) {
+			throw APIError.invalidArgument('Danh sách import trống')
+		}
+		if (items.length > 2000) {
+			throw APIError.invalidArgument('Tối đa 2000 dòng mỗi lần import')
+		}
+
+		const errors: { row: number; message: string }[] = []
+		let successCount = 0
+		const maxRow = await orm
+			.select({ id: leavePersonnel.id })
+			.from(leavePersonnel)
+			.orderBy(sql`${leavePersonnel.id} desc`)
+			.limit(1)
+		let nextSeq = (maxRow[0]?.id ?? 0) + 1
+		const usedCodes = new Set<string>()
+
+		for (let i = 0; i < items.length; i++) {
+			const row = i + 1
+			const item = items[i]!
+			let code = String(item.code || '').trim()
+			const fullName = String(item.fullName || '').trim()
+			if (!fullName) {
+				errors.push({ row, message: 'Tên là bắt buộc' })
+				continue
+			}
+			if (!code) {
+				do {
+					code = `QN-${String(nextSeq++).padStart(6, '0')}`
+				} while (usedCodes.has(code))
+			}
+			usedCodes.add(code)
+			const objectTypeRaw = String(item.objectType || 'SQ')
+				.trim()
+				.toUpperCase()
+			if (!isLeaveObjectType(objectTypeRaw)) {
+				errors.push({
+					row,
+					message: `Đối tượng không hợp lệ: ${item.objectType}`
+				})
+				continue
+			}
+			const objectType = normalizeObjectType(objectTypeRaw)!
+			let userId: number | null = null
+			if (item.userId != null && String(item.userId).trim() !== '') {
+				userId = Number(item.userId)
+				if (Number.isNaN(userId) || userId <= 0) {
+					errors.push({ row, message: 'User ID không hợp lệ' })
+					continue
+				}
+			}
+
+			const values = {
+				code,
+				fullName,
+				enlistmentDate: item.enlistmentDate
+					? String(item.enlistmentDate).trim() || null
+					: null,
+				recruitment: item.recruitment
+					? String(item.recruitment).trim() || null
+					: null,
+				objectType,
+				rank: item.rank ? String(item.rank).trim() || null : null,
+				position: item.position
+					? String(item.position).trim() || null
+					: null,
+				unitId: item.unitId ?? null,
+				unitName: item.unitName
+					? String(item.unitName).trim() || null
+					: null,
+				hometown: item.hometown
+					? String(item.hometown).trim() || null
+					: null,
+				permanentResidence: item.permanentResidence
+					? String(item.permanentResidence).trim() || null
+					: null,
+				userId: userId && userId > 0 ? userId : null
+			}
+
+			try {
+				const existing = await orm
+					.select()
+					.from(leavePersonnel)
+					.where(eq(leavePersonnel.code, code))
+					.limit(1)
+				if (existing[0]) {
+					await orm
+						.update(leavePersonnel)
+						.set(values)
+						.where(eq(leavePersonnel.id, existing[0].id))
+				} else {
+					await orm.insert(leavePersonnel).values(values)
+				}
+				successCount++
+			} catch (e: unknown) {
+				errors.push({
+					row,
+					message: String((e as Error)?.message || e)
+				})
+			}
+		}
+
+		return {
+			data: {
+				successCount,
+				errorCount: errors.length,
+				totalCount: items.length,
+				errors
+			}
+		}
+	}
+)

--- a/apps/api/leave-management/positions.ts
+++ b/apps/api/leave-management/positions.ts
@@ -1,0 +1,107 @@
+import { api, APIError, Query } from 'encore.dev/api'
+import { asc, eq } from 'drizzle-orm'
+import orm from '../database'
+import { leavePositions } from '../schema/leave-positions'
+
+type PositionResponse = {
+	id: number
+	name: string
+	sortOrder: number
+	isActive: boolean
+}
+
+const mapPosition = (
+	row: typeof leavePositions.$inferSelect
+): PositionResponse => ({
+	id: row.id,
+	name: row.name,
+	sortOrder: row.sortOrder,
+	isActive: !!row.isActive
+})
+
+export const ListLeavePositions = api(
+	{ auth: true, expose: true, method: 'GET', path: '/leave/positions' },
+	async (q: {
+		activeOnly?: Query<boolean>
+	}): Promise<{ data: PositionResponse[] }> => {
+		const activeOnly = String(q.activeOnly ?? 'true') !== 'false'
+		const rows = await orm
+			.select()
+			.from(leavePositions)
+			.where(activeOnly ? eq(leavePositions.isActive, true) : undefined)
+			.orderBy(asc(leavePositions.sortOrder), asc(leavePositions.name))
+		return { data: rows.map(mapPosition) }
+	}
+)
+
+export const CreateLeavePosition = api(
+	{ auth: true, expose: true, method: 'POST', path: '/leave/positions' },
+	async (body: {
+		name: string
+		sortOrder?: number
+		isActive?: boolean
+	}): Promise<{ data: PositionResponse }> => {
+		if (!body.name?.trim())
+			throw APIError.invalidArgument('Tên chức vụ là bắt buộc')
+		try {
+			const rows = await orm
+				.insert(leavePositions)
+				.values({
+					name: body.name.trim(),
+					sortOrder: body.sortOrder ?? 0,
+					isActive: body.isActive !== false
+				})
+				.returning()
+			return { data: mapPosition(rows[0]!) }
+		} catch {
+			throw APIError.alreadyExists('Chức vụ đã tồn tại')
+		}
+	}
+)
+
+export const UpdateLeavePosition = api(
+	{ auth: true, expose: true, method: 'PATCH', path: '/leave/positions/:id' },
+	async ({
+		id,
+		...body
+	}: {
+		id: number
+		name?: string
+		sortOrder?: number
+		isActive?: boolean
+	}): Promise<{ data: PositionResponse }> => {
+		const rows = await orm
+			.update(leavePositions)
+			.set({
+				...(body.name !== undefined ? { name: body.name.trim() } : {}),
+				...(body.sortOrder !== undefined
+					? { sortOrder: body.sortOrder }
+					: {}),
+				...(body.isActive !== undefined
+					? { isActive: body.isActive }
+					: {}),
+				updatedAt: new Date().toISOString()
+			})
+			.where(eq(leavePositions.id, id))
+			.returning()
+		if (!rows[0]) throw APIError.notFound('Không tìm thấy chức vụ')
+		return { data: mapPosition(rows[0]) }
+	}
+)
+
+export const DeleteLeavePosition = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'DELETE',
+		path: '/leave/positions/:id'
+	},
+	async ({ id }: { id: number }): Promise<{ ok: boolean }> => {
+		const rows = await orm
+			.delete(leavePositions)
+			.where(eq(leavePositions.id, id))
+			.returning()
+		if (!rows[0]) throw APIError.notFound('Không tìm thấy chức vụ')
+		return { ok: true }
+	}
+)

--- a/apps/api/leave-management/units.ts
+++ b/apps/api/leave-management/units.ts
@@ -1,0 +1,318 @@
+/**
+ * Danh mục đơn vị / đầu mối đơn vị trực thuộc (phân hệ phép)
+ */
+import { api, APIError, Query } from 'encore.dev/api'
+import { and, asc, eq, inArray, like, or, sql } from 'drizzle-orm'
+import { getAuthData } from '~encore/auth'
+import orm from '../database'
+import { leaveUnits } from '../schema/leave-management'
+import { resolveLeaveAccess } from './access'
+
+/** Resolve commander assignment for a leave unit.
+ * Personnel-level commander fields remain the fallback when the unit catalog
+ * has not yet been linked to an account.
+ */
+export async function resolveUnitCommander(unitId?: number | null): Promise<{
+	commanderUserId: number | null
+	commanderName: string | null
+}> {
+	if (!unitId) return { commanderUserId: null, commanderName: null }
+	const rows = await orm
+		.select()
+		.from(leaveUnits)
+		.where(eq(leaveUnits.id, unitId))
+		.limit(1)
+	return {
+		commanderUserId: rows[0]?.commanderUserId ?? null,
+		commanderName: rows[0]?.commanderName ?? null
+	}
+}
+
+export interface LeaveUnitResponse {
+	id: number
+	createdAt: string
+	updatedAt: string
+	code: string | null
+	name: string
+	parentId: number | null
+	level: string | null
+	commanderUserId: number | null
+	commanderName: string | null
+	managementArea: string
+	isActive: boolean
+}
+
+function mapRow(r: typeof leaveUnits.$inferSelect): LeaveUnitResponse {
+	return {
+		id: r.id,
+		createdAt: r.createdAt ?? '',
+		updatedAt: r.updatedAt ?? '',
+		code: r.code,
+		name: r.name,
+		parentId: r.parentId,
+		level: r.level,
+		commanderUserId: r.commanderUserId,
+		commanderName: r.commanderName,
+		managementArea: r.managementArea,
+		isActive: !!r.isActive
+	}
+}
+
+export const ListLeaveUnits = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/units'
+	},
+	async (q: {
+		search?: Query<string>
+		activeOnly?: Query<boolean>
+	}): Promise<{ data: LeaveUnitResponse[] }> => {
+		const auth = getAuthData()!
+		const access = await resolveLeaveAccess(
+			Number(auth.userID),
+			!!auth.isSuperAdmin
+		)
+		const conditions = []
+		if (!access.isAdmin) {
+			if (!access.unitIds.length) return { data: [] }
+			conditions.push(inArray(leaveUnits.id, access.unitIds))
+		}
+		// activeOnly mặc định true; ?activeOnly=false để lấy cả ẩn
+		const activeOnly = String(q.activeOnly ?? 'true') !== 'false'
+		if (activeOnly) {
+			conditions.push(eq(leaveUnits.isActive, true))
+		}
+		if (q.search) {
+			const s = `%${String(q.search).trim()}%`
+			conditions.push(
+				or(like(leaveUnits.name, s), like(leaveUnits.code, s))!
+			)
+		}
+		const rows = await orm
+			.select()
+			.from(leaveUnits)
+			.where(conditions.length ? and(...conditions) : undefined)
+			.orderBy(asc(leaveUnits.name))
+		return { data: rows.map(mapRow) }
+	}
+)
+
+export const CreateLeaveUnit = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/units'
+	},
+	async (body: {
+		name: string
+		code?: string | null
+		parentId?: number | null
+		level?: string | null
+		managementArea?: string
+		isActive?: boolean
+	}): Promise<{ data: LeaveUnitResponse }> => {
+		if (!body.name?.trim()) {
+			throw APIError.invalidArgument('Tên đơn vị là bắt buộc')
+		}
+		const inserted = await orm
+			.insert(leaveUnits)
+			.values({
+				name: body.name.trim(),
+				code: body.code?.trim() || null,
+				parentId: body.parentId ?? null,
+				level: body.level || null,
+				managementArea: body.managementArea || 'cán_bộ',
+				isActive: body.isActive !== false
+			})
+			.returning()
+		return { data: mapRow(inserted[0]!) }
+	}
+)
+
+export const UpdateLeaveUnit = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'PATCH',
+		path: '/leave/units/:id'
+	},
+	async ({
+		id,
+		name,
+		code,
+		parentId,
+		level,
+		managementArea,
+		isActive
+	}: {
+		id: number
+		name?: string
+		code?: string | null
+		parentId?: number | null
+		level?: string | null
+		managementArea?: string
+		isActive?: boolean
+	}): Promise<{ data: LeaveUnitResponse }> => {
+		const existing = await orm
+			.select()
+			.from(leaveUnits)
+			.where(eq(leaveUnits.id, id))
+			.limit(1)
+		if (!existing[0]) throw APIError.notFound('Không tìm thấy đơn vị')
+		const updated = await orm
+			.update(leaveUnits)
+			.set({
+				...(name !== undefined ? { name: name.trim() } : {}),
+				...(code !== undefined ? { code: code?.trim() || null } : {}),
+				...(parentId !== undefined
+					? { parentId: parentId ?? null }
+					: {}),
+				...(level !== undefined ? { level: level || null } : {}),
+				...(managementArea !== undefined ? { managementArea } : {}),
+				...(isActive !== undefined ? { isActive } : {})
+			})
+			.where(eq(leaveUnits.id, id))
+			.returning()
+		return { data: mapRow(updated[0]!) }
+	}
+)
+
+export const DeleteLeaveUnit = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'DELETE',
+		path: '/leave/units/:id'
+	},
+	async ({ id }: { id: number }): Promise<{ ok: boolean }> => {
+		const res = await orm
+			.delete(leaveUnits)
+			.where(eq(leaveUnits.id, id))
+			.returning()
+		if (!res[0]) throw APIError.notFound('Không tìm thấy đơn vị')
+		return { ok: true }
+	}
+)
+
+/** Import hàng loạt đơn vị (theo tên; upsert theo code nếu có) */
+export const ImportLeaveUnits = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/units/import'
+	},
+	async (body: {
+		items: { name: string; code?: string | null }[]
+	}): Promise<{
+		data: {
+			successCount: number
+			errorCount: number
+			totalCount: number
+			errors: { row: number; message: string }[]
+		}
+	}> => {
+		const items = body.items || []
+		if (!items.length) {
+			throw APIError.invalidArgument('Danh sách import trống')
+		}
+		const errors: { row: number; message: string }[] = []
+		let successCount = 0
+		for (let i = 0; i < items.length; i++) {
+			const row = i + 1
+			const name = String(items[i]?.name || '').trim()
+			const code = items[i]?.code
+				? String(items[i]!.code).trim() || null
+				: null
+			if (!name) {
+				errors.push({ row, message: 'Tên đơn vị là bắt buộc' })
+				continue
+			}
+			try {
+				if (code) {
+					const existing = await orm
+						.select()
+						.from(leaveUnits)
+						.where(eq(leaveUnits.code, code))
+						.limit(1)
+					if (existing[0]) {
+						await orm
+							.update(leaveUnits)
+							.set({ name, isActive: true })
+							.where(eq(leaveUnits.id, existing[0].id))
+						successCount++
+						continue
+					}
+				}
+				// match by name
+				const byName = await orm
+					.select()
+					.from(leaveUnits)
+					.where(eq(leaveUnits.name, name))
+					.limit(1)
+				if (byName[0]) {
+					await orm
+						.update(leaveUnits)
+						.set({
+							...(code ? { code } : {}),
+							isActive: true
+						})
+						.where(eq(leaveUnits.id, byName[0].id))
+				} else {
+					await orm.insert(leaveUnits).values({
+						name,
+						code,
+						isActive: true
+					})
+				}
+				successCount++
+			} catch (e: unknown) {
+				errors.push({
+					row,
+					message: String((e as Error)?.message || e)
+				})
+			}
+		}
+		return {
+			data: {
+				successCount,
+				errorCount: errors.length,
+				totalCount: items.length,
+				errors
+			}
+		}
+	}
+)
+
+/** Seed từ bảng units (tiểu đoàn/đại đội) nếu leave_units trống */
+export const SeedLeaveUnitsFromSystem = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/units/seed-from-system'
+	},
+	async (): Promise<{ data: { inserted: number } }> => {
+		const { units } = await import('../schema/units')
+		const existing = await orm
+			.select({ c: sql<number>`count(*)` })
+			.from(leaveUnits)
+		if ((existing[0]?.c ?? 0) > 0) {
+			return { data: { inserted: 0 } }
+		}
+		const sys = await orm.select().from(units).orderBy(asc(units.id))
+		let inserted = 0
+		for (const u of sys) {
+			await orm.insert(leaveUnits).values({
+				code: u.alias,
+				name: u.name,
+				isActive: true
+			})
+			inserted++
+		}
+		return { data: { inserted } }
+	}
+)


### PR DESCRIPTION
## Mục tiêu

Thêm các API danh mục nhân sự, đơn vị, chức vụ, địa phương và đồng bộ tài khoản.

## Phạm vi

PR này chỉ chứa nhóm thay đổi tương ứng được tách từ #185; không kèm toàn bộ các PR trước.

## Thứ tự merge

Phụ thuộc #187; merge theo thứ tự PR tăng dần. Nhánh được tách độc lập từ `main` để phần review chỉ hiển thị đúng phạm vi của PR này.

## Lưu ý kiểm thử

Trạng thái tích hợp đầy đủ đã chạy được generate, migrate database sạch, Encore check và frontend build. Các lỗi TypeScript/lint và tình trạng thiếu automated tests đã được ghi nhận riêng, không được che giấu trong PR này.