### PR TITLE
feat(leave): save SMTP settings from admin UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist
 dist-ssr
 *.local
 .env
+.leave-mail-config.enc
 .cache
 server/dist
 public/dist

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,21 @@
+# Bắt buộc khi chạy API local
+HASH_SECRET=dev-hash-secret-change-me
+JWT_PRIVATE_KEY=dev-jwt-private-key-change-me
+
+# SMTP gửi mail thật (Gmail cần bật 2FA và dùng App Password)
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=your-account@gmail.com
+SMTP_PASS=your-16-character-app-password
+SMTP_FROM=Quản lý phép <your-account@gmail.com>
+SMTP_NO_AUTH=false
+LEAVE_MAIL_DEV=false
+
+# Hoặc dùng hộp thư Ethereal để thử nghiệm, không gửi tới người nhận thật
+# LEAVE_MAIL_DEV=true
+
+# Cấu hình dịch vụ local khác
+S3_ACCESS_KEY=minio
+S3_SECRET_KEY=minio123
+S3_ENDPOINT=http://127.0.0.1:9000
+MARIADB_SYNC_ENABLED=false

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -24,6 +24,24 @@ Run this command from your application's root folder:
 ```bash
 encore run
 ```
+
+### Cấu hình SMTP sau khi clone
+
+Git không lưu `apps/api/.env` vì file này chứa mật khẩu. Sau khi clone, tạo
+file cấu hình local từ mẫu:
+
+```bash
+cp apps/api/.env.example apps/api/.env
+```
+
+Sau đó điền `SMTP_USER`, `SMTP_PASS` và `SMTP_FROM` trong
+`apps/api/.env`. Với Gmail, `SMTP_PASS` phải là App Password được tạo sau khi
+bật xác minh hai bước, không phải mật khẩu đăng nhập Gmail. Đặt
+`LEAVE_MAIL_DEV=false` để gửi mail thật rồi khởi động lại Encore.
+
+Nếu chỉ cần kiểm thử mà chưa có SMTP, đặt `LEAVE_MAIL_DEV=true`; thư sẽ được
+gửi vào hộp thư Ethereal thử nghiệm và không tới địa chỉ người nhận thật.
+
 ### Using the API
 
 To see that your app is running, you can ping the API.

--- a/apps/api/leave-management/access.ts
+++ b/apps/api/leave-management/access.ts
@@ -1,0 +1,153 @@
+/**
+ * Vai trò truy cập phân hệ phép: admin | commander | personnel
+ */
+import { api } from 'encore.dev/api'
+import { eq } from 'drizzle-orm'
+import { getAuthData } from '~encore/auth'
+import orm from '../database'
+import { users } from '../schema/users'
+import { leaveUnits } from '../schema/leave-management'
+import { leavePersonnel } from '../schema/leave-management'
+
+export type LeaveAccessRole =
+	| 'admin'
+	| 'commander'
+	| 'agency'
+	| 'personnel'
+	| 'none'
+
+export interface LeaveAccess {
+	role: LeaveAccessRole
+	isAdmin: boolean
+	/** Là chỉ huy CQ của ít nhất 1 đơn vị */
+	isCommander: boolean
+	/** Tài khoản Cơ quan quản lý (Cán bộ / Quân lực) */
+	isAgency: boolean
+	/** Có hồ sơ quân nhân liên kết */
+	isPersonnel: boolean
+	/** Được lập đề xuất phép (admin / chỉ huy / quân nhân, không áp dụng CQQL) */
+	canPropose: boolean
+	managementArea: string | null
+	/** Đơn vị được phụ trách (leave_units.id); admin = [] nghĩa là tất cả */
+	unitIds: number[]
+	/** Tên đơn vị phụ trách */
+	unitNames: string[]
+}
+
+/** Tính quyền leave cho user hiện tại (dùng trong API khác) */
+export async function resolveLeaveAccess(
+	userId: number,
+	isSuperAdmin: boolean
+): Promise<LeaveAccess> {
+	if (isSuperAdmin) {
+		return {
+			role: 'admin',
+			isAdmin: true,
+			isCommander: true,
+			isAgency: true,
+			isPersonnel: false,
+			canPropose: true,
+			managementArea: null,
+			unitIds: [],
+			unitNames: []
+		}
+	}
+
+	const asUnitCmd = await orm
+		.select()
+		.from(leaveUnits)
+		.where(eq(leaveUnits.commanderUserId, userId))
+	const account = await orm
+		.select({
+			position: users.position,
+			managementArea: users.managementArea
+		})
+		.from(users)
+		.where(eq(users.id, userId))
+		.limit(1)
+	const isAgency = account[0]?.position === 'Cơ quan quản lý'
+	const managementArea = account[0]?.managementArea ?? null
+
+	const unitIds = [
+		...new Set(
+			asUnitCmd.map((u) => u.id).filter((id): id is number => id != null)
+		)
+	]
+	const unitNames = asUnitCmd.map((u) => u.name)
+
+	// Cũng coi là chỉ huy nếu còn gán trên hồ sơ QN (dữ liệu cũ)
+	const asPersCmd = await orm
+		.select({ unitId: leavePersonnel.unitId })
+		.from(leavePersonnel)
+		.where(eq(leavePersonnel.commanderUserId, userId))
+	for (const p of asPersCmd) {
+		if (p.unitId != null && !unitIds.includes(p.unitId)) {
+			unitIds.push(p.unitId)
+		}
+	}
+	const isCommander = unitIds.length > 0
+	if (isAgency && managementArea) {
+		const managedUnits = await orm
+			.select({ id: leaveUnits.id, name: leaveUnits.name })
+			.from(leaveUnits)
+			.where(eq(leaveUnits.managementArea, managementArea))
+		for (const unit of managedUnits) {
+			if (!unitIds.includes(unit.id)) unitIds.push(unit.id)
+			if (!unitNames.includes(unit.name)) unitNames.push(unit.name)
+		}
+	}
+
+	const myPersonnel = await orm
+		.select({ id: leavePersonnel.id })
+		.from(leavePersonnel)
+		.where(eq(leavePersonnel.userId, userId))
+		.limit(1)
+
+	const isPersonnel = !!myPersonnel[0]
+
+	let role: LeaveAccessRole = 'none'
+	if (isAgency) role = 'agency'
+	else if (isCommander) role = 'commander'
+	else if (isPersonnel) role = 'personnel'
+
+	return {
+		role,
+		isAdmin: false,
+		isCommander,
+		isAgency,
+		isPersonnel,
+		canPropose: (isCommander || isPersonnel) && !isAgency,
+		managementArea,
+		unitIds,
+		unitNames
+	}
+}
+
+export const GetLeaveMyAccess = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/my-access'
+	},
+	async (): Promise<{ data: LeaveAccess }> => {
+		const auth = getAuthData()!
+		const uid = Number(auth.userID)
+		const data = await resolveLeaveAccess(uid, !!auth.isSuperAdmin)
+		// super admin: check if also has personnel
+		if (data.isAdmin) {
+			const p = await orm
+				.select({ id: leavePersonnel.id })
+				.from(leavePersonnel)
+				.where(eq(leavePersonnel.userId, uid))
+				.limit(1)
+			return {
+				data: {
+					...data,
+					isPersonnel: !!p[0]
+				}
+			}
+		}
+		return { data }
+	}
+)

--- a/apps/api/leave-management/accounts.ts
+++ b/apps/api/leave-management/accounts.ts
@@ -1,0 +1,106 @@
+import { api, APIError } from 'encore.dev/api'
+import { eq } from 'drizzle-orm'
+import { getAuthData } from '~encore/auth'
+import orm from '../database'
+import { users } from '../schema/users'
+import { leavePersonnel, leaveUnits } from '../schema/leave-management'
+
+type LeaveAccountKind = 'personnel' | 'commander' | 'management'
+
+export const AssignLeaveAccount = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/accounts/assign'
+	},
+	async (body: {
+		userId: number
+		kind: LeaveAccountKind
+		personnelId?: number
+		unitId?: number
+		managementArea?: 'cán_bộ' | 'quân_lực'
+	}): Promise<{ ok: boolean }> => {
+		if (!getAuthData()?.isSuperAdmin) {
+			throw APIError.permissionDenied(
+				'Chỉ admin được gán loại tài khoản phép'
+			)
+		}
+		const user = await orm
+			.select()
+			.from(users)
+			.where(eq(users.id, body.userId))
+			.limit(1)
+		if (!user[0]) throw APIError.notFound('Không tìm thấy tài khoản')
+
+		if (body.kind === 'personnel') {
+			if (!body.personnelId)
+				throw APIError.invalidArgument('Chọn quân nhân')
+			const p = await orm
+				.select()
+				.from(leavePersonnel)
+				.where(eq(leavePersonnel.id, body.personnelId))
+				.limit(1)
+			if (!p[0]) throw APIError.notFound('Không tìm thấy quân nhân')
+			if (p[0].userId && p[0].userId !== body.userId) {
+				throw APIError.alreadyExists('Quân nhân đã có tài khoản')
+			}
+			await orm
+				.update(leavePersonnel)
+				.set({ userId: body.userId, email: p[0].email })
+				.where(eq(leavePersonnel.id, body.personnelId))
+			await orm
+				.update(users)
+				.set({
+					position: 'Quân nhân',
+					leaveUnitId: p[0].unitId,
+					managementArea: p[0].managementArea
+				})
+				.where(eq(users.id, body.userId))
+		} else if (body.kind === 'commander') {
+			if (!body.unitId)
+				throw APIError.invalidArgument('Chọn cơ quan chỉ huy')
+			const u = await orm
+				.select()
+				.from(leaveUnits)
+				.where(eq(leaveUnits.id, body.unitId))
+				.limit(1)
+			if (!u[0]) throw APIError.notFound('Không tìm thấy cơ quan')
+			await orm
+				.update(leaveUnits)
+				.set({
+					commanderUserId: body.userId,
+					commanderName: user[0].displayName
+				})
+				.where(eq(leaveUnits.id, body.unitId))
+			await orm
+				.update(users)
+				.set({
+					position: 'Chỉ huy cơ quan',
+					leaveUnitId: body.unitId,
+					managementArea: u[0].managementArea
+				})
+				.where(eq(users.id, body.userId))
+			await orm
+				.update(leavePersonnel)
+				.set({
+					commanderUserId: body.userId,
+					commanderName: user[0].displayName
+				})
+				.where(eq(leavePersonnel.unitId, body.unitId))
+		} else {
+			if (!body.managementArea) {
+				throw APIError.invalidArgument('Chọn Cán bộ hoặc Quân lực')
+			}
+			await orm
+				.update(users)
+				.set({
+					position: 'Cơ quan quản lý',
+					leaveUnitId: null,
+					managementArea: body.managementArea
+				})
+				.where(eq(users.id, body.userId))
+		}
+		return { ok: true }
+	}
+)

--- a/apps/api/leave-management/alerts.ts
+++ b/apps/api/leave-management/alerts.ts
@@ -1,0 +1,295 @@
+/**
+ * Thông báo in-app: chỉ huy / CQQL / người đề xuất
+ * + chuông (notifications) + leave_alerts
+ */
+import { api, APIError, Query } from 'encore.dev/api'
+import { and, desc, eq, isNull, sql } from 'drizzle-orm'
+import { v4 as uuidv4 } from 'uuid'
+import log from 'encore.dev/log'
+import { getAuthData } from '~encore/auth'
+import orm from '../database'
+import { leaveAlerts, leaveRequests } from '../schema/leave-management'
+import { users } from '../schema/users'
+import { notifications } from '../schema/notifications'
+import { nowIso } from './helpers'
+
+export type LeaveAlertKind =
+	| 'NEED_COMMANDER'
+	| 'NEED_AGENCY'
+	| 'DECIDED'
+	| 'RETURNED'
+
+export interface LeaveAlertResponse {
+	id: number
+	createdAt: string
+	userId: number
+	requestId: number
+	kind: LeaveAlertKind
+	title: string
+	message: string
+	readAt: string | null
+	/** Snapshot ngắn từ đơn */
+	personnelName?: string | null
+	personnelCode?: string | null
+	status?: string | null
+	totalDays?: number | null
+	startDate?: string | null
+	endDate?: string | null
+}
+
+function mapAlert(
+	a: typeof leaveAlerts.$inferSelect,
+	extra?: Partial<LeaveAlertResponse>
+): LeaveAlertResponse {
+	return {
+		id: a.id,
+		createdAt: a.createdAt ?? '',
+		userId: a.userId,
+		requestId: a.requestId,
+		kind: a.kind as LeaveAlertKind,
+		title: a.title,
+		message: a.message,
+		readAt: a.readAt,
+		...extra
+	}
+}
+
+/** Tạo alert + chuông notification cho 1 user (không spam trùng unread cùng request+kind) */
+export async function createLeaveAlert(opts: {
+	userId: number
+	requestId: number
+	kind: LeaveAlertKind
+	title: string
+	message: string
+}): Promise<void> {
+	if (!opts.userId || opts.userId <= 0) return
+	const existing = await orm
+		.select({ id: leaveAlerts.id })
+		.from(leaveAlerts)
+		.where(
+			and(
+				eq(leaveAlerts.userId, opts.userId),
+				eq(leaveAlerts.requestId, opts.requestId),
+				eq(leaveAlerts.kind, opts.kind),
+				isNull(leaveAlerts.readAt)
+			)
+		)
+		.limit(1)
+	if (existing[0]) return
+	await orm.insert(leaveAlerts).values({
+		userId: opts.userId,
+		requestId: opts.requestId,
+		kind: opts.kind,
+		title: opts.title,
+		message: opts.message
+	})
+
+	// Chuông thông báo (bảng notifications)
+	try {
+		await orm.insert(notifications).values({
+			id: uuidv4(),
+			notificationType: 'leave',
+			title: opts.title,
+			message: opts.message,
+			recipientId: opts.userId,
+			isBatch: false,
+			totalCount: 1,
+			batchKey: `leave:${opts.requestId}:${opts.kind}`
+		})
+	} catch (e) {
+		log.warn('createLeaveAlert: bell notification failed', {
+			err: String((e as Error)?.message || e),
+			userId: opts.userId
+		})
+	}
+}
+
+/** Gửi alert tới mọi super admin (CQQL) */
+export async function alertSuperAdmins(opts: {
+	requestId: number
+	kind: LeaveAlertKind
+	title: string
+	message: string
+}): Promise<void> {
+	const admins = await orm
+		.select({ id: users.id })
+		.from(users)
+		.where(eq(users.isSuperUser, true))
+	for (const a of admins) {
+		await createLeaveAlert({
+			userId: a.id,
+			requestId: opts.requestId,
+			kind: opts.kind,
+			title: opts.title,
+			message: opts.message
+		})
+	}
+}
+
+export const ListLeaveAlerts = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/alerts'
+	},
+	async (q: {
+		unreadOnly?: Query<boolean>
+		limit?: Query<number>
+	}): Promise<{ data: LeaveAlertResponse[] }> => {
+		const auth = getAuthData()!
+		const uid = Number(auth.userID)
+		const unreadOnly = String(q.unreadOnly ?? 'false') === 'true'
+		const limit = Math.min(100, Math.max(1, Number(q.limit) || 30))
+
+		const conditions = [eq(leaveAlerts.userId, uid)]
+		if (unreadOnly) conditions.push(isNull(leaveAlerts.readAt))
+
+		const rows = await orm
+			.select()
+			.from(leaveAlerts)
+			.where(and(...conditions))
+			.orderBy(desc(leaveAlerts.id))
+			.limit(limit)
+
+		const reqIds = [...new Set(rows.map((r) => r.requestId))]
+		const reqMap = new Map<number, typeof leaveRequests.$inferSelect>()
+		if (reqIds.length) {
+			for (const id of reqIds) {
+				const r = await orm
+					.select()
+					.from(leaveRequests)
+					.where(eq(leaveRequests.id, id))
+					.limit(1)
+				if (r[0]) reqMap.set(id, r[0])
+			}
+		}
+
+		return {
+			data: rows.map((a) => {
+				const req = reqMap.get(a.requestId)
+				return mapAlert(a, {
+					personnelName: req?.personnelName,
+					personnelCode: req?.personnelCode,
+					status: req?.status,
+					totalDays: req?.totalDays,
+					startDate: req?.startDate,
+					endDate: req?.endDate
+				})
+			})
+		}
+	}
+)
+
+export const GetLeaveAlertCount = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/alerts/unread-count'
+	},
+	async (): Promise<{ data: { count: number; pendingApprove: number } }> => {
+		const auth = getAuthData()!
+		const uid = Number(auth.userID)
+		const isAdmin = !!auth.isSuperAdmin
+
+		const unread = await orm
+			.select({ c: sql<number>`count(*)` })
+			.from(leaveAlerts)
+			.where(and(eq(leaveAlerts.userId, uid), isNull(leaveAlerts.readAt)))
+
+		// Đơn chờ tôi duyệt (chỉ huy hoặc CQQL)
+		let pendingApprove = 0
+		if (isAdmin) {
+			const agency = await orm
+				.select({ c: sql<number>`count(*)` })
+				.from(leaveRequests)
+				.where(eq(leaveRequests.status, 'PENDING_AGENCY'))
+			pendingApprove += Number(agency[0]?.c || 0)
+		}
+		const cmd = await orm
+			.select({ c: sql<number>`count(*)` })
+			.from(leaveRequests)
+			.where(
+				and(
+					eq(leaveRequests.commanderUserId, uid),
+					eq(leaveRequests.status, 'PENDING_COMMANDER')
+				)
+			)
+		// admin also sees PENDING as commander step
+		const cmdPending = await orm
+			.select({ c: sql<number>`count(*)` })
+			.from(leaveRequests)
+			.where(
+				and(
+					eq(leaveRequests.commanderUserId, uid),
+					eq(leaveRequests.status, 'PENDING')
+				)
+			)
+		pendingApprove += Number(cmd[0]?.c || 0) + Number(cmdPending[0]?.c || 0)
+		// Super admin count PENDING_COMMANDER only in agency count already separate;
+		// for badge we want "what I need to act on"
+		if (isAdmin) {
+			// already added PENDING_AGENCY; commander ones only if assigned
+		}
+
+		return {
+			data: {
+				count: Number(unread[0]?.c || 0),
+				pendingApprove
+			}
+		}
+	}
+)
+
+export const MarkLeaveAlertsRead = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/alerts/mark-read'
+	},
+	async (body: {
+		ids?: number[]
+		requestId?: number
+		all?: boolean
+	}): Promise<{ ok: boolean }> => {
+		const auth = getAuthData()!
+		const uid = Number(auth.userID)
+		const ts = nowIso()
+
+		if (body.all) {
+			await orm
+				.update(leaveAlerts)
+				.set({ readAt: ts })
+				.where(
+					and(eq(leaveAlerts.userId, uid), isNull(leaveAlerts.readAt))
+				)
+			return { ok: true }
+		}
+		if (body.requestId != null) {
+			await orm
+				.update(leaveAlerts)
+				.set({ readAt: ts })
+				.where(
+					and(
+						eq(leaveAlerts.userId, uid),
+						eq(leaveAlerts.requestId, body.requestId),
+						isNull(leaveAlerts.readAt)
+					)
+				)
+			return { ok: true }
+		}
+		const ids = body.ids || []
+		if (!ids.length) {
+			throw APIError.invalidArgument('Cần ids, requestId hoặc all')
+		}
+		for (const id of ids) {
+			await orm
+				.update(leaveAlerts)
+				.set({ readAt: ts })
+				.where(and(eq(leaveAlerts.id, id), eq(leaveAlerts.userId, uid)))
+		}
+		return { ok: true }
+	}
+)

--- a/apps/api/leave-management/audit.ts
+++ b/apps/api/leave-management/audit.ts
@@ -1,0 +1,38 @@
+import { getAuthData } from '~encore/auth'
+import { api, Query } from 'encore.dev/api'
+import { desc, eq } from 'drizzle-orm'
+import orm from '../database'
+import { leaveAuditLogs } from '../schema'
+
+export async function writeLeaveAudit(input: {
+	action: string
+	entityType: string
+	entityId?: number | null
+	details?: unknown
+}) {
+	const userId = Number(getAuthData()?.userID || 0) || null
+	await orm.insert(leaveAuditLogs).values({
+		userId,
+		action: input.action,
+		entityType: input.entityType,
+		entityId: input.entityId ?? null,
+		details: input.details == null ? null : JSON.stringify(input.details)
+	})
+}
+
+export const ListLeaveAuditLogs = api(
+	{ auth: true, expose: true, method: 'GET', path: '/leave/audit-logs' },
+	async (q: { entityType?: Query<string>; limit?: Query<number> }) => {
+		const rows = await orm
+			.select()
+			.from(leaveAuditLogs)
+			.where(
+				q.entityType
+					? eq(leaveAuditLogs.entityType, String(q.entityType))
+					: undefined
+			)
+			.orderBy(desc(leaveAuditLogs.id))
+			.limit(Math.min(500, Math.max(1, Number(q.limit || 100))))
+		return { data: rows }
+	}
+)

--- a/apps/api/leave-management/batches.ts
+++ b/apps/api/leave-management/batches.ts
@@ -1,0 +1,356 @@
+/**
+ * Quản lý đợt nghỉ phép (leave batches)
+ */
+import { api, APIError, Query } from 'encore.dev/api'
+import { and, desc, eq, inArray } from 'drizzle-orm'
+import orm from '../database'
+import { leaveBatches, leaveRequests } from '../schema'
+import { resolveLeaveAccess } from './access'
+import { writeLeaveAudit } from './audit'
+
+export interface LeaveBatchResponse {
+	id: number
+	createdAt: string
+	updatedAt: string
+	requestId: number
+	personnelId: number | null
+	personnelCode: string | null
+	personnelName: string | null
+	objectType: string
+	leaveType: string
+	batchIndex: number
+	batchLabel: string
+	startDate: string | null
+	endDate: string | null
+	totalDays: number
+	note: string | null
+	createdByUserId: number | null
+}
+
+function mapRow(r: typeof leaveBatches.$inferSelect): LeaveBatchResponse {
+	return {
+		id: r.id,
+		createdAt: r.createdAt ?? '',
+		updatedAt: r.updatedAt ?? '',
+		requestId: r.requestId,
+		personnelId: r.personnelId,
+		personnelCode: r.personnelCode,
+		personnelName: r.personnelName,
+		objectType: r.objectType,
+		leaveType: r.leaveType,
+		batchIndex: r.batchIndex,
+		batchLabel: r.batchLabel,
+		startDate: r.startDate,
+		endDate: r.endDate,
+		totalDays: r.totalDays,
+		note: r.note,
+		createdByUserId: r.createdByUserId
+	}
+}
+
+export const CreateLeaveBatch = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/batches'
+	},
+	async (body: {
+		requestId: number
+		personnelId?: number | null
+		personnelCode?: string | null
+		personnelName?: string | null
+		objectType: string
+		leaveType: string
+		batchIndex?: number
+		batchLabel?: string
+		startDate?: string | null
+		endDate?: string | null
+		totalDays?: number
+		note?: string | null
+	}): Promise<{ data: LeaveBatchResponse }> => {
+		const req = await orm
+			.select()
+			.from(leaveRequests)
+			.where(eq(leaveRequests.id, body.requestId))
+			.limit(1)
+		if (!req[0]) throw APIError.notFound('Không tìm thấy đơn phép')
+
+		const inserted = await orm
+			.insert(leaveBatches)
+			.values({
+				requestId: body.requestId,
+				personnelId: body.personnelId ?? req[0].personnelId ?? null,
+				personnelCode:
+					body.personnelCode ?? req[0].personnelCode ?? null,
+				personnelName:
+					body.personnelName ?? req[0].personnelName ?? null,
+				objectType: body.objectType,
+				leaveType: body.leaveType,
+				batchIndex: body.batchIndex ?? 1,
+				batchLabel: body.batchLabel || '',
+				startDate: body.startDate ?? req[0].startDate ?? null,
+				endDate: body.endDate ?? req[0].endDate ?? null,
+				totalDays: body.totalDays ?? req[0].totalDays ?? 0,
+				note: body.note ?? null,
+				createdByUserId:
+					Number((await getAuthData())?.userID || 0) || null
+			})
+			.returning()
+		await writeLeaveAudit({
+			action: 'CREATE',
+			entityType: 'LEAVE_BATCH',
+			entityId: inserted[0]!.id,
+			details: { requestId: body.requestId, batchLabel: body.batchLabel }
+		})
+
+		return { data: mapRow(inserted[0]!) }
+	}
+)
+
+import { getAuthData } from '~encore/auth'
+
+export const ListLeaveBatches = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/batches'
+	},
+	async (q: {
+		requestId?: Query<number>
+	}): Promise<{ data: LeaveBatchResponse[] }> => {
+		const auth = getAuthData()!
+		const access = await resolveLeaveAccess(
+			Number(auth.userID),
+			!!auth.isSuperAdmin
+		)
+		const conditions = []
+		if (!access.isAdmin) {
+			if (!access.unitIds.length) return { data: [] }
+			const managedRequests = await orm
+				.select({ id: leaveRequests.id })
+				.from(leaveRequests)
+				.where(inArray(leaveRequests.unitId, access.unitIds))
+			if (!managedRequests.length) return { data: [] }
+			conditions.push(
+				inArray(
+					leaveBatches.requestId,
+					managedRequests.map((r) => r.id)
+				)
+			)
+		}
+		if (q.requestId) {
+			conditions.push(eq(leaveBatches.requestId, Number(q.requestId)))
+		}
+		const rows = await orm
+			.select()
+			.from(leaveBatches)
+			.where(conditions.length ? and(...conditions) : undefined)
+			.orderBy(desc(leaveBatches.id))
+		const mapped = rows.map(mapRow)
+		const grouped = new Map<string, LeaveBatchResponse>()
+		for (const row of mapped) {
+			const isClass =
+				row.batchLabel.startsWith('Đợt nghỉ ') &&
+				row.personnelCode != null
+			const key = isClass
+				? [
+						'class',
+						row.personnelName ?? '',
+						row.leaveType,
+						row.startDate ?? '',
+						row.endDate ?? '',
+						row.totalDays
+					].join(':')
+				: `batch:${row.id}`
+			if (!grouped.has(key)) {
+				grouped.set(
+					key,
+					isClass
+						? { ...row, personnelId: null, personnelCode: null }
+						: row
+				)
+			}
+		}
+		const result = [...grouped.values()]
+		await writeLeaveAudit({
+			action: 'VIEW',
+			entityType: 'LEAVE_BATCH',
+			details: { requestId: q.requestId ?? null, count: result.length }
+		})
+		return { data: result }
+	}
+)
+
+export const GetLeaveBatch = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/batches/:id'
+	},
+	async ({ id }: { id: number }): Promise<{ data: LeaveBatchResponse }> => {
+		const auth = getAuthData()!
+		const access = await resolveLeaveAccess(
+			Number(auth.userID),
+			!!auth.isSuperAdmin
+		)
+		const rows = await orm
+			.select()
+			.from(leaveBatches)
+			.where(eq(leaveBatches.id, id))
+			.limit(1)
+		if (!rows[0]) throw APIError.notFound('Không tìm thấy đợt nghỉ phép')
+		if (!access.isAdmin) {
+			const request = await orm
+				.select({ unitId: leaveRequests.unitId })
+				.from(leaveRequests)
+				.where(eq(leaveRequests.id, rows[0].requestId))
+				.limit(1)
+			if (
+				request[0]?.unitId == null ||
+				!access.unitIds.includes(request[0].unitId)
+			) {
+				throw APIError.permissionDenied(
+					'Không có quyền xem đợt nghỉ này'
+				)
+			}
+		}
+		return { data: mapRow(rows[0]) }
+	}
+)
+
+export const UpdateLeaveBatch = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'PATCH',
+		path: '/leave/batches/:id'
+	},
+	async ({
+		id,
+		startDate,
+		endDate,
+		totalDays,
+		batchLabel,
+		note
+	}: {
+		id: number
+		startDate?: string | null
+		endDate?: string | null
+		totalDays?: number
+		batchLabel?: string
+		note?: string | null
+	}): Promise<{ data: LeaveBatchResponse }> => {
+		const existing = await orm
+			.select()
+			.from(leaveBatches)
+			.where(eq(leaveBatches.id, id))
+			.limit(1)
+		if (!existing[0])
+			throw APIError.notFound('Không tìm thấy đợt nghỉ phép')
+
+		const updated = await orm
+			.update(leaveBatches)
+			.set({
+				...(startDate !== undefined
+					? { startDate: startDate || null }
+					: {}),
+				...(endDate !== undefined ? { endDate: endDate || null } : {}),
+				...(totalDays !== undefined ? { totalDays } : {}),
+				...(batchLabel !== undefined
+					? { batchLabel: batchLabel || '' }
+					: {}),
+				...(note !== undefined ? { note: note || null } : {})
+			})
+			.where(eq(leaveBatches.id, id))
+			.returning()
+		await writeLeaveAudit({
+			action: 'UPDATE',
+			entityType: 'LEAVE_BATCH',
+			entityId: id,
+			details: { batchLabel, startDate, endDate, totalDays }
+		})
+		return { data: mapRow(updated[0]!) }
+	}
+)
+
+export const DeleteLeaveBatch = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'DELETE',
+		path: '/leave/batches/:id'
+	},
+	async ({ id }: { id: number }): Promise<{ ok: boolean }> => {
+		const res = await orm
+			.delete(leaveBatches)
+			.where(eq(leaveBatches.id, id))
+			.returning()
+		if (!res[0]) throw APIError.notFound('Không tìm thấy đợt nghỉ phép')
+		await writeLeaveAudit({
+			action: 'DELETE',
+			entityType: 'LEAVE_BATCH',
+			entityId: id,
+			details: { requestId: res[0].requestId }
+		})
+		return { ok: true }
+	}
+)
+
+export const CreateLeaveBatchForRequest = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/requests/:id/batches'
+	},
+	async (
+		{ id }: { id: number },
+		body: {
+			personnelId?: number | null
+			personnelCode?: string | null
+			personnelName?: string | null
+			objectType: string
+			leaveType: string
+			batchIndex?: number
+			batchLabel?: string
+			startDate?: string | null
+			endDate?: string | null
+			totalDays?: number
+			note?: string | null
+		}
+	): Promise<{ data: LeaveBatchResponse }> => {
+		const req = await orm
+			.select()
+			.from(leaveRequests)
+			.where(eq(leaveRequests.id, id))
+			.limit(1)
+		if (!req[0]) throw APIError.notFound('Không tìm thấy đơn phép')
+
+		const inserted = await orm
+			.insert(leaveBatches)
+			.values({
+				requestId: id,
+				personnelId: body.personnelId ?? req[0].personnelId ?? null,
+				personnelCode:
+					body.personnelCode ?? req[0].personnelCode ?? null,
+				personnelName:
+					body.personnelName ?? req[0].personnelName ?? null,
+				objectType: body.objectType,
+				leaveType: body.leaveType,
+				batchIndex: body.batchIndex ?? 1,
+				batchLabel: body.batchLabel || '',
+				startDate: body.startDate ?? req[0].startDate ?? null,
+				endDate: body.endDate ?? req[0].endDate ?? null,
+				totalDays: body.totalDays ?? req[0].totalDays ?? 0,
+				note: body.note ?? null,
+				createdByUserId:
+					Number((await getAuthData())?.userID || 0) || null
+			})
+			.returning()
+
+		return { data: mapRow(inserted[0]!) }
+	}
+)

--- a/apps/api/leave-management/classes.ts
+++ b/apps/api/leave-management/classes.ts
@@ -1,0 +1,94 @@
+import { api, APIError, Query } from 'encore.dev/api'
+import { and, eq, sql } from 'drizzle-orm'
+import orm from '../database'
+import { leaveClasses, leaveUnits } from '../schema/leave-management'
+
+export interface LeaveClassResponse {
+	id: number
+	unitId: number
+	unitName: string
+	name: string
+	isActive: boolean
+}
+
+export const ListLeaveClasses = api(
+	{ auth: true, expose: true, method: 'GET', path: '/leave/classes' },
+	async (q: {
+		unitId?: Query<number>
+	}): Promise<{ data: LeaveClassResponse[] }> => {
+		const rows = await orm
+			.select({
+				id: leaveClasses.id,
+				unitId: leaveClasses.unitId,
+				unitName: leaveUnits.name,
+				name: leaveClasses.name,
+				isActive: leaveClasses.isActive
+			})
+			.from(leaveClasses)
+			.innerJoin(leaveUnits, eq(leaveClasses.unitId, leaveUnits.id))
+			.where(
+				q.unitId != null
+					? eq(leaveClasses.unitId, Number(q.unitId))
+					: undefined
+			)
+			.orderBy(leaveUnits.name, leaveClasses.name)
+		return { data: rows }
+	}
+)
+
+export const CreateLeaveClass = api(
+	{ auth: true, expose: true, method: 'POST', path: '/leave/classes' },
+	async (body: {
+		unitId: number
+		name: string
+	}): Promise<{ data: LeaveClassResponse }> => {
+		const name = body.name?.trim().toUpperCase()
+		if (!/^A(?:10|[1-9])$/.test(name || '')) {
+			throw APIError.invalidArgument('Tên lớp phải từ A1 đến A10')
+		}
+		const unit = await orm
+			.select()
+			.from(leaveUnits)
+			.where(
+				and(
+					eq(leaveUnits.id, body.unitId),
+					eq(leaveUnits.level, 'company')
+				)
+			)
+			.limit(1)
+		if (!unit[0])
+			throw APIError.invalidArgument('Lớp chỉ được tạo trong đại đội')
+		const count = await orm
+			.select({ value: sql<number>`count(*)` })
+			.from(leaveClasses)
+			.where(eq(leaveClasses.unitId, body.unitId))
+		if (Number(count[0]?.value || 0) >= 2) {
+			throw APIError.failedPrecondition(
+				'Mỗi đại đội chỉ được duy trì tối đa 2 lớp'
+			)
+		}
+		const row = (
+			await orm
+				.insert(leaveClasses)
+				.values({ unitId: body.unitId, name })
+				.returning()
+		)[0]!
+		return {
+			data: {
+				id: row.id,
+				unitId: row.unitId,
+				unitName: unit[0].name,
+				name: row.name,
+				isActive: row.isActive
+			}
+		}
+	}
+)
+
+export const DeleteLeaveClass = api(
+	{ auth: true, expose: true, method: 'DELETE', path: '/leave/classes/:id' },
+	async ({ id }: { id: number }): Promise<{ ok: boolean }> => {
+		await orm.delete(leaveClasses).where(eq(leaveClasses.id, id))
+		return { ok: true }
+	}
+)

--- a/apps/api/leave-management/helpers.ts
+++ b/apps/api/leave-management/helpers.ts
@@ -1,0 +1,285 @@
+import type { LeaveObjectType } from '../schema/leave-management'
+
+/** Mã chuẩn theo tài liệu */
+export const CANONICAL_OBJECT_TYPES: LeaveObjectType[] = [
+	'SQ',
+	'QNCN',
+	'CNQP',
+	'VCQP',
+	'HSQBS',
+	'HV',
+	'KHAC'
+]
+
+/** Map legacy → chuẩn */
+const LEGACY_OBJECT_MAP: Record<string, LeaveObjectType> = {
+	QN: 'SQ',
+	CN: 'CNQP',
+	HSQ: 'HSQBS',
+	BS: 'HSQBS',
+	SQ: 'SQ',
+	QNCN: 'QNCN',
+	CNQP: 'CNQP',
+	VCQP: 'VCQP',
+	HSQBS: 'HSQBS',
+	HV: 'HV',
+	KHAC: 'KHAC'
+}
+
+/** Đối tượng được nghỉ thêm (theo tiêu chuẩn phép thêm) */
+export const EXTRA_ELIGIBLE: LeaveObjectType[] = [
+	'SQ',
+	'QNCN',
+	'CNQP',
+	'VCQP',
+	// legacy
+	'QN',
+	'CN'
+]
+
+/** Đối tượng phép đặc biệt */
+export const SPECIAL_ELIGIBLE: LeaveObjectType[] = [
+	'SQ',
+	'QNCN',
+	'CNQP',
+	'VCQP',
+	'QN',
+	'CN'
+]
+
+export const OBJECT_TYPE_LABELS: Record<string, string> = {
+	SQ: 'Sỹ quan',
+	QNCN: 'Quân nhân chuyên nghiệp',
+	CNQP: 'Công nhân quốc phòng',
+	VCQP: 'Viên chức quốc phòng',
+	HSQBS: 'Hạ sỹ quan, Binh sỹ',
+	HV: 'Học viên',
+	KHAC: 'Đối tượng khác',
+	// legacy labels
+	QN: 'Sỹ quan',
+	CN: 'Công nhân quốc phòng',
+	HSQ: 'Hạ sỹ quan, Binh sỹ',
+	BS: 'Hạ sỹ quan, Binh sỹ'
+}
+
+/**
+ * Lý do nghỉ thêm — fallback cứng (MS 01–06).
+ * Ưu tiên đọc từ bảng leave_extra_standards khi có.
+ * Code chuẩn: '01'..'06'; giữ alias semantic cũ để tương thích dữ liệu.
+ */
+export const EXTRA_10_REASONS = [
+	{
+		code: '01',
+		label: 'Đóng quân ở đơn vị xa nơi đăng ký nghỉ phép (nơi cư trú của vợ hoặc chồng; con đẻ, con nuôi hợp pháp; bố, mẹ, người nuôi dưỡng hợp pháp của bản thân, của vợ hoặc của chồng) cách từ 500 km trở lên'
+	},
+	{
+		code: '02',
+		label: 'Đóng quân ở địa bàn có điều kiện kinh tế xã hội đặc biệt khó khăn; địa bàn vùng sâu, vùng xa, vùng biên giới cách nơi đăng ký nghỉ phép (nơi cư trú của vợ hoặc chồng; con đẻ, con nuôi hợp pháp; bố, mẹ, người nuôi dưỡng hợp pháp của bản thân, của vợ hoặc của chồng) từ 300 km trở lên.'
+	},
+	{
+		code: '03',
+		label: 'Đóng quân tại các đảo thuộc quần đảo Trường Sa và Nhà giàn DK'
+	},
+	// alias cũ
+	{
+		code: 'DISTANCE_GTE_500',
+		label: 'Đơn vị đóng quân cách nơi đăng ký nghỉ phép từ 500km trở lên'
+	},
+	{
+		code: 'DIFFICULT_AREA_GTE_300',
+		label: 'Đóng quân ở địa bàn KTXH đặc biệt khó khăn, vùng sâu, vùng xa, vùng biên giới cách nơi đăng ký nghỉ phép từ 300km trở lên'
+	},
+	{
+		code: 'ISLAND_TRUONG_SA_DK',
+		label: 'Đóng quân tại các đảo thuộc quần đảo Trường Sa và Nhà giàn DK'
+	}
+] as const
+
+export const EXTRA_5_REASONS = [
+	{
+		code: '04',
+		label: 'Đơn vị đóng quân cách nơi đăng ký nghỉ phép (nơi cư trú của vợ hoặc chồng; con đẻ, con nuôi hợp pháp; bố, mẹ, người nuôi dưỡng hợp pháp của bản thân, của vợ hoặc của chồng) từ 300 km đến dưới 500 km'
+	},
+	{
+		code: '05',
+		label: 'Đóng quân ở địa bàn vùng sâu, vùng xa, vùng biên giới cách nơi đăng ký nghỉ phép (nơi cư trú của vợ hoặc chồng; con đẻ, con nuôi hợp pháp; bố, mẹ, người nuôi dưỡng hợp pháp của bản thân, của vợ hoặc của chồng) từ 200 km đến dưới 300 km.'
+	},
+	{
+		code: '06',
+		label: 'Đóng quân tại các đảo được hưởng phụ cấp khu vực.'
+	},
+	// alias cũ
+	{
+		code: 'DISTANCE_300_500',
+		label: 'Đóng quân cách nơi đăng ký nghỉ phép từ 300km đến dưới 500km'
+	},
+	{
+		code: 'DIFFICULT_AREA_200_300',
+		label: 'Đóng quân ở địa bàn KTXH đặc biệt khó khăn, vùng sâu, vùng xa, vùng biên giới cách nơi đăng ký nghỉ phép từ 200km tới dưới 300km'
+	},
+	{
+		code: 'ISLAND_AREA_ALLOWANCE',
+		label: 'Đóng quân tại các đảo được hưởng phụ cấp khu vực'
+	}
+] as const
+
+export type Extra10Code = (typeof EXTRA_10_REASONS)[number]['code']
+export type Extra5Code = (typeof EXTRA_5_REASONS)[number]['code']
+
+/** Chuẩn hoá mã đối tượng (legacy → canonical) */
+export function normalizeObjectType(v: string): LeaveObjectType | null {
+	const key = String(v || '')
+		.trim()
+		.toUpperCase()
+	return (LEGACY_OBJECT_MAP[key] as LeaveObjectType) || null
+}
+
+export function isLeaveObjectType(v: string): v is LeaveObjectType {
+	return normalizeObjectType(v) != null
+}
+
+/**
+ * Tính thâm niên (năm) từ ngày nhập ngũ / tuyển dụng.
+ * Theo tài liệu: lấy tháng/năm bắt đầu nghỉ phép trừ tháng/năm tuyển dụng.
+ * @param asOf — mặc định hôm nay; khi đề xuất dùng startDate
+ */
+export function computeServiceYears(
+	enlistmentDate: string | null | undefined,
+	asOf: Date = new Date()
+): number {
+	if (!enlistmentDate) return 0
+	const d = new Date(enlistmentDate)
+	if (Number.isNaN(d.getTime())) return 0
+	let years = asOf.getFullYear() - d.getFullYear()
+	const m = asOf.getMonth() - d.getMonth()
+	if (m < 0 || (m === 0 && asOf.getDate() < d.getDate())) {
+		years -= 1
+	}
+	return Math.max(0, years)
+}
+
+/** Parse asOf từ chuỗi ngày YYYY-MM-DD */
+export function asOfFromDate(dateStr: string | null | undefined): Date {
+	if (!dateStr) return new Date()
+	const d = new Date(dateStr)
+	if (Number.isNaN(d.getTime())) return new Date()
+	return d
+}
+
+/**
+ * Quy định phép hằng năm (fallback cứng nếu DB thiếu rule):
+ * - HSQBS: 10 ngày
+ * - SQ/QNCN/CNQP/VCQP: <15 → 20; 15–25 → 25; ≥25 → 30
+ * - HV / KHAC: 0 (cấu hình trên DB)
+ */
+export function resolveAnnualBaseDays(
+	objectType: LeaveObjectType | string,
+	serviceYears: number
+): number {
+	const ot = normalizeObjectType(String(objectType)) || objectType
+	if (ot === 'HSQBS' || ot === 'HSQ' || ot === 'BS') return 10
+	if (ot === 'HV' || ot === 'KHAC') return 0
+	if (
+		ot === 'SQ' ||
+		ot === 'QNCN' ||
+		ot === 'CNQP' ||
+		ot === 'VCQP' ||
+		ot === 'QN' ||
+		ot === 'CN'
+	) {
+		if (serviceYears < 15) return 20
+		if (serviceYears < 25) return 25
+		return 30
+	}
+	return 0
+}
+
+export function canTakeExtraLeave(
+	objectType: LeaveObjectType | string
+): boolean {
+	const ot = normalizeObjectType(String(objectType))
+	if (!ot) return false
+	return (['SQ', 'QNCN', 'CNQP', 'VCQP'] as string[]).includes(ot)
+}
+
+export function validateExtraReasons(
+	extraDays: number,
+	reasons: string[]
+): string | null {
+	if (extraDays === 0) return null
+	if (extraDays !== 5 && extraDays !== 10) {
+		return 'Nghỉ thêm chỉ được chọn 5 hoặc 10 ngày'
+	}
+	if (!reasons.length) {
+		return 'Vui lòng chọn ít nhất một lý do nghỉ thêm'
+	}
+	const allowed =
+		extraDays === 10
+			? EXTRA_10_REASONS.map((r) => r.code)
+			: EXTRA_5_REASONS.map((r) => r.code)
+	const invalid = reasons.filter((c) => !allowed.includes(c as never))
+	if (invalid.length) {
+		return `Lý do nghỉ thêm không hợp lệ cho ${extraDays} ngày: ${invalid.join(', ')}`
+	}
+	return null
+}
+
+export const SPECIAL_MAX_DAYS = 10
+
+/** Lý do phép đặc biệt (theo quy định) */
+export const SPECIAL_REASONS = [
+	{
+		code: 'MARRIAGE',
+		label: 'Bản thân kết hôn, hoặc con đẻ / con nuôi hợp pháp kết hôn'
+	},
+	{
+		code: 'FAMILY_HARDSHIP',
+		label: 'Gia đình gặp khó khăn đột xuất do vợ hoặc chồng, con đẻ / con nuôi hợp pháp, bố mẹ / người nuôi dưỡng hợp pháp của bản thân, của vợ hoặc của chồng bị đau ốm nặng, tai nạn rủi ro, hy sinh, từ trần, hoặc bị thiệt hại nặng về tài sản do thiên tai, hỏa hoạn, dịch bệnh nguy hiểm gây ra'
+	}
+] as const
+
+export type SpecialReasonCode = (typeof SPECIAL_REASONS)[number]['code']
+
+export function canTakeSpecialLeave(
+	objectType: LeaveObjectType | string
+): boolean {
+	const ot = normalizeObjectType(String(objectType))
+	if (!ot) return false
+	return (['SQ', 'QNCN', 'CNQP', 'VCQP'] as string[]).includes(ot)
+}
+
+export function validateSpecialLeave(
+	objectType: LeaveObjectType | string,
+	specialDays: number,
+	reasons: string[]
+): string | null {
+	if (!canTakeSpecialLeave(objectType)) {
+		return 'Chỉ sỹ quan, QNCN, công nhân QP và viên chức QP được nghỉ phép đặc biệt'
+	}
+	if (
+		!Number.isFinite(specialDays) ||
+		specialDays < 1 ||
+		specialDays > SPECIAL_MAX_DAYS
+	) {
+		return `Phép đặc biệt mỗi lần không quá ${SPECIAL_MAX_DAYS} ngày (tối thiểu 1 ngày)`
+	}
+	if (!reasons.length) {
+		return 'Vui lòng chọn ít nhất một lý do phép đặc biệt'
+	}
+	const allowed = SPECIAL_REASONS.map((r) => r.code)
+	const invalid = reasons.filter((c) => !allowed.includes(c as never))
+	if (invalid.length) {
+		return `Lý do phép đặc biệt không hợp lệ: ${invalid.join(', ')}`
+	}
+	return null
+}
+
+export function nowIso(): string {
+	return new Date().toISOString()
+}
+
+export function objectTypeLabel(code: string | null | undefined): string {
+	if (!code) return ''
+	const n = normalizeObjectType(code) || code
+	return OBJECT_TYPE_LABELS[n] || OBJECT_TYPE_LABELS[code] || code
+}

--- a/apps/api/leave-management/index.ts
+++ b/apps/api/leave-management/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Phân hệ Quản lý phép
+ */
+export * from './personnel'
+export * from './localities'
+export * from './regulations'
+export * from './leaves'
+export * from './units'
+export * from './records'
+export * from './alerts'
+export * from './mail-api'
+export * from './batches'
+export * from './reports'
+export * from './positions'
+export * from './classes'
+export * from './accounts'

--- a/apps/api/leave-management/leaves.ts
+++ b/apps/api/leave-management/leaves.ts
@@ -1,0 +1,1576 @@
+/**
+ * Danh sách phép + đề xuất nghỉ phép
+ */
+import { api, APIError, Query } from 'encore.dev/api'
+import log from 'encore.dev/log'
+import { and, desc, eq, like, or } from 'drizzle-orm'
+import { getAuthData } from '~encore/auth'
+import orm from '../database'
+import {
+	leavePersonnel,
+	leaveRequests,
+	leaveRegulations,
+	leaveRecords,
+	type LeaveObjectType,
+	type LeaveRequestStatus,
+	type LeaveType
+} from '../schema/leave-management'
+import { leaveBatches } from '../schema/leave-batches'
+import {
+	asOfFromDate,
+	canTakeExtraLeave,
+	computeServiceYears,
+	isLeaveObjectType,
+	normalizeObjectType,
+	nowIso,
+	objectTypeLabel,
+	resolveAnnualBaseDays,
+	validateExtraReasons,
+	validateSpecialLeave,
+	SPECIAL_MAX_DAYS
+} from './helpers'
+import { resolveLocalityPath } from './localities'
+import { resolveLeaveAccess } from './access'
+import { users } from '../schema/users'
+import {
+	buildLeaveDecisionMail,
+	buildLeaveSubmittedMail,
+	looksLikeEmail,
+	sendLeaveMail
+} from './mail'
+import { alertSuperAdmins, createLeaveAlert } from './alerts'
+import { resolveUnitCommander } from './units'
+
+/**
+ * Email người nhận thông báo — ưu tiên users.email (đã cập nhật trên tài khoản).
+ * Fallback: leave_personnel.email · username dạng email.
+ */
+async function resolveUserEmail(
+	userId: number | null | undefined
+): Promise<string | null> {
+	if (userId == null || userId <= 0) return null
+	const u = await orm
+		.select()
+		.from(users)
+		.where(eq(users.id, userId))
+		.limit(1)
+	const row = u[0] as { email?: string | null; username?: string } | undefined
+	if (row?.email && looksLikeEmail(row.email)) {
+		return row.email.trim()
+	}
+	if (row?.username && looksLikeEmail(row.username)) {
+		return row.username.trim()
+	}
+	const p = await orm
+		.select()
+		.from(leavePersonnel)
+		.where(eq(leavePersonnel.userId, userId))
+		.limit(1)
+	if (p[0]?.email && looksLikeEmail(p[0].email)) {
+		return p[0].email.trim()
+	}
+	return null
+}
+
+/** Email quân nhân nhận kết quả duyệt: user liên kết hồ sơ / người đề xuất */
+async function resolvePersonnelNotifyEmail(
+	row: typeof leaveRequests.$inferSelect
+): Promise<string | null> {
+	// 1) User người đề xuất (tài khoản đăng nhập)
+	if (row.proposedByUserId) {
+		const e = await resolveUserEmail(row.proposedByUserId)
+		if (e) return e
+	}
+	// 2) User gắn trên hồ sơ QN
+	if (row.personnelId) {
+		const p = await orm
+			.select()
+			.from(leavePersonnel)
+			.where(eq(leavePersonnel.id, row.personnelId))
+			.limit(1)
+		if (p[0]?.userId) {
+			const e = await resolveUserEmail(p[0].userId)
+			if (e) return e
+		}
+		if (p[0]?.email && looksLikeEmail(p[0].email)) {
+			return p[0].email.trim()
+		}
+	}
+	// 3) Snapshot lúc gửi đơn
+	if (row.proposerEmail && looksLikeEmail(row.proposerEmail)) {
+		return row.proposerEmail.trim()
+	}
+	return null
+}
+
+async function resolveAdminEmails(): Promise<string[]> {
+	const admins = await orm
+		.select()
+		.from(users)
+		.where(eq(users.isSuperUser, true))
+	const emails: string[] = []
+	for (const a of admins) {
+		const e = await resolveUserEmail(a.id)
+		if (e) emails.push(e)
+		else if (looksLikeEmail(a.username)) emails.push(a.username.trim())
+	}
+	return [...new Set(emails)]
+}
+
+export interface LeaveRequestResponse {
+	id: number
+	createdAt: string
+	updatedAt: string
+	leaveType: LeaveType
+	requestScope: 'INDIVIDUAL' | 'CLASS'
+	classId: number | null
+	className: string | null
+	status: LeaveRequestStatus
+	personnelId: number | null
+	personnelCode: string | null
+	personnelName: string | null
+	objectType: LeaveObjectType
+	objectTypeLabel: string
+	rank: string | null
+	position: string | null
+	enlistmentDate: string | null
+	unitId: number | null
+	unitName: string | null
+	serviceYears: number
+	baseDays: number
+	travelDays: number
+	extraDays: number
+	extraReasons: string[]
+	totalDays: number
+	startDate: string | null
+	endDate: string | null
+	localityId: number | null
+	localityPath: string | null
+	note: string | null
+	proposedByUserId: number | null
+	proposedByUsername: string | null
+	proposedByDisplayName: string | null
+	proposerEmail: string | null
+	commanderUserId: number | null
+	commanderName: string | null
+	adminNote: string | null
+	decidedByUserId: number | null
+	decidedByUsername: string | null
+	decidedAt: string | null
+	/** Số ngày đã đi (đơn APPROVED cùng năm, cùng loại) */
+	usedDays: number
+	/** Số ngày còn lại theo hạn mức năm (chỉ ANNUAL; SPECIAL = null) */
+	remainingDays: number | null
+	/** Hạn mức ngày phép cơ bản năm */
+	quotaDays: number | null
+}
+
+function parseReasons(raw: string | null): string[] {
+	if (!raw) return []
+	try {
+		const v = JSON.parse(raw)
+		return Array.isArray(v) ? v.map(String) : []
+	} catch {
+		return []
+	}
+}
+
+function leaveYear(startDate: string | null | undefined): string {
+	if (startDate && /^\d{4}/.test(startDate)) return startDate.slice(0, 4)
+	return String(new Date().getFullYear())
+}
+
+/** Parse YYYY-MM-DD → Date local midnight (tránh lệch timezone) */
+function parseDateOnly(iso: string | null | undefined): Date | null {
+	if (!iso) return null
+	const m = String(iso)
+		.trim()
+		.match(/^(\d{4})-(\d{2})-(\d{2})/)
+	if (!m) {
+		const d = new Date(iso)
+		return Number.isNaN(d.getTime()) ? null : d
+	}
+	return new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
+}
+
+function startOfToday(asOf: Date = new Date()): Date {
+	return new Date(asOf.getFullYear(), asOf.getMonth(), asOf.getDate())
+}
+
+/**
+ * Số ngày đã thực sự đi (trôi qua trên lịch), không phải tổng ngày được duyệt.
+ * - Chưa tới startDate → 0
+ * - Đang trong khoảng nghỉ → từ start đến hôm nay (inclusive)
+ * - Đã qua endDate → full totalDays
+ */
+export function elapsedLeaveDays(
+	startDate: string | null | undefined,
+	endDate: string | null | undefined,
+	totalDays: number,
+	asOf: Date = new Date()
+): number {
+	const start = parseDateOnly(startDate)
+	if (!start) return 0
+	const today = startOfToday(asOf)
+	if (today < start) return 0
+
+	const total = Math.max(0, Number(totalDays) || 0)
+	let end = parseDateOnly(endDate)
+	if (!end && total >= 1) {
+		end = new Date(start)
+		end.setDate(end.getDate() + total - 1)
+	}
+	if (end && today > end) {
+		return total > 0
+			? total
+			: Math.max(
+					0,
+					Math.round((end.getTime() - start.getTime()) / 86400000) + 1
+				)
+	}
+
+	// Đang nghỉ: inclusive start..today
+	const elapsed =
+		Math.round((today.getTime() - start.getTime()) / 86400000) + 1
+	if (total > 0) return Math.min(total, Math.max(0, elapsed))
+	return Math.max(0, elapsed)
+}
+
+function mapRow(
+	r: typeof leaveRequests.$inferSelect,
+	usage?: {
+		usedDays: number
+		remainingDays: number | null
+		quotaDays: number | null
+	}
+): LeaveRequestResponse {
+	const ot =
+		(normalizeObjectType(String(r.objectType)) as LeaveObjectType) ||
+		(r.objectType as LeaveObjectType)
+	return {
+		id: r.id,
+		createdAt: r.createdAt ?? '',
+		updatedAt: r.updatedAt ?? '',
+		leaveType: r.leaveType as LeaveType,
+		requestScope: r.requestScope as 'INDIVIDUAL' | 'CLASS',
+		classId: r.classId ?? null,
+		className: r.className ?? null,
+		status: r.status as LeaveRequestStatus,
+		personnelId: r.personnelId,
+		personnelCode: r.personnelCode,
+		personnelName: r.personnelName,
+		objectType: ot,
+		objectTypeLabel: objectTypeLabel(ot),
+		rank: r.rank,
+		position: (r as { position?: string | null }).position ?? null,
+		enlistmentDate:
+			(r as { enlistmentDate?: string | null }).enlistmentDate ?? null,
+		unitId: r.unitId,
+		unitName: r.unitName,
+		serviceYears: r.serviceYears,
+		baseDays: r.baseDays,
+		travelDays: r.travelDays,
+		extraDays: r.extraDays,
+		extraReasons: parseReasons(r.extraReasons),
+		totalDays: r.totalDays,
+		startDate: r.startDate,
+		endDate: r.endDate,
+		localityId: r.localityId,
+		localityPath: r.localityPath,
+		note: r.note,
+		proposedByUserId: r.proposedByUserId,
+		proposedByUsername: r.proposedByUsername,
+		proposedByDisplayName: r.proposedByDisplayName,
+		proposerEmail: r.proposerEmail ?? null,
+		commanderUserId: r.commanderUserId ?? null,
+		commanderName: r.commanderName ?? null,
+		adminNote: r.adminNote,
+		decidedByUserId: r.decidedByUserId,
+		decidedByUsername: r.decidedByUsername,
+		decidedAt: r.decidedAt,
+		usedDays: usage?.usedDays ?? 0,
+		remainingDays: usage?.remainingDays ?? null,
+		quotaDays: usage?.quotaDays ?? null
+	}
+}
+
+/**
+ * Lưu trữ: ghi khi gửi duyệt, cập nhật khi xử lý (upsert theo requestId).
+ */
+async function upsertLeaveRecord(
+	row: typeof leaveRequests.$inferSelect
+): Promise<void> {
+	const payload = {
+		requestId: row.id,
+		status: row.status as LeaveRequestStatus,
+		leaveType: row.leaveType as LeaveType,
+		personnelId: row.personnelId,
+		personnelCode: row.personnelCode,
+		personnelName: row.personnelName,
+		objectType: row.objectType as LeaveObjectType,
+		rank: row.rank,
+		position: (row as { position?: string | null }).position ?? null,
+		enlistmentDate:
+			(row as { enlistmentDate?: string | null }).enlistmentDate ?? null,
+		unitId: row.unitId,
+		unitName: row.unitName,
+		serviceYears: row.serviceYears,
+		baseDays: row.baseDays,
+		travelDays: row.travelDays,
+		extraDays: row.extraDays,
+		extraReasons: row.extraReasons,
+		totalDays: row.totalDays,
+		startDate: row.startDate,
+		endDate: row.endDate,
+		leaveYear: leaveYear(row.startDate),
+		localityId: row.localityId,
+		localityPath: row.localityPath,
+		note: row.note,
+		adminNote: row.adminNote,
+		proposedByUserId: row.proposedByUserId,
+		proposedByUsername: row.proposedByUsername,
+		proposedByDisplayName: row.proposedByDisplayName,
+		decidedByUserId: row.decidedByUserId,
+		decidedByUsername: row.decidedByUsername,
+		decidedAt: row.decidedAt,
+		archivedAt: nowIso()
+	}
+	const existing = await orm
+		.select({ id: leaveRecords.id })
+		.from(leaveRecords)
+		.where(eq(leaveRecords.requestId, row.id))
+		.limit(1)
+	if (existing[0]) {
+		await orm
+			.update(leaveRecords)
+			.set(payload)
+			.where(eq(leaveRecords.id, existing[0].id))
+	} else {
+		await orm.insert(leaveRecords).values(payload)
+	}
+}
+
+/**
+ * Đã đi / còn lại theo personnel + năm (đơn APPROVED):
+ * - Đã đi = số ngày đã trôi qua trên lịch (từ start → hôm nay), không lấy full totalDays
+ * - Còn lại = số ngày phép đã duyệt nhưng chưa tới (totalDays − đã trôi qua)
+ * - quotaDays = hạn mức phép cơ bản năm (tham chiếu, ANNUAL)
+ */
+async function computeUsageForRows(
+	rows: (typeof leaveRequests.$inferSelect)[]
+): Promise<
+	Map<
+		number,
+		{
+			usedDays: number
+			remainingDays: number | null
+			quotaDays: number | null
+		}
+	>
+> {
+	const result = new Map<
+		number,
+		{
+			usedDays: number
+			remainingDays: number | null
+			quotaDays: number | null
+		}
+	>()
+	if (!rows.length) return result
+
+	const asOf = new Date()
+	const approved = await orm
+		.select()
+		.from(leaveRequests)
+		.where(eq(leaveRequests.status, 'APPROVED'))
+
+	for (const r of rows) {
+		const year = leaveYear(r.startDate)
+		const leaveType = r.leaveType as LeaveType
+		const related = approved.filter((a) => {
+			if (a.personnelId == null || a.personnelId !== r.personnelId)
+				return false
+			if (a.leaveType !== leaveType) return false
+			return leaveYear(a.startDate) === year
+		})
+
+		let used = 0
+		let remainingOnLeave = 0
+		for (const a of related) {
+			const total = Number(a.totalDays) || 0
+			const el = elapsedLeaveDays(a.startDate, a.endDate, total, asOf)
+			used += el
+			remainingOnLeave += Math.max(0, total - el)
+		}
+
+		let quota: number | null = null
+		if (leaveType === 'ANNUAL') {
+			const ot =
+				normalizeObjectType(String(r.objectType)) ||
+				(r.objectType as LeaveObjectType)
+			quota = await resolveBaseDays(
+				'ANNUAL',
+				ot as LeaveObjectType,
+				r.serviceYears
+			)
+		}
+
+		result.set(r.id, {
+			usedDays: used,
+			remainingDays: remainingOnLeave,
+			quotaDays: quota
+		})
+	}
+	return result
+}
+
+async function resolveBaseDays(
+	leaveType: LeaveType,
+	objectType: LeaveObjectType,
+	serviceYears: number
+): Promise<number> {
+	const rules = await orm
+		.select()
+		.from(leaveRegulations)
+		.where(
+			and(
+				eq(leaveRegulations.leaveType, leaveType),
+				eq(leaveRegulations.isActive, true)
+			)
+		)
+
+	if (leaveType === 'SPECIAL') {
+		// Mặc định tối đa 10 ngày; số ngày thực tế do client gửi (specialDays)
+		return SPECIAL_MAX_DAYS
+	}
+
+	const ot = normalizeObjectType(String(objectType)) || objectType
+	const match = rules.find((r) => {
+		const rot = r.objectType
+			? normalizeObjectType(String(r.objectType))
+			: null
+		if (rot !== ot) return false
+		const min = r.minYears ?? 0
+		const max = r.maxYears
+		if (serviceYears < min) return false
+		if (max != null && serviceYears >= max) return false
+		return true
+	})
+	if (match) return match.baseDays
+	return resolveAnnualBaseDays(ot, serviceYears)
+}
+
+export const ListLeaveRequests = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/requests'
+	},
+	async (q: {
+		status?: Query<string>
+		mine?: Query<boolean>
+		leaveType?: Query<string>
+		/** Tìm mã QN hoặc họ tên */
+		search?: Query<string>
+		/** Lọc theo chỉ huy cơ quan (user id) */
+		commanderUserId?: Query<number>
+		/**
+		 * mine — đơn tôi đề xuất
+		 * commander — đơn chờ/tôi là chỉ huy cơ quan
+		 * agency — đơn chờ cơ quan quản lý (super admin)
+		 * all — toàn bộ (super admin) hoặc đơn liên quan (user)
+		 */
+		inbox?: Query<string>
+	}): Promise<{ data: LeaveRequestResponse[] }> => {
+		const auth = getAuthData()!
+		const uid = Number(auth.userID)
+		const isAdmin = !!auth.isSuperAdmin
+		const access = await resolveLeaveAccess(uid, isAdmin)
+		const conditions = []
+		if (q.status) {
+			const st = String(q.status)
+			// legacy PENDING ≈ chờ chỉ huy
+			if (st === 'PENDING') {
+				conditions.push(
+					or(
+						eq(leaveRequests.status, 'PENDING'),
+						eq(leaveRequests.status, 'PENDING_COMMANDER')
+					)!
+				)
+			} else {
+				conditions.push(
+					eq(leaveRequests.status, st as LeaveRequestStatus)
+				)
+			}
+		}
+		if (q.leaveType === 'ANNUAL' || q.leaveType === 'SPECIAL') {
+			conditions.push(eq(leaveRequests.leaveType, q.leaveType))
+		}
+		if (q.commanderUserId != null && Number(q.commanderUserId) > 0) {
+			conditions.push(
+				eq(leaveRequests.commanderUserId, Number(q.commanderUserId))
+			)
+		}
+		if (q.search) {
+			const s = `%${String(q.search).trim()}%`
+			if (String(q.search).trim()) {
+				conditions.push(
+					or(
+						like(leaveRequests.personnelCode, s),
+						like(leaveRequests.personnelName, s)
+					)!
+				)
+			}
+		}
+
+		const inbox = String(
+			q.inbox || (q.mine ? 'mine' : isAdmin ? 'all' : 'related')
+		)
+		if (inbox === 'mine') {
+			conditions.push(eq(leaveRequests.proposedByUserId, uid))
+		} else if (inbox === 'commander') {
+			conditions.push(eq(leaveRequests.commanderUserId, uid))
+		} else if (inbox === 'agency') {
+			if (!isAdmin && !access.isAgency) {
+				throw APIError.permissionDenied(
+					'Chỉ cơ quan quản lý xem hộp thư này'
+				)
+			}
+			conditions.push(eq(leaveRequests.status, 'PENDING_AGENCY'))
+			if (!isAdmin && access.unitIds.length) {
+				conditions.push(
+					or(
+						...access.unitIds.map((id) =>
+							eq(leaveRequests.unitId, id)
+						)
+					)!
+				)
+			}
+		} else if (inbox === 'all') {
+			if (!isAdmin) {
+				if (access.isAgency && access.unitIds.length) {
+					conditions.push(
+						or(
+							...access.unitIds.map((id) =>
+								eq(leaveRequests.unitId, id)
+							)
+						)!
+					)
+				} else {
+					conditions.push(
+						or(
+							eq(leaveRequests.proposedByUserId, uid),
+							eq(leaveRequests.commanderUserId, uid)
+						)!
+					)
+				}
+			}
+		} else {
+			// related
+			conditions.push(
+				or(
+					eq(leaveRequests.proposedByUserId, uid),
+					eq(leaveRequests.commanderUserId, uid)
+				)!
+			)
+		}
+
+		const rows = await orm
+			.select()
+			.from(leaveRequests)
+			.where(conditions.length ? and(...conditions) : undefined)
+			.orderBy(desc(leaveRequests.id))
+		const usage = await computeUsageForRows(rows)
+		return {
+			data: rows.map((r) => mapRow(r, usage.get(r.id)))
+		}
+	}
+)
+
+export const GetLeaveRequest = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/requests/:id'
+	},
+	async ({ id }: { id: number }): Promise<{ data: LeaveRequestResponse }> => {
+		const auth = getAuthData()!
+		const rows = await orm
+			.select()
+			.from(leaveRequests)
+			.where(eq(leaveRequests.id, id))
+			.limit(1)
+		if (!rows[0]) throw APIError.notFound('Không tìm thấy đơn phép')
+		const uid = Number(auth.userID)
+		const access = await resolveLeaveAccess(uid, !!auth.isSuperAdmin)
+		const isCommander =
+			rows[0].commanderUserId != null && rows[0].commanderUserId === uid
+		if (
+			!auth.isSuperAdmin &&
+			rows[0].proposedByUserId !== uid &&
+			!isCommander &&
+			!(
+				access.isAgency &&
+				rows[0].unitId != null &&
+				access.unitIds.includes(rows[0].unitId)
+			)
+		) {
+			throw APIError.permissionDenied('Không có quyền xem đơn này')
+		}
+		const usage = await computeUsageForRows([rows[0]])
+		return { data: mapRow(rows[0], usage.get(rows[0].id)) }
+	}
+)
+
+interface CreateLeaveBody {
+	leaveType?: string
+	requestScope?: 'INDIVIDUAL' | 'CLASS'
+	classId?: number | null
+	className?: string | null
+	/** Chỉ huy/đại đội nhập trực tiếp, không tính theo thâm niên */
+	manualDays?: number
+	personnelId?: number | null
+	/** Đối tượng cố định từ profile — server ưu tiên profile */
+	objectType?: string
+	rank?: string | null
+	unitId?: number | null
+	unitName?: string | null
+	travelDays?: number
+	extraDays?: number
+	/** Lý do nghỉ thêm (ANNUAL) hoặc lý do phép đặc biệt (SPECIAL) */
+	extraReasons?: string[]
+	/** Số ngày phép đặc biệt (1–10), chỉ dùng khi leaveType=SPECIAL */
+	specialDays?: number
+	startDate?: string | null
+	endDate?: string | null
+	localityId?: number | null
+	/** Địa chỉ cụ thể (số nhà, đường…) — ghép vào localityPath */
+	localityDetail?: string | null
+	note?: string | null
+}
+
+export const CreateLeaveRequest = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/requests'
+	},
+	async (body: CreateLeaveBody): Promise<{ data: LeaveRequestResponse }> => {
+		const auth = getAuthData()!
+		const uid = Number(auth.userID)
+		const access = await resolveLeaveAccess(uid, !!auth.isSuperAdmin)
+		if (access.isAgency && !access.isAdmin) {
+			throw APIError.permissionDenied(
+				'Cơ quan quản lý không có quyền đề xuất nghỉ phép'
+			)
+		}
+		const userRow = (
+			await orm.select().from(users).where(eq(users.id, uid)).limit(1)
+		)[0]
+
+		// Prefill from linked personnel
+		const personnel =
+			body.personnelId != null
+				? (
+						await orm
+							.select()
+							.from(leavePersonnel)
+							.where(eq(leavePersonnel.id, body.personnelId))
+							.limit(1)
+					)[0]
+				: (
+						await orm
+							.select()
+							.from(leavePersonnel)
+							.where(eq(leavePersonnel.userId, uid))
+							.limit(1)
+					)[0]
+		if (
+			personnel &&
+			!access.isAdmin &&
+			personnel.userId !== uid &&
+			(personnel.unitId == null ||
+				!access.isCommander ||
+				!access.unitIds.includes(personnel.unitId))
+		) {
+			throw APIError.permissionDenied(
+				'Chỉ được đề xuất cho quân nhân thuộc đơn vị mình quản lý'
+			)
+		}
+
+		// Super admin can create without personnel if objectType provided
+		if (!personnel && !auth.isSuperAdmin) {
+			throw APIError.failedPrecondition(
+				'Tài khoản chưa liên kết hồ sơ quân nhân. Liên hệ quản trị để gán trong Danh sách quân nhân.'
+			)
+		}
+
+		const rawObjectType = (personnel?.objectType ||
+			body.objectType) as string
+		if (!isLeaveObjectType(rawObjectType)) {
+			throw APIError.invalidArgument('Đối tượng không hợp lệ')
+		}
+		const objectType = normalizeObjectType(rawObjectType)!
+
+		const leaveType: LeaveType =
+			body.leaveType === 'SPECIAL' ? 'SPECIAL' : 'ANNUAL'
+
+		// Thâm niên: tháng/năm bắt đầu nghỉ − tháng/năm nhập ngũ/tuyển dụng
+		const serviceYears = computeServiceYears(
+			personnel?.enlistmentDate,
+			asOfFromDate(body.startDate)
+		)
+		const extraReasons = body.extraReasons || []
+
+		let baseDays: number
+		let travelDays: number
+		let extraDays: number
+		let totalDays: number
+		let reasonsJson: string
+
+		if (leaveType === 'SPECIAL') {
+			let specialDays = Number(body.specialDays ?? SPECIAL_MAX_DAYS)
+			if (!Number.isFinite(specialDays)) specialDays = SPECIAL_MAX_DAYS
+			specialDays = Math.min(
+				SPECIAL_MAX_DAYS,
+				Math.max(1, Math.floor(specialDays))
+			)
+			const err = validateSpecialLeave(
+				objectType,
+				specialDays,
+				extraReasons
+			)
+			if (err) throw APIError.invalidArgument(err)
+			baseDays = specialDays
+			travelDays = 0
+			extraDays = 0
+			totalDays = specialDays
+			reasonsJson = JSON.stringify(extraReasons)
+		} else {
+			baseDays = await resolveBaseDays(
+				leaveType,
+				objectType,
+				serviceYears
+			)
+			travelDays = Math.max(0, Number(body.travelDays || 0))
+			extraDays = Math.max(0, Number(body.extraDays || 0))
+			if (extraDays > 0) {
+				if (!canTakeExtraLeave(objectType)) {
+					throw APIError.invalidArgument(
+						'Hạ sĩ quan / binh sĩ không được nghỉ thêm theo quy định form này'
+					)
+				}
+				const err = validateExtraReasons(extraDays, extraReasons)
+				if (err) throw APIError.invalidArgument(err)
+			} else {
+				extraDays = 0
+			}
+			totalDays = baseDays + travelDays + extraDays
+			reasonsJson = JSON.stringify(extraDays > 0 ? extraReasons : [])
+		}
+		if (body.manualDays !== undefined) {
+			if (!access.isAdmin && !access.isCommander) {
+				throw APIError.permissionDenied(
+					'Chỉ chỉ huy đơn vị được nhập trực tiếp số ngày nghỉ'
+				)
+			}
+			const manualDays = Math.floor(Number(body.manualDays))
+			if (
+				!Number.isFinite(manualDays) ||
+				manualDays < 1 ||
+				manualDays > 365
+			) {
+				throw APIError.invalidArgument('Số ngày nghỉ phải từ 1 đến 365')
+			}
+			baseDays = manualDays
+			travelDays = 0
+			extraDays = 0
+			totalDays = manualDays
+			reasonsJson = JSON.stringify(extraReasons)
+		}
+
+		const basePath = await resolveLocalityPath(body.localityId)
+		const detail = body.localityDetail?.trim() || ''
+		// VD: Tỉnh Hà Tĩnh, Xã Cẩm Bình, số 12 đường ABC
+		const localityPath =
+			body.manualDays !== undefined
+				? personnel?.permanentResidence || personnel?.hometown || null
+				: detail
+					? basePath
+						? `${basePath}, ${detail}`
+						: detail
+					: basePath
+
+		// SQ/QNCN/CNQP/VCQP: chờ chỉ huy đơn vị → CQQL
+		// Chỉ huy lấy cố định theo đơn vị (danh mục), fallback hồ sơ QN
+		const needsCommander = canTakeExtraLeave(objectType)
+		const unitForCmd = body.unitId ?? personnel?.unitId ?? null
+		const fromUnit = await resolveUnitCommander(unitForCmd)
+		const commanderId =
+			fromUnit.commanderUserId ?? personnel?.commanderUserId ?? null
+		const commanderNm =
+			fromUnit.commanderName ?? personnel?.commanderName ?? null
+		// Chỉ huy/Đại đội tự lập đơn: chuyển thẳng lên CQQL,
+		// không tạo bước duyệt lại cho chính người lập.
+		const proposedByCommander = access.isCommander && !auth.isSuperAdmin
+		const initialStatus: LeaveRequestStatus = proposedByCommander
+			? 'PENDING_AGENCY'
+			: needsCommander && commanderId
+				? 'PENDING_COMMANDER'
+				: 'PENDING_AGENCY'
+
+		if (needsCommander && !commanderId && !auth.isSuperAdmin) {
+			throw APIError.failedPrecondition(
+				'Đơn vị chưa gán Chỉ huy CQ (hoặc hồ sơ chưa có đơn vị). Gán chỉ huy tại Danh mục đơn vị.'
+			)
+		}
+
+		// Snapshot email: ưu tiên email tài khoản đăng nhập (users.email)
+		const proposerEmail =
+			(await resolveUserEmail(uid)) || personnel?.email?.trim() || null
+
+		const inserted = await orm
+			.insert(leaveRequests)
+			.values({
+				leaveType,
+				requestScope: body.requestScope || 'INDIVIDUAL',
+				classId: body.classId ?? personnel?.classId ?? null,
+				className: body.className ?? personnel?.className ?? null,
+				status: initialStatus,
+				personnelId: personnel?.id ?? null,
+				personnelCode: personnel?.code ?? null,
+				personnelName:
+					personnel?.fullName || userRow?.displayName || null,
+				objectType,
+				rank: body.rank ?? personnel?.rank ?? null,
+				position: personnel?.position ?? null,
+				enlistmentDate: personnel?.enlistmentDate ?? null,
+				unitId: body.unitId ?? personnel?.unitId ?? null,
+				unitName: body.unitName ?? personnel?.unitName ?? null,
+				serviceYears,
+				baseDays,
+				travelDays,
+				extraDays,
+				extraReasons: reasonsJson,
+				totalDays,
+				startDate: body.startDate || null,
+				endDate: body.endDate || null,
+				localityId: body.localityId ?? null,
+				localityPath,
+				note: body.note || null,
+				proposedByUserId: uid,
+				proposedByUsername: userRow?.username || null,
+				proposedByDisplayName:
+					userRow?.displayName || userRow?.username || null,
+				proposerEmail,
+				commanderUserId: commanderId,
+				commanderName: commanderNm
+			})
+			.returning()
+
+		const row = inserted[0]!
+		// Ghi lưu trữ khi gửi duyệt
+		try {
+			await upsertLeaveRecord(row)
+		} catch (e) {
+			log.error('CreateLeaveRequest: upsert leave record failed', {
+				error: String((e as Error)?.message || e)
+			})
+		}
+
+		// Mỗi đề xuất gửi lên → thông báo chuông (+ mail nếu có SMTP) cho đúng cấp
+		try {
+			const who = row.personnelName || 'Quân nhân'
+			const code = row.personnelCode ? ` (${row.personnelCode})` : ''
+			const typeLabel =
+				row.leaveType === 'SPECIAL' ? 'phép đặc biệt' : 'phép hằng năm'
+			const when =
+				row.startDate && row.endDate
+					? ` (${row.startDate} → ${row.endDate})`
+					: ''
+			const where = row.localityPath ? ` · ${row.localityPath}` : ''
+			const detailMsg = `${who}${code}: đề xuất ${typeLabel} ${row.totalDays} ngày${when}${where}`
+
+			if (initialStatus === 'PENDING_COMMANDER' && commanderId) {
+				// Chuông + alert chỉ huy CQ của đơn vị
+				await createLeaveAlert({
+					userId: commanderId,
+					requestId: row.id,
+					kind: 'NEED_COMMANDER',
+					title: `[Đề xuất phép] Chờ chỉ huy CQ duyệt — ${who}`,
+					message: `${detailMsg}. Vào Duyệt đề xuất để xử lý.`
+				})
+				const cmdEmail = await resolveUserEmail(commanderId)
+				if (cmdEmail) {
+					const m = buildLeaveSubmittedMail({
+						personnelName: who,
+						personnelCode: row.personnelCode,
+						totalDays: row.totalDays,
+						leaveType: row.leaveType,
+						startDate: row.startDate,
+						endDate: row.endDate,
+						localityPath: row.localityPath,
+						toRole: 'commander'
+					})
+					const r = await sendLeaveMail({
+						to: cmdEmail,
+						subject: m.subject,
+						text: m.text,
+						requestId: row.id,
+						kind: 'SUBMITTED'
+					})
+					if (!r.ok) {
+						log.warn('CreateLeaveRequest: commander email failed', {
+							to: cmdEmail,
+							mode: r.mode,
+							error: r.error
+						})
+					}
+				}
+			} else {
+				// Thẳng CQQL / admin
+				await alertSuperAdmins({
+					requestId: row.id,
+					kind: 'NEED_AGENCY',
+					title: `[Đề xuất phép] Chờ CQQL ký — ${who}`,
+					message: `${detailMsg}. Vào Duyệt đề xuất để ký / duyệt.`
+				})
+				const adminEmails = await resolveAdminEmails()
+				const m = buildLeaveSubmittedMail({
+					personnelName: who,
+					personnelCode: row.personnelCode,
+					totalDays: row.totalDays,
+					leaveType: row.leaveType,
+					startDate: row.startDate,
+					endDate: row.endDate,
+					localityPath: row.localityPath,
+					toRole: 'agency'
+				})
+				for (const to of adminEmails) {
+					const r = await sendLeaveMail({
+						to,
+						subject: m.subject,
+						text: m.text,
+						requestId: row.id,
+						kind: 'SUBMITTED'
+					})
+					if (!r.ok) {
+						log.warn('CreateLeaveRequest: admin email failed', {
+							to,
+							mode: r.mode,
+							error: r.error
+						})
+					}
+				}
+			}
+
+			// Chuông xác nhận cho người gửi đề xuất
+			await createLeaveAlert({
+				userId: uid,
+				requestId: row.id,
+				kind: 'SUBMITTED',
+				title: `[Đề xuất phép] Đã gửi — chờ duyệt`,
+				message: `Bạn đã gửi ${typeLabel} ${row.totalDays} ngày${when}. Trạng thái: ${
+					initialStatus === 'PENDING_COMMANDER'
+						? 'chờ chỉ huy CQ'
+						: 'chờ CQQL'
+				}.`
+			})
+
+			// Mail xác nhận người đề xuất (nếu có email)
+			const proposerMail = proposerEmail || (await resolveUserEmail(uid))
+			if (proposerMail) {
+				const m = buildLeaveSubmittedMail({
+					personnelName: who,
+					personnelCode: row.personnelCode,
+					totalDays: row.totalDays,
+					leaveType: row.leaveType,
+					startDate: row.startDate,
+					endDate: row.endDate,
+					localityPath: row.localityPath,
+					toRole: 'proposer'
+				})
+				await sendLeaveMail({
+					to: proposerMail,
+					subject: m.subject,
+					text: m.text,
+					requestId: row.id,
+					kind: 'SUBMITTED'
+				})
+			}
+		} catch (e) {
+			log.warn('CreateLeaveRequest: leave alert/mail failed', {
+				error: String((e as Error)?.message || e)
+			})
+		}
+
+		const usage = await computeUsageForRows([row])
+		return { data: mapRow(row, usage.get(row.id)) }
+	}
+)
+
+/**
+ * Chỉ huy CQ được sửa ngày đi đường / nghỉ thêm (khi đơn còn chờ chỉ huy).
+ * Tự tính lại totalDays (+ endDate nếu có startDate).
+ */
+export const PatchLeaveRequest = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'PATCH',
+		path: '/leave/requests/:id'
+	},
+	async ({
+		id,
+		travelDays,
+		extraDays,
+		extraReasons,
+		startDate,
+		endDate,
+		adminNote
+	}: {
+		id: number
+		travelDays?: number
+		extraDays?: number
+		extraReasons?: string[]
+		startDate?: string | null
+		endDate?: string | null
+		adminNote?: string | null
+	}): Promise<{ data: LeaveRequestResponse }> => {
+		const auth = getAuthData()!
+		const uid = Number(auth.userID)
+		const isAdmin = !!auth.isSuperAdmin
+		const access = await resolveLeaveAccess(uid, isAdmin)
+
+		const rows = await orm
+			.select()
+			.from(leaveRequests)
+			.where(eq(leaveRequests.id, id))
+			.limit(1)
+		if (!rows[0]) throw APIError.notFound('Không tìm thấy đơn phép')
+		const cur = rows[0]
+		const st = cur.status as LeaveRequestStatus
+		const isCommanderStep = st === 'PENDING_COMMANDER' || st === 'PENDING'
+		if (!isCommanderStep) {
+			throw APIError.failedPrecondition(
+				'Chỉ sửa được khi đơn đang chờ chỉ huy cơ quan'
+			)
+		}
+		const isCommander =
+			cur.commanderUserId != null && cur.commanderUserId === uid
+		if (!isCommander && !isAdmin) {
+			throw APIError.permissionDenied(
+				'Chỉ chỉ huy cơ quan (hoặc admin) được sửa ngày đi đường / nghỉ thêm'
+			)
+		}
+		if (cur.leaveType === 'SPECIAL') {
+			throw APIError.invalidArgument(
+				'Phép đặc biệt không chỉnh ngày đi đường / nghỉ thêm'
+			)
+		}
+
+		const travel =
+			travelDays !== undefined
+				? Math.max(0, Number(travelDays) || 0)
+				: cur.travelDays
+		let extra =
+			extraDays !== undefined
+				? Math.max(0, Number(extraDays) || 0)
+				: cur.extraDays
+		let reasons =
+			extraReasons !== undefined
+				? extraReasons
+				: parseReasons(cur.extraReasons)
+
+		if (extra > 0) {
+			const ot = cur.objectType as LeaveObjectType
+			if (!canTakeExtraLeave(ot)) {
+				throw APIError.invalidArgument(
+					'Đối tượng này không được nghỉ thêm'
+				)
+			}
+			const err = validateExtraReasons(extra, reasons)
+			if (err) throw APIError.invalidArgument(err)
+		} else {
+			extra = 0
+			reasons = []
+		}
+
+		const totalDays = cur.baseDays + travel + extra
+		// Auto endDate nếu có start và không gửi endDate
+		let nextEnd = endDate !== undefined ? endDate || null : cur.endDate
+		const nextStart =
+			startDate !== undefined ? startDate || null : cur.startDate
+		if (nextStart && totalDays >= 1 && endDate === undefined) {
+			const d = new Date(nextStart)
+			if (!Number.isNaN(d.getTime())) {
+				d.setDate(d.getDate() + totalDays - 1)
+				const y = d.getFullYear()
+				const m = String(d.getMonth() + 1).padStart(2, '0')
+				const day = String(d.getDate()).padStart(2, '0')
+				nextEnd = `${y}-${m}-${day}`
+			}
+		}
+
+		const updated = await orm
+			.update(leaveRequests)
+			.set({
+				travelDays: travel,
+				extraDays: extra,
+				extraReasons: JSON.stringify(reasons),
+				totalDays,
+				startDate: nextStart,
+				endDate: nextEnd,
+				...(adminNote !== undefined
+					? { adminNote: adminNote || null }
+					: {})
+			})
+			.where(eq(leaveRequests.id, id))
+			.returning()
+		const row = updated[0]!
+		try {
+			await upsertLeaveRecord(row)
+		} catch (e) {
+			log.error('PatchLeaveRequest: upsert leave record failed', {
+				error: String((e as Error)?.message || e)
+			})
+		}
+		const usage = await computeUsageForRows([row])
+		return { data: mapRow(row, usage.get(row.id)) }
+	}
+)
+
+export const DecideLeaveRequest = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/requests/:id/decide'
+	},
+	async ({
+		id,
+		decision,
+		adminNote,
+		travelDays,
+		extraDays,
+		extraReasons
+	}: {
+		id: number
+		/** APPROVED = duyệt bước hiện tại | RETURNED/REJECTED = trả lại */
+		decision: 'APPROVED' | 'REJECTED' | 'RETURNED'
+		adminNote?: string | null
+		/** Chỉ huy có thể chỉnh khi duyệt */
+		travelDays?: number
+		extraDays?: number
+		extraReasons?: string[]
+	}): Promise<{
+		data: LeaveRequestResponse
+		/** Kết quả gửi mail tự động (khi duyệt cuối / trả lại) */
+		mail?: {
+			ok: boolean
+			to: string
+			mode: string
+			error?: string
+			previewUrl?: string
+			isTestInbox: boolean
+			message: string
+		} | null
+	}> => {
+		const auth = getAuthData()!
+		const uid = Number(auth.userID)
+		const isAdmin = !!auth.isSuperAdmin
+		const access = await resolveLeaveAccess(uid, isAdmin)
+
+		const norm =
+			decision === 'REJECTED'
+				? 'RETURNED'
+				: decision === 'APPROVED'
+					? 'APPROVED'
+					: decision === 'RETURNED'
+						? 'RETURNED'
+						: null
+		if (!norm) {
+			throw APIError.invalidArgument(
+				'decision phải là APPROVED | RETURNED | REJECTED'
+			)
+		}
+
+		const rows = await orm
+			.select()
+			.from(leaveRequests)
+			.where(eq(leaveRequests.id, id))
+			.limit(1)
+		if (!rows[0]) throw APIError.notFound('Không tìm thấy đơn phép')
+		const cur = rows[0]
+		const st = cur.status as LeaveRequestStatus
+
+		const isCommanderStep = st === 'PENDING_COMMANDER' || st === 'PENDING'
+		const isAgencyStep = st === 'PENDING_AGENCY'
+
+		if (!isCommanderStep && !isAgencyStep) {
+			throw APIError.failedPrecondition(
+				'Đơn không ở trạng thái chờ duyệt / chờ ký'
+			)
+		}
+
+		if (isCommanderStep) {
+			const isCommander =
+				cur.commanderUserId != null && cur.commanderUserId === uid
+			if (!isCommander && !isAdmin) {
+				throw APIError.permissionDenied(
+					'Chỉ chỉ huy cơ quan (hoặc admin) được duyệt bước này'
+				)
+			}
+		}
+		if (
+			isAgencyStep &&
+			!isAdmin &&
+			!(
+				access.isAgency &&
+				cur.unitId != null &&
+				access.unitIds.includes(cur.unitId)
+			)
+		) {
+			throw APIError.permissionDenied(
+				'Chỉ cơ quan quản lý phụ trách được duyệt / trả lại sau khi ký'
+			)
+		}
+
+		// Chỉ huy chỉnh ngày đi đường / nghỉ thêm trước khi duyệt
+		let travel = cur.travelDays
+		let extra = cur.extraDays
+		let reasons = parseReasons(cur.extraReasons)
+		let totalDays = cur.totalDays
+		let endDate = cur.endDate
+		if (
+			isCommanderStep &&
+			cur.leaveType === 'ANNUAL' &&
+			(travelDays !== undefined ||
+				extraDays !== undefined ||
+				extraReasons !== undefined)
+		) {
+			travel =
+				travelDays !== undefined
+					? Math.max(0, Number(travelDays) || 0)
+					: cur.travelDays
+			extra =
+				extraDays !== undefined
+					? Math.max(0, Number(extraDays) || 0)
+					: cur.extraDays
+			reasons =
+				extraReasons !== undefined
+					? extraReasons
+					: parseReasons(cur.extraReasons)
+			if (extra > 0) {
+				const ot = cur.objectType as LeaveObjectType
+				if (!canTakeExtraLeave(ot)) {
+					throw APIError.invalidArgument(
+						'Đối tượng này không được nghỉ thêm'
+					)
+				}
+				const err = validateExtraReasons(extra, reasons)
+				if (err) throw APIError.invalidArgument(err)
+			} else {
+				extra = 0
+				reasons = []
+			}
+			totalDays = cur.baseDays + travel + extra
+			if (cur.startDate && totalDays >= 1) {
+				const d = new Date(cur.startDate)
+				if (!Number.isNaN(d.getTime())) {
+					d.setDate(d.getDate() + totalDays - 1)
+					const y = d.getFullYear()
+					const m = String(d.getMonth() + 1).padStart(2, '0')
+					const day = String(d.getDate()).padStart(2, '0')
+					endDate = `${y}-${m}-${day}`
+				}
+			}
+		}
+
+		const decider = (
+			await orm.select().from(users).where(eq(users.id, uid)).limit(1)
+		)[0]
+
+		let nextStatus: LeaveRequestStatus
+		if (norm === 'RETURNED') {
+			nextStatus = 'RETURNED'
+		} else if (isCommanderStep) {
+			nextStatus = 'PENDING_AGENCY'
+		} else {
+			nextStatus = 'APPROVED'
+		}
+
+		const updated = await orm
+			.update(leaveRequests)
+			.set({
+				status: nextStatus,
+				travelDays: travel,
+				extraDays: extra,
+				extraReasons: JSON.stringify(reasons),
+				totalDays,
+				endDate,
+				adminNote: adminNote || cur.adminNote || null,
+				decidedByUserId: uid,
+				decidedByUsername: decider?.username || null,
+				decidedAt: nowIso()
+			})
+			.where(eq(leaveRequests.id, id))
+			.returning()
+
+		const row = updated[0]!
+
+		// Cập nhật lưu trữ (đã gửi duyệt / đã duyệt / trả lại)
+		try {
+			await upsertLeaveRecord(row)
+		} catch (e) {
+			log.error('DecideLeaveRequest: upsert leave record failed', {
+				requestId: id,
+				error: String((e as Error)?.message || e)
+			})
+		}
+
+		// Duyệt cuối tạo luôn đợt nghỉ, không bắt nhập lại thủ công.
+		if (nextStatus === 'APPROVED') {
+			try {
+				const batchConditions =
+					row.requestScope === 'CLASS'
+						? and(
+								eq(
+									leaveBatches.personnelName,
+									row.className || row.personnelName || 'Lớp'
+								),
+								eq(leaveBatches.leaveType, row.leaveType),
+								eq(leaveBatches.startDate, row.startDate),
+								eq(leaveBatches.endDate, row.endDate),
+								eq(leaveBatches.totalDays, row.totalDays)
+							)
+						: eq(leaveBatches.requestId, row.id)
+				const existingBatch = await orm
+					.select({ id: leaveBatches.id })
+					.from(leaveBatches)
+					.where(batchConditions)
+					.limit(1)
+				if (!existingBatch[0]) {
+					await orm.insert(leaveBatches).values({
+						requestId: row.id,
+						personnelId: row.personnelId,
+						personnelCode: row.personnelCode,
+						personnelName:
+							row.requestScope === 'CLASS'
+								? row.className || row.personnelName
+								: row.personnelName,
+						objectType: row.objectType,
+						leaveType: row.leaveType,
+						batchIndex: 1,
+						batchLabel:
+							row.requestScope === 'CLASS'
+								? `Đợt nghỉ ${row.className || 'lớp'}`
+								: 'Đợt nghỉ theo đơn đã duyệt',
+						startDate: row.startDate,
+						endDate: row.endDate,
+						totalDays: row.totalDays,
+						note: row.note,
+						createdByUserId: uid
+					})
+				}
+			} catch (e) {
+				log.error('DecideLeaveRequest: create leave batch failed', {
+					requestId: id,
+					error: String((e as Error)?.message || e)
+				})
+			}
+		}
+
+		// Thông báo bước tiếp / người đề xuất
+		try {
+			const who = row.personnelName || 'Quân nhân'
+			const code = row.personnelCode ? ` (${row.personnelCode})` : ''
+			if (nextStatus === 'PENDING_AGENCY') {
+				await alertSuperAdmins({
+					requestId: row.id,
+					kind: 'NEED_AGENCY',
+					title: 'Đơn phép đã qua chỉ huy — chờ CQQL ký',
+					message: `${who}${code}: chỉ huy đã duyệt bước 1. Vào Duyệt đề xuất để ký / duyệt cuối.`
+				})
+				const adminEmails = await resolveAdminEmails()
+				const m = buildLeaveSubmittedMail({
+					personnelName: who,
+					personnelCode: row.personnelCode,
+					totalDays: row.totalDays,
+					leaveType: row.leaveType,
+					startDate: row.startDate,
+					endDate: row.endDate,
+					localityPath: row.localityPath,
+					toRole: 'agency'
+				})
+				for (const to of adminEmails) {
+					await sendLeaveMail({
+						to,
+						subject: m.subject,
+						text: m.text
+					})
+				}
+			}
+			if (
+				(nextStatus === 'APPROVED' || nextStatus === 'RETURNED') &&
+				row.proposedByUserId
+			) {
+				await createLeaveAlert({
+					userId: row.proposedByUserId,
+					requestId: row.id,
+					kind: nextStatus === 'APPROVED' ? 'DECIDED' : 'RETURNED',
+					title:
+						nextStatus === 'APPROVED'
+							? 'Đơn nghỉ phép đã được duyệt'
+							: 'Đơn nghỉ phép bị trả lại',
+					message:
+						nextStatus === 'APPROVED'
+							? `${who}${code}: đơn ${row.totalDays} ngày đã được phê duyệt.`
+							: `${who}${code}: đơn bị trả lại. ${adminNote || ''}`.trim()
+				})
+			}
+		} catch (e) {
+			log.warn('DecideLeaveRequest: leave alert failed', {
+				error: String((e as Error)?.message || e)
+			})
+		}
+
+		// Tự gửi mail khi duyệt cuối / trả lại — lấy users.email (không cần bấm gửi)
+		let mailOut: {
+			ok: boolean
+			to: string
+			mode: string
+			error?: string
+			previewUrl?: string
+			isTestInbox: boolean
+			message: string
+		} | null = null
+
+		if (nextStatus === 'APPROVED' || nextStatus === 'RETURNED') {
+			const email = await resolvePersonnelNotifyEmail(row)
+			if (email) {
+				const mail = buildLeaveDecisionMail({
+					personnelName: row.personnelName || 'đồng chí',
+					leaveType: row.leaveType,
+					status: nextStatus,
+					totalDays: row.totalDays,
+					adminNote: adminNote,
+					actorName:
+						decider?.displayName || decider?.username || null,
+					startDate: row.startDate,
+					endDate: row.endDate
+				})
+				const mailResult = await sendLeaveMail({
+					to: email,
+					subject: mail.subject,
+					text: mail.text,
+					requestId: id,
+					kind: 'DECISION'
+				})
+				if (!mailResult.ok) {
+					log.warn('DecideLeaveRequest: email not delivered', {
+						to: email,
+						mode: mailResult.mode,
+						error: mailResult.error,
+						requestId: id
+					})
+					mailOut = {
+						ok: false,
+						to: email,
+						mode: mailResult.mode,
+						error: mailResult.error,
+						isTestInbox: false,
+						message:
+							mailResult.error ||
+							`Không gửi được mail tới ${email}`
+					}
+				} else {
+					log.info('DecideLeaveRequest: auto-notified personnel', {
+						to: email,
+						mode: mailResult.mode,
+						status: nextStatus,
+						requestId: id,
+						previewUrl: mailResult.previewUrl
+					})
+					mailOut = {
+						ok: true,
+						to: email,
+						mode: mailResult.mode,
+						previewUrl: mailResult.previewUrl,
+						isTestInbox: mailResult.isTestInbox,
+						message: mailResult.isTestInbox
+							? `Đã gửi (chế độ TEST Ethereal) tới ${email} — không vào Gmail thật. Mở previewUrl để xem thư.`
+							: `Đã gửi mail thật tới ${email}`
+					}
+				}
+			} else {
+				log.warn(
+					'DecideLeaveRequest: no user email — cập nhật email trên tài khoản QN',
+					{ requestId: id, proposedByUserId: row.proposedByUserId }
+				)
+				mailOut = {
+					ok: false,
+					to: '',
+					mode: 'no-recipient',
+					isTestInbox: false,
+					message:
+						'Tài khoản quân nhân chưa có email (users.email). Vào Danh sách người dùng → sửa email.'
+				}
+			}
+		}
+
+		const usage = await computeUsageForRows([row])
+		return { data: mapRow(row, usage.get(row.id)), mail: mailOut }
+	}
+)
+
+export const CancelLeaveRequest = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/requests/:id/cancel'
+	},
+	async ({ id }: { id: number }): Promise<{ data: LeaveRequestResponse }> => {
+		const auth = getAuthData()!
+		const rows = await orm
+			.select()
+			.from(leaveRequests)
+			.where(eq(leaveRequests.id, id))
+			.limit(1)
+		if (!rows[0]) throw APIError.notFound('Không tìm thấy đơn phép')
+		if (
+			!auth.isSuperAdmin &&
+			rows[0].proposedByUserId !== Number(auth.userID)
+		) {
+			throw APIError.permissionDenied('Không có quyền hủy đơn này')
+		}
+		const st = rows[0].status as LeaveRequestStatus
+		if (
+			st !== 'PENDING' &&
+			st !== 'DRAFT' &&
+			st !== 'PENDING_COMMANDER' &&
+			st !== 'PENDING_AGENCY'
+		) {
+			throw APIError.failedPrecondition('Chỉ hủy được đơn đang chờ')
+		}
+		const updated = await orm
+			.update(leaveRequests)
+			.set({ status: 'CANCELLED' })
+			.where(eq(leaveRequests.id, id))
+			.returning()
+		const row = updated[0]!
+		try {
+			await upsertLeaveRecord(row)
+		} catch (e) {
+			log.error('CancelLeaveRequest: upsert leave record failed', {
+				error: String((e as Error)?.message || e)
+			})
+		}
+		const usage = await computeUsageForRows([row])
+		return { data: mapRow(row, usage.get(row.id)) }
+	}
+)

--- a/apps/api/leave-management/leaves.ts
+++ b/apps/api/leave-management/leaves.ts
@@ -122,7 +122,7 @@ export interface LeaveRequestResponse {
 	createdAt: string
 	updatedAt: string
 	leaveType: LeaveType
-	requestScope: 'INDIVIDUAL' | 'CLASS'
+	requestScope: 'INDIVIDUAL' | 'CLASS' | 'SHORT_LEAVE'
 	classId: number | null
 	className: string | null
 	status: LeaveRequestStatus
@@ -252,7 +252,7 @@ function mapRow(
 		createdAt: r.createdAt ?? '',
 		updatedAt: r.updatedAt ?? '',
 		leaveType: r.leaveType as LeaveType,
-		requestScope: r.requestScope as 'INDIVIDUAL' | 'CLASS',
+		requestScope: r.requestScope as 'INDIVIDUAL' | 'CLASS' | 'SHORT_LEAVE',
 		classId: r.classId ?? null,
 		className: r.className ?? null,
 		status: r.status as LeaveRequestStatus,
@@ -626,7 +626,7 @@ export const GetLeaveRequest = api(
 
 interface CreateLeaveBody {
 	leaveType?: string
-	requestScope?: 'INDIVIDUAL' | 'CLASS'
+	requestScope?: 'INDIVIDUAL' | 'CLASS' | 'SHORT_LEAVE'
 	classId?: number | null
 	className?: string | null
 	/** Chỉ huy/đại đội nhập trực tiếp, không tính theo thâm niên */
@@ -795,14 +795,13 @@ export const CreateLeaveRequest = api(
 		const basePath = await resolveLocalityPath(body.localityId)
 		const detail = body.localityDetail?.trim() || ''
 		// VD: Tỉnh Hà Tĩnh, Xã Cẩm Bình, số 12 đường ABC
-		const localityPath =
-			body.manualDays !== undefined
-				? personnel?.permanentResidence || personnel?.hometown || null
+		const localityPath = detail
+			? basePath
+				? `${basePath}, ${detail}`
 				: detail
-					? basePath
-						? `${basePath}, ${detail}`
-						: detail
-					: basePath
+			: body.manualDays !== undefined
+				? personnel?.permanentResidence || personnel?.hometown || null
+				: basePath
 
 		// SQ/QNCN/CNQP/VCQP: chờ chỉ huy đơn vị → CQQL
 		// Chỉ huy lấy cố định theo đơn vị (danh mục), fallback hồ sơ QN

--- a/apps/api/leave-management/localities.ts
+++ b/apps/api/leave-management/localities.ts
@@ -1,0 +1,430 @@
+/**
+ * CRUD danh sách địa phương: Tỉnh → Xã/Phường → Thôn
+ */
+import { api, APIError, Query } from 'encore.dev/api'
+import { and, asc, eq, isNull } from 'drizzle-orm'
+import orm from '../database'
+import {
+	leaveLocalities,
+	type LeaveLocalityLevel
+} from '../schema/leave-management'
+
+export interface LocalityResponse {
+	id: number
+	createdAt: string
+	updatedAt: string
+	name: string
+	level: LeaveLocalityLevel
+	parentId: number | null
+	code: string | null
+	children?: LocalityResponse[]
+}
+
+function mapRow(r: typeof leaveLocalities.$inferSelect): LocalityResponse {
+	return {
+		id: r.id,
+		createdAt: r.createdAt ?? '',
+		updatedAt: r.updatedAt ?? '',
+		name: r.name,
+		level: r.level as LeaveLocalityLevel,
+		parentId: r.parentId,
+		code: r.code
+	}
+}
+
+const LEVELS: LeaveLocalityLevel[] = ['province', 'ward', 'village']
+
+function isLevel(v: string): v is LeaveLocalityLevel {
+	return LEVELS.includes(v as LeaveLocalityLevel)
+}
+
+export const ListLeaveLocalities = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/localities'
+	},
+	async (q: {
+		level?: Query<string>
+		parentId?: Query<number>
+		tree?: Query<boolean>
+	}): Promise<{ data: LocalityResponse[] }> => {
+		if (q.tree) {
+			const all = await orm
+				.select()
+				.from(leaveLocalities)
+				.orderBy(asc(leaveLocalities.name))
+			const mapped = all.map(mapRow)
+			const byParent = new Map<number | null, LocalityResponse[]>()
+			for (const row of mapped) {
+				const key = row.parentId
+				if (!byParent.has(key)) byParent.set(key, [])
+				byParent.get(key)!.push(row)
+			}
+			const attach = (node: LocalityResponse): LocalityResponse => {
+				const kids = byParent.get(node.id) || []
+				return {
+					...node,
+					children: kids.map(attach)
+				}
+			}
+			const roots = (byParent.get(null) || []).map(attach)
+			return { data: roots }
+		}
+
+		const conditions = []
+		if (q.level && isLevel(String(q.level))) {
+			conditions.push(
+				eq(leaveLocalities.level, q.level as LeaveLocalityLevel)
+			)
+		}
+		if (q.parentId != null && Number(q.parentId) > 0) {
+			conditions.push(eq(leaveLocalities.parentId, Number(q.parentId)))
+		} else if (
+			q.parentId === 0 ||
+			(q.level && String(q.level) === 'province')
+		) {
+			// provinces: parent null
+			if (!q.parentId || Number(q.parentId) === 0) {
+				if (String(q.level || '') === 'province' || q.parentId === 0) {
+					conditions.push(isNull(leaveLocalities.parentId))
+				}
+			}
+		}
+
+		const rows = await orm
+			.select()
+			.from(leaveLocalities)
+			.where(conditions.length ? and(...conditions) : undefined)
+			.orderBy(asc(leaveLocalities.name))
+		return { data: rows.map(mapRow) }
+	}
+)
+
+interface CreateLocalityBody {
+	name: string
+	level: string
+	parentId?: number | null
+	code?: string | null
+}
+
+export const CreateLeaveLocality = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/localities'
+	},
+	async (body: CreateLocalityBody): Promise<{ data: LocalityResponse }> => {
+		if (!body.name?.trim()) {
+			throw APIError.invalidArgument('Tên địa phương là bắt buộc')
+		}
+		if (!isLevel(body.level)) {
+			throw APIError.invalidArgument(
+				'Cấp phải là province | ward | village'
+			)
+		}
+		if (body.level === 'province' && body.parentId) {
+			throw APIError.invalidArgument('Tỉnh không có đơn vị cha')
+		}
+		if (body.level !== 'province') {
+			if (!body.parentId) {
+				throw APIError.invalidArgument('Cần chọn địa phương cha')
+			}
+			const parent = await orm
+				.select()
+				.from(leaveLocalities)
+				.where(eq(leaveLocalities.id, body.parentId))
+				.limit(1)
+			if (!parent[0]) throw APIError.invalidArgument('Không tìm thấy cha')
+			const expectedParent = body.level === 'ward' ? 'province' : 'ward'
+			if (parent[0].level !== expectedParent) {
+				throw APIError.invalidArgument(
+					`Cấp cha phải là ${expectedParent}`
+				)
+			}
+		}
+		const inserted = await orm
+			.insert(leaveLocalities)
+			.values({
+				name: body.name.trim(),
+				level: body.level as LeaveLocalityLevel,
+				parentId: body.parentId ?? null,
+				code: body.code || null
+			})
+			.returning()
+		return { data: mapRow(inserted[0]!) }
+	}
+)
+
+export const UpdateLeaveLocality = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'PATCH',
+		path: '/leave/localities/:id'
+	},
+	async ({
+		id,
+		name,
+		code
+	}: {
+		id: number
+		name?: string
+		code?: string | null
+	}): Promise<{ data: LocalityResponse }> => {
+		const existing = await orm
+			.select()
+			.from(leaveLocalities)
+			.where(eq(leaveLocalities.id, id))
+			.limit(1)
+		if (!existing[0]) throw APIError.notFound('Không tìm thấy địa phương')
+		const updated = await orm
+			.update(leaveLocalities)
+			.set({
+				...(name != null ? { name: name.trim() } : {}),
+				...(code !== undefined ? { code: code || null } : {})
+			})
+			.where(eq(leaveLocalities.id, id))
+			.returning()
+		return { data: mapRow(updated[0]!) }
+	}
+)
+
+export const DeleteLeaveLocality = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'DELETE',
+		path: '/leave/localities/:id'
+	},
+	async ({ id }: { id: number }): Promise<{ ok: boolean }> => {
+		const children = await orm
+			.select()
+			.from(leaveLocalities)
+			.where(eq(leaveLocalities.parentId, id))
+			.limit(1)
+		if (children[0]) {
+			throw APIError.failedPrecondition(
+				'Còn địa phương con — xóa con trước'
+			)
+		}
+		const res = await orm
+			.delete(leaveLocalities)
+			.where(eq(leaveLocalities.id, id))
+			.returning()
+		if (!res[0]) throw APIError.notFound('Không tìm thấy địa phương')
+		return { ok: true }
+	}
+)
+
+/** Build path "Tỉnh > Xã > Thôn" */
+export async function resolveLocalityPath(
+	localityId: number | null | undefined
+): Promise<string | null> {
+	if (!localityId) return null
+	const parts: string[] = []
+	let currentId: number | null = localityId
+	for (let i = 0; i < 5 && currentId; i++) {
+		const rows = await orm
+			.select()
+			.from(leaveLocalities)
+			.where(eq(leaveLocalities.id, currentId))
+			.limit(1)
+		if (!rows[0]) break
+		parts.unshift(rows[0].name)
+		currentId = rows[0].parentId
+	}
+	return parts.length ? parts.join(' > ') : null
+}
+
+export interface ImportLocalityItem {
+	/** Tên tỉnh (bắt buộc) */
+	province: string
+	/** Tên xã/phường (tuỳ chọn) */
+	ward?: string | null
+	/** Tên thôn (tuỳ chọn — cần ward) */
+	village?: string | null
+	provinceCode?: string | null
+	wardCode?: string | null
+	villageCode?: string | null
+}
+
+export interface ImportLocalityResult {
+	successCount: number
+	errorCount: number
+	totalCount: number
+	createdCount: number
+	skippedCount: number
+	errors: { row: number; message: string }[]
+}
+
+function cacheKey(
+	level: LeaveLocalityLevel,
+	parentId: number | null,
+	name: string
+): string {
+	return `${level}|${parentId ?? 'null'}|${name}`
+}
+
+function normalizeLocalityName(name: string): string {
+	return name.replace(/\s+/g, ' ').trim()
+}
+
+/**
+ * Import địa phương dạng phẳng (file 3321 xã/phường):
+ * mỗi dòng = Tỉnh/TP + Xã/Phường (+ tuỳ chọn Thôn).
+ * Cache in-memory để import ~3k dòng nhanh.
+ */
+export const ImportLeaveLocalities = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/localities/import'
+	},
+	async (body: {
+		items: ImportLocalityItem[]
+	}): Promise<{ data: ImportLocalityResult }> => {
+		const items = body.items || []
+		if (!items.length) {
+			throw APIError.invalidArgument('Danh sách import trống')
+		}
+		if (items.length > 10000) {
+			throw APIError.invalidArgument('Tối đa 10000 dòng mỗi lần import')
+		}
+
+		// Preload existing localities into cache
+		const all = await orm.select().from(leaveLocalities)
+		const byKey = new Map<string, { id: number; code: string | null }>()
+		for (const r of all) {
+			byKey.set(
+				cacheKey(
+					r.level as LeaveLocalityLevel,
+					r.parentId,
+					normalizeLocalityName(r.name)
+				),
+				{ id: r.id, code: r.code }
+			)
+		}
+
+		const findOrCreate = async (
+			name: string,
+			level: LeaveLocalityLevel,
+			parentId: number | null,
+			code?: string | null
+		): Promise<{ id: number; created: boolean }> => {
+			const n = normalizeLocalityName(name)
+			const key = cacheKey(level, parentId, n)
+			const hit = byKey.get(key)
+			if (hit) {
+				if (code && !hit.code) {
+					await orm
+						.update(leaveLocalities)
+						.set({ code })
+						.where(eq(leaveLocalities.id, hit.id))
+					hit.code = code
+				}
+				return { id: hit.id, created: false }
+			}
+			const inserted = await orm
+				.insert(leaveLocalities)
+				.values({
+					name: n,
+					level,
+					parentId,
+					code: code || null
+				})
+				.returning()
+			const id = inserted[0]!.id
+			byKey.set(key, { id, code: code || null })
+			return { id, created: true }
+		}
+
+		const errors: { row: number; message: string }[] = []
+		let successCount = 0
+		let createdCount = 0
+		let skippedCount = 0
+
+		for (let i = 0; i < items.length; i++) {
+			const row = i + 1
+			const item = items[i]!
+			const province = normalizeLocalityName(String(item.province || ''))
+			if (!province) {
+				errors.push({ row, message: 'Tên tỉnh/thành phố là bắt buộc' })
+				continue
+			}
+			const ward = item.ward
+				? normalizeLocalityName(String(item.ward))
+				: ''
+			const village = item.village
+				? normalizeLocalityName(String(item.village))
+				: ''
+			if (village && !ward) {
+				errors.push({
+					row,
+					message: 'Thôn cần có Xã/Phường'
+				})
+				continue
+			}
+
+			try {
+				let anyCreated = false
+				const p = await findOrCreate(
+					province,
+					'province',
+					null,
+					item.provinceCode
+						? String(item.provinceCode).trim() || null
+						: null
+				)
+				if (p.created) anyCreated = true
+
+				if (ward) {
+					const w = await findOrCreate(
+						ward,
+						'ward',
+						p.id,
+						item.wardCode
+							? String(item.wardCode).trim() || null
+							: null
+					)
+					if (w.created) anyCreated = true
+
+					if (village) {
+						const v = await findOrCreate(
+							village,
+							'village',
+							w.id,
+							item.villageCode
+								? String(item.villageCode).trim() || null
+								: null
+						)
+						if (v.created) anyCreated = true
+					}
+				}
+
+				successCount++
+				if (anyCreated) createdCount++
+				else skippedCount++
+			} catch (e: unknown) {
+				errors.push({
+					row,
+					message: String((e as Error)?.message || e)
+				})
+			}
+		}
+
+		return {
+			data: {
+				successCount,
+				errorCount: errors.length,
+				totalCount: items.length,
+				createdCount,
+				skippedCount,
+				errors
+			}
+		}
+	}
+)

--- a/apps/api/leave-management/mail-api.ts
+++ b/apps/api/leave-management/mail-api.ts
@@ -6,7 +6,12 @@ import { desc } from 'drizzle-orm'
 import { getAuthData } from '~encore/auth'
 import orm from '../database'
 import { leaveMailLog } from '../schema/leave-management'
-import { getMailStatus, sendLeaveMail, type MailStatus } from './mail'
+import {
+	getMailStatus,
+	saveMailConfig,
+	sendLeaveMail,
+	type MailStatus
+} from './mail'
 
 export const GetLeaveMailStatus = api(
 	{
@@ -17,6 +22,43 @@ export const GetLeaveMailStatus = api(
 	},
 	async (): Promise<{ data: MailStatus }> => {
 		return { data: getMailStatus() }
+	}
+)
+
+export const SaveLeaveMailConfig = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/mail/config'
+	},
+	async (body: {
+		host?: string
+		port?: string | number
+		user: string
+		pass: string
+		from?: string
+	}): Promise<{
+		data: { ok: boolean; message: string; status: MailStatus }
+	}> => {
+		const auth = getAuthData()!
+		if (!auth.isSuperAdmin) {
+			throw APIError.permissionDenied('Chỉ admin được cấu hình SMTP')
+		}
+		try {
+			const status = saveMailConfig(body)
+			return {
+				data: {
+					ok: true,
+					message: 'Đã lưu cấu hình SMTP',
+					status
+				}
+			}
+		} catch (error) {
+			throw APIError.invalidArgument(
+				String((error as Error)?.message || error)
+			)
+		}
 	}
 )
 

--- a/apps/api/leave-management/mail-api.ts
+++ b/apps/api/leave-management/mail-api.ts
@@ -1,0 +1,131 @@
+/**
+ * API kiểm tra / gửi thử email quản lý phép
+ */
+import { api, APIError, Query } from 'encore.dev/api'
+import { desc } from 'drizzle-orm'
+import { getAuthData } from '~encore/auth'
+import orm from '../database'
+import { leaveMailLog } from '../schema/leave-management'
+import { getMailStatus, sendLeaveMail, type MailStatus } from './mail'
+
+export const GetLeaveMailStatus = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/mail/status'
+	},
+	async (): Promise<{ data: MailStatus }> => {
+		return { data: getMailStatus() }
+	}
+)
+
+export const TestLeaveMail = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/mail/test'
+	},
+	async (body: {
+		to?: string
+	}): Promise<{
+		data: {
+			ok: boolean
+			mode: string
+			error?: string
+			previewUrl?: string
+			to: string
+		}
+	}> => {
+		const auth = getAuthData()!
+		if (!auth.isSuperAdmin) {
+			throw APIError.permissionDenied('Chỉ admin được gửi mail thử')
+		}
+		const to = (body.to || '').trim()
+		if (!to) {
+			throw APIError.invalidArgument(
+				'Cần trường to (email nhận thử), VD: ban@example.com'
+			)
+		}
+		const result = await sendLeaveMail({
+			to,
+			subject: '[Quản lý phép] Thư thử — cấu hình SMTP',
+			text: [
+				'Đây là email thử từ hệ thống Quản lý phép.',
+				'',
+				`Thời điểm: ${new Date().toISOString()}`,
+				`Người gửi thử: user #${auth.userID}`,
+				'',
+				'Nếu bạn nhận được thư này trên Gmail/Outlook thật,',
+				'thì SMTP đã cấu hình đúng (LEAVE_MAIL_DEV=false + App Password).',
+				'',
+				'Nếu mode=ethereal-dev: thư CHỈ xem qua previewUrl, không vào hộp Gmail.',
+				'— Hệ thống QLHV / Phép'
+			].join('\n'),
+			kind: 'TEST'
+		})
+		return {
+			data: {
+				ok: result.ok,
+				mode: result.mode,
+				error: result.error,
+				previewUrl: result.previewUrl,
+				to,
+				isTestInbox: result.isTestInbox
+			}
+		}
+	}
+)
+
+export const ListLeaveMailLog = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/mail/log'
+	},
+	async (q: {
+		limit?: Query<number>
+	}): Promise<{
+		data: {
+			id: number
+			createdAt: string
+			requestId: number | null
+			toEmail: string
+			subject: string
+			body: string | null
+			mode: string | null
+			ok: boolean
+			error: string | null
+			previewUrl: string | null
+			kind: string | null
+		}[]
+	}> => {
+		const auth = getAuthData()!
+		if (!auth.isSuperAdmin) {
+			throw APIError.permissionDenied('Chỉ admin xem nhật ký mail')
+		}
+		const limit = Math.min(100, Math.max(1, Number(q.limit) || 30))
+		const rows = await orm
+			.select()
+			.from(leaveMailLog)
+			.orderBy(desc(leaveMailLog.id))
+			.limit(limit)
+		return {
+			data: rows.map((r) => ({
+				id: r.id,
+				createdAt: r.createdAt ?? '',
+				requestId: r.requestId,
+				toEmail: r.toEmail,
+				subject: r.subject,
+				body: r.body,
+				mode: r.mode,
+				ok: !!r.ok,
+				error: r.error,
+				previewUrl: r.previewUrl,
+				kind: r.kind
+			}))
+		}
+	}
+)

--- a/apps/api/leave-management/mail.ts
+++ b/apps/api/leave-management/mail.ts
@@ -29,6 +29,7 @@ import nodemailer from 'nodemailer'
 import type { Transporter } from 'nodemailer'
 import fs from 'fs'
 import path from 'path'
+import crypto from 'crypto'
 import { appConfig } from '../configs'
 import orm from '../database'
 import { leaveMailLog } from '../schema/leave-management'
@@ -72,9 +73,112 @@ let etherealUser: string | null = null
 let lastPreviewUrl: string | null = null
 
 const PREVIEW_FILE = path.resolve(process.cwd(), '.leave-mail-last-preview.txt')
+const CONFIG_FILE = path.resolve(process.cwd(), '.leave-mail-config.enc')
+
+type StoredMailConfig = {
+	SMTP_HOST: string
+	SMTP_PORT: string
+	SMTP_USER: string
+	SMTP_PASS: string
+	SMTP_FROM: string
+	LEAVE_MAIL_DEV: string
+}
+
+let storedConfig: StoredMailConfig | null | undefined
+
+function configKey(): Buffer {
+	return crypto
+		.createHash('sha256')
+		.update(
+			String(
+				process.env.JWT_PRIVATE_KEY ||
+					process.env.HASH_SECRET ||
+					'leave-mail-local-config'
+			)
+		)
+		.digest()
+}
+
+function loadStoredConfig(): StoredMailConfig | null {
+	if (storedConfig !== undefined) return storedConfig
+	try {
+		if (!fs.existsSync(CONFIG_FILE)) return (storedConfig = null)
+		const payload = JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8')) as {
+			iv: string
+			tag: string
+			data: string
+		}
+		const decipher = crypto.createDecipheriv(
+			'aes-256-gcm',
+			configKey(),
+			Buffer.from(payload.iv, 'base64')
+		)
+		decipher.setAuthTag(Buffer.from(payload.tag, 'base64'))
+		const plain = Buffer.concat([
+			decipher.update(Buffer.from(payload.data, 'base64')),
+			decipher.final()
+		]).toString('utf8')
+		return (storedConfig = JSON.parse(plain) as StoredMailConfig)
+	} catch (error) {
+		log.error('Leave mail: cannot read saved SMTP config', {
+			error: String((error as Error)?.message || error)
+		})
+		return (storedConfig = null)
+	}
+}
+
+export function saveMailConfig(input: {
+	host?: string
+	port?: number | string
+	user: string
+	pass: string
+	from?: string
+}): MailStatus {
+	const user = input.user.trim()
+	const pass = input.pass.replace(/\s+/g, '')
+	if (!user || !pass)
+		throw new Error('SMTP user và SMTP password là bắt buộc')
+
+	const next: StoredMailConfig = {
+		SMTP_HOST: input.host?.trim() || 'smtp.gmail.com',
+		SMTP_PORT: String(Number(input.port) || 587),
+		SMTP_USER: user,
+		SMTP_PASS: pass,
+		SMTP_FROM: input.from?.trim() || `Quản lý phép <${user}>`,
+		LEAVE_MAIL_DEV: 'false'
+	}
+	const iv = crypto.randomBytes(12)
+	const cipher = crypto.createCipheriv('aes-256-gcm', configKey(), iv)
+	const encrypted = Buffer.concat([
+		cipher.update(JSON.stringify(next), 'utf8'),
+		cipher.final()
+	])
+	const tmp = `${CONFIG_FILE}.tmp`
+	fs.writeFileSync(
+		tmp,
+		JSON.stringify({
+			iv: iv.toString('base64'),
+			tag: cipher.getAuthTag().toString('base64'),
+			data: encrypted.toString('base64')
+		}),
+		{ encoding: 'utf8', mode: 0o600 }
+	)
+	fs.renameSync(tmp, CONFIG_FILE)
+	storedConfig = next
+	transporter?.close()
+	transporter = null
+	transportMode = 'none'
+	etherealUser = null
+	return getMailStatus()
+}
 
 function env(key: string, fallback = ''): string {
-	// Ưu tiên process.env (dotenv / encore), fallback appConfig
+	// Cấu hình lưu từ giao diện được ưu tiên, sau đó mới tới .env / Encore.
+	const saved = loadStoredConfig()
+	const fromSaved = saved?.[key as keyof StoredMailConfig]
+	if (fromSaved != null && String(fromSaved).trim() !== '') {
+		return String(fromSaved).trim()
+	}
 	const fromProcess = process.env[key]
 	if (fromProcess != null && String(fromProcess).trim() !== '') {
 		return String(fromProcess).trim()

--- a/apps/api/leave-management/mail.ts
+++ b/apps/api/leave-management/mail.ts
@@ -1,0 +1,590 @@
+/**
+ * Gửi email thông báo đơn phép.
+ *
+ * Cấu hình apps/api/.env:
+ *
+ * ## Cách 1 — Gmail (production / thật)
+ *   SMTP_HOST=smtp.gmail.com
+ *   SMTP_PORT=587
+ *   SMTP_USER=your@gmail.com
+ *   SMTP_PASS=xxxx xxxx xxxx xxxx   # App Password (bật 2FA)
+ *   SMTP_FROM="QL Phép <your@gmail.com>"
+ *
+ * ## Cách 2 — SMTP không auth (Mailpit / MailHog local)
+ *   SMTP_HOST=127.0.0.1
+ *   SMTP_PORT=1025
+ *   SMTP_USER=
+ *   SMTP_PASS=
+ *   SMTP_NO_AUTH=true
+ *   SMTP_FROM="QL Phép <leave@localhost>"
+ *
+ * ## Cách 3 — Dev auto (Ethereal) — không cần SMTP thật
+ *   LEAVE_MAIL_DEV=true
+ *   → nodemailer tạo hộp mail test; log có link xem thư
+ *
+ *   LEAVE_MAIL_WEBHOOK=https://...  (optional fallback)
+ */
+import log from 'encore.dev/log'
+import nodemailer from 'nodemailer'
+import type { Transporter } from 'nodemailer'
+import fs from 'fs'
+import path from 'path'
+import { appConfig } from '../configs'
+import orm from '../database'
+import { leaveMailLog } from '../schema/leave-management'
+
+export interface LeaveMailPayload {
+	to: string
+	subject: string
+	text: string
+	html?: string
+	/** leave_requests.id nếu có */
+	requestId?: number | null
+	/** DECISION | SUBMITTED | TEST */
+	kind?: string
+}
+
+export interface SendMailResult {
+	ok: boolean
+	mode: string
+	error?: string
+	previewUrl?: string
+	to: string
+	/** true = mail chỉ nằm trên Ethereal, KHÔNG vào hộp Gmail thật */
+	isTestInbox: boolean
+}
+
+export interface MailStatus {
+	configured: boolean
+	mode: 'smtp' | 'smtp-no-auth' | 'ethereal-dev' | 'webhook' | 'none'
+	host: string | null
+	port: number | null
+	user: string | null
+	from: string | null
+	devMode: boolean
+	lastPreviewUrl: string | null
+	hint: string
+}
+
+let transporter: Transporter | null = null
+let transportMode: MailStatus['mode'] = 'none'
+let etherealUser: string | null = null
+let lastPreviewUrl: string | null = null
+
+const PREVIEW_FILE = path.resolve(process.cwd(), '.leave-mail-last-preview.txt')
+
+function env(key: string, fallback = ''): string {
+	// Ưu tiên process.env (dotenv / encore), fallback appConfig
+	const fromProcess = process.env[key]
+	if (fromProcess != null && String(fromProcess).trim() !== '') {
+		return String(fromProcess).trim()
+	}
+	const cfg = appConfig as Record<string, string | undefined>
+	const v = cfg[key]
+	return v != null && String(v).trim() !== '' ? String(v).trim() : fallback
+}
+
+function isDevMail(): boolean {
+	const v = env('LEAVE_MAIL_DEV', 'false').toLowerCase()
+	return v === 'true' || v === '1' || v === 'yes'
+}
+
+function smtpHost(): string {
+	return env('SMTP_HOST')
+}
+
+function smtpPort(): number {
+	return Number(env('SMTP_PORT', '587') || 587)
+}
+
+function smtpUser(): string {
+	return env('SMTP_USER')
+}
+
+function smtpPass(): string {
+	return env('SMTP_PASS')
+}
+
+function smtpFrom(): string {
+	return (
+		env('SMTP_FROM') ||
+		(smtpUser() ? smtpUser() : 'QL Phép <noreply@localhost>')
+	)
+}
+
+function smtpNoAuth(): boolean {
+	const v = env('SMTP_NO_AUTH', '').toLowerCase()
+	if (v === 'true' || v === '1') return true
+	// Mailpit / MailHog default ports without credentials
+	const port = smtpPort()
+	const host = smtpHost()
+	if (
+		!smtpUser() &&
+		!smtpPass() &&
+		host &&
+		(port === 1025 ||
+			port === 1026 ||
+			host === '127.0.0.1' ||
+			host === 'localhost')
+	) {
+		return true
+	}
+	return false
+}
+
+function hasSmtpAuth(): boolean {
+	return !!(smtpHost() && smtpUser() && smtpPass())
+}
+
+function hasSmtpNoAuth(): boolean {
+	return !!(smtpHost() && smtpNoAuth())
+}
+
+function loadLastPreview(): string | null {
+	try {
+		if (fs.existsSync(PREVIEW_FILE)) {
+			return fs.readFileSync(PREVIEW_FILE, 'utf8').trim() || null
+		}
+	} catch {
+		/* ignore */
+	}
+	return lastPreviewUrl
+}
+
+function saveLastPreview(url: string) {
+	lastPreviewUrl = url
+	try {
+		fs.writeFileSync(PREVIEW_FILE, url + '\n', 'utf8')
+	} catch {
+		/* ignore */
+	}
+}
+
+export function getMailStatus(): MailStatus {
+	const host = smtpHost() || null
+	const port = host ? smtpPort() : null
+	const user = smtpUser() || etherealUser || null
+	const dev = isDevMail()
+
+	let mode: MailStatus['mode'] = 'none'
+	let hint =
+		'Chưa cấu hình. Xem apps/api/.env (SMTP_* hoặc LEAVE_MAIL_DEV=true).'
+
+	if (hasSmtpAuth()) {
+		mode = 'smtp'
+		hint = `SMTP ${host}:${port} (có auth) — gửi mail thật.`
+	} else if (hasSmtpNoAuth()) {
+		mode = 'smtp-no-auth'
+		hint = `SMTP ${host}:${port} (không auth — Mailpit/MailHog). UI Mailpit thường :8025`
+	} else if (dev || transportMode === 'ethereal-dev') {
+		mode = 'ethereal-dev'
+		hint =
+			'Chế độ dev Ethereal — mail test; mở lastPreviewUrl để xem thư đã gửi.'
+	} else if (env('LEAVE_MAIL_WEBHOOK')) {
+		mode = 'webhook'
+		hint = 'Dùng LEAVE_MAIL_WEBHOOK fallback.'
+	}
+
+	return {
+		configured: mode !== 'none',
+		mode,
+		host,
+		port,
+		user,
+		from: smtpFrom(),
+		devMode: dev,
+		lastPreviewUrl: loadLastPreview(),
+		hint
+	}
+}
+
+async function ensureTransporter(): Promise<Transporter | null> {
+	if (transporter) return transporter
+
+	// 1) Real SMTP with auth
+	if (hasSmtpAuth()) {
+		const port = smtpPort()
+		transporter = nodemailer.createTransport({
+			host: smtpHost(),
+			port,
+			secure: port === 465,
+			auth: {
+				user: smtpUser(),
+				pass: smtpPass()
+			}
+		})
+		transportMode = 'smtp'
+		log.info('Leave mail: SMTP transporter ready', {
+			host: smtpHost(),
+			port
+		})
+		return transporter
+	}
+
+	// 2) SMTP no auth (Mailpit)
+	if (hasSmtpNoAuth()) {
+		const port = smtpPort()
+		transporter = nodemailer.createTransport({
+			host: smtpHost(),
+			port,
+			secure: false,
+			tls: { rejectUnauthorized: false }
+		})
+		transportMode = 'smtp-no-auth'
+		log.info('Leave mail: SMTP no-auth transporter ready', {
+			host: smtpHost(),
+			port
+		})
+		return transporter
+	}
+
+	// 3) Ethereal dev auto
+	if (isDevMail()) {
+		try {
+			const account = await nodemailer.createTestAccount()
+			etherealUser = account.user
+			transporter = nodemailer.createTransport({
+				host: account.smtp.host,
+				port: account.smtp.port,
+				secure: account.smtp.secure,
+				auth: {
+					user: account.user,
+					pass: account.pass
+				}
+			})
+			transportMode = 'ethereal-dev'
+			log.info('Leave mail: Ethereal test account ready', {
+				user: account.user,
+				web: 'https://ethereal.email'
+			})
+			return transporter
+		} catch (e) {
+			log.error('Leave mail: cannot create Ethereal account', {
+				err: String((e as Error)?.message || e)
+			})
+			return null
+		}
+	}
+
+	return null
+}
+
+function toHtml(text: string): string {
+	const esc = text
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+	const body = esc.replace(/\n/g, '<br/>')
+	return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"/></head>
+<body style="font-family:system-ui,sans-serif;line-height:1.5;color:#111;padding:16px">
+${body}
+<hr style="border:none;border-top:1px solid #ddd;margin:24px 0"/>
+<p style="font-size:12px;color:#666">Email tự động từ hệ thống Quản lý phép — vui lòng không trả lời.</p>
+</body></html>`
+}
+
+async function logMail(entry: {
+	to: string
+	subject: string
+	body: string
+	mode: string
+	ok: boolean
+	error?: string
+	previewUrl?: string
+	requestId?: number | null
+	kind?: string
+}) {
+	try {
+		await orm.insert(leaveMailLog).values({
+			toEmail: entry.to,
+			subject: entry.subject,
+			body: entry.body,
+			mode: entry.mode,
+			ok: entry.ok,
+			error: entry.error || null,
+			previewUrl: entry.previewUrl || null,
+			requestId: entry.requestId ?? null,
+			kind: entry.kind || null
+		})
+	} catch (e) {
+		log.warn('leave_mail_log insert failed', {
+			err: String((e as Error)?.message || e)
+		})
+	}
+}
+
+export async function sendLeaveMail(
+	payload: LeaveMailPayload
+): Promise<SendMailResult> {
+	const to = (payload.to || '').trim()
+	const kind = payload.kind || 'GENERIC'
+	if (!to) {
+		log.warn('sendLeaveMail: missing recipient', {
+			subject: payload.subject
+		})
+		const r: SendMailResult = {
+			ok: false,
+			mode: 'no-recipient',
+			error: 'Thiếu email người nhận (users.email trống)',
+			to: '',
+			isTestInbox: false
+		}
+		await logMail({
+			to: '(empty)',
+			subject: payload.subject,
+			body: payload.text,
+			mode: r.mode,
+			ok: false,
+			error: r.error,
+			requestId: payload.requestId,
+			kind
+		})
+		return r
+	}
+
+	log.info('LEAVE_EMAIL attempt', {
+		to,
+		subject: payload.subject,
+		status: getMailStatus().mode,
+		kind
+	})
+
+	// 1) SMTP / Ethereal
+	const tx = await ensureTransporter()
+	if (tx) {
+		try {
+			const info = await tx.sendMail({
+				from: smtpFrom(),
+				to,
+				subject: payload.subject,
+				text: payload.text,
+				html: payload.html || toHtml(payload.text)
+			})
+			const preview =
+				nodemailer.getTestMessageUrl(info) ||
+				(typeof info === 'object' && info && 'preview' in info
+					? String((info as { preview?: string }).preview)
+					: null)
+			if (preview) {
+				saveLastPreview(String(preview))
+				log.info('LEAVE_EMAIL preview (Ethereal)', {
+					to,
+					previewUrl: preview
+				})
+			}
+			log.info('LEAVE_EMAIL sent', {
+				to,
+				mode: transportMode,
+				messageId: info.messageId
+			})
+			const isTest = transportMode === 'ethereal-dev'
+			const result: SendMailResult = {
+				ok: true,
+				mode: transportMode,
+				previewUrl: preview ? String(preview) : undefined,
+				to,
+				isTestInbox: isTest
+			}
+			await logMail({
+				to,
+				subject: payload.subject,
+				body: payload.text,
+				mode: result.mode,
+				ok: true,
+				previewUrl: result.previewUrl,
+				requestId: payload.requestId,
+				kind
+			})
+			return result
+		} catch (e: unknown) {
+			const msg = String((e as Error)?.message || e)
+			log.error('LEAVE_EMAIL transport error', { err: msg, to })
+			// fall through to webhook
+			transporter = null
+			transportMode = 'none'
+			await logMail({
+				to,
+				subject: payload.subject,
+				body: payload.text,
+				mode: 'smtp-error',
+				ok: false,
+				error: msg,
+				requestId: payload.requestId,
+				kind
+			})
+		}
+	}
+
+	// 2) Webhook fallback
+	const webhook = env('LEAVE_MAIL_WEBHOOK')
+	if (webhook) {
+		try {
+			const resp = await fetch(webhook, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(payload)
+			})
+			if (!resp.ok) {
+				const r: SendMailResult = {
+					ok: false,
+					mode: 'webhook-error',
+					error: `HTTP ${resp.status}`,
+					to,
+					isTestInbox: false
+				}
+				await logMail({
+					to,
+					subject: payload.subject,
+					body: payload.text,
+					mode: r.mode,
+					ok: false,
+					error: r.error,
+					requestId: payload.requestId,
+					kind
+				})
+				return r
+			}
+			const r: SendMailResult = {
+				ok: true,
+				mode: 'webhook',
+				to,
+				isTestInbox: false
+			}
+			await logMail({
+				to,
+				subject: payload.subject,
+				body: payload.text,
+				mode: 'webhook',
+				ok: true,
+				requestId: payload.requestId,
+				kind
+			})
+			return r
+		} catch (e: unknown) {
+			return {
+				ok: false,
+				mode: 'webhook-error',
+				error: String((e as Error)?.message || e),
+				to,
+				isTestInbox: false
+			}
+		}
+	}
+
+	log.warn(
+		'LEAVE_EMAIL not sent: set SMTP_USER/SMTP_PASS (Gmail App Password) or LEAVE_MAIL_DEV=true'
+	)
+	const r: SendMailResult = {
+		ok: false,
+		mode: 'not-configured',
+		error: 'Chưa cấu hình SMTP thật. Điền SMTP_USER + SMTP_PASS (App Password Gmail) trong apps/api/.env, đặt LEAVE_MAIL_DEV=false, rồi restart encore. Hiện LEAVE_MAIL_DEV chỉ gửi vào hộp test Ethereal (không vào Gmail).',
+		to,
+		isTestInbox: false
+	}
+	await logMail({
+		to,
+		subject: payload.subject,
+		body: payload.text,
+		mode: r.mode,
+		ok: false,
+		error: r.error,
+		requestId: payload.requestId,
+		kind
+	})
+	return r
+}
+
+export function buildLeaveDecisionMail(opts: {
+	personnelName: string
+	leaveType: string
+	status: 'APPROVED' | 'RETURNED'
+	totalDays: number
+	adminNote?: string | null
+	actorName?: string | null
+	startDate?: string | null
+	endDate?: string | null
+}): { subject: string; text: string } {
+	const typeLabel =
+		opts.leaveType === 'SPECIAL' ? 'phép đặc biệt' : 'phép hằng năm'
+	const result =
+		opts.status === 'APPROVED' ? 'đã được DUYỆT' : 'đã bị TRẢ LẠI'
+	const subject = `[Quản lý phép] Đơn ${typeLabel} của ${opts.personnelName} ${result}`
+	const lines = [
+		`Xin chào ${opts.personnelName},`,
+		``,
+		`Đơn đề xuất ${typeLabel} (${opts.totalDays} ngày) của bạn ${result}.`,
+		opts.startDate || opts.endDate
+			? `Thời gian: ${opts.startDate || '—'} → ${opts.endDate || '—'}`
+			: '',
+		opts.actorName ? `Người xử lý: ${opts.actorName}` : '',
+		opts.adminNote ? `Ghi chú: ${opts.adminNote}` : '',
+		``,
+		`Vui lòng đăng nhập hệ thống → Quản lý phép để xem chi tiết.`,
+		`— Hệ thống quản lý học viên / phép`
+	].filter(Boolean)
+	return { subject, text: lines.join('\n') }
+}
+
+export function buildLeaveSubmittedMail(opts: {
+	personnelName: string
+	personnelCode?: string | null
+	totalDays: number
+	leaveType: string
+	startDate?: string | null
+	endDate?: string | null
+	localityPath?: string | null
+	toRole: 'commander' | 'agency' | 'proposer'
+}): { subject: string; text: string } {
+	const typeLabel =
+		opts.leaveType === 'SPECIAL' ? 'phép đặc biệt' : 'phép hằng năm'
+	const code = opts.personnelCode ? ` (${opts.personnelCode})` : ''
+	if (opts.toRole === 'proposer') {
+		return {
+			subject: `[Quản lý phép] Đã gửi đề xuất ${typeLabel}`,
+			text: [
+				`Xin chào ${opts.personnelName},`,
+				``,
+				`Đơn đề xuất ${typeLabel} (${opts.totalDays} ngày) đã được gửi và đang chờ duyệt.`,
+				opts.startDate
+					? `Thời gian: ${opts.startDate} → ${opts.endDate || '—'}`
+					: '',
+				opts.localityPath ? `Nơi nghỉ: ${opts.localityPath}` : '',
+				``,
+				`Bạn sẽ nhận email khi đơn được duyệt hoặc trả lại.`,
+				`— Hệ thống quản lý phép`
+			]
+				.filter(Boolean)
+				.join('\n')
+		}
+	}
+	const roleHint =
+		opts.toRole === 'commander'
+			? 'Vui lòng đăng nhập → Quản lý phép → Duyệt đề xuất để xử lý (bước chỉ huy CQ).'
+			: 'Vui lòng đăng nhập → Quản lý phép → Duyệt đề xuất để ký / duyệt cuối (CQQL).'
+	return {
+		subject: `[Quản lý phép] Có đơn ${typeLabel} chờ duyệt — ${opts.personnelName}${code}`,
+		text: [
+			`Kính gửi đồng chí,`,
+			``,
+			`Có đơn đề xuất ${typeLabel} cần xử lý:`,
+			`• Họ tên: ${opts.personnelName}${code}`,
+			`• Số ngày: ${opts.totalDays}`,
+			opts.startDate
+				? `• Thời gian: ${opts.startDate} → ${opts.endDate || '—'}`
+				: '',
+			opts.localityPath ? `• Nơi nghỉ: ${opts.localityPath}` : '',
+			``,
+			roleHint,
+			`— Hệ thống quản lý phép`
+		]
+			.filter(Boolean)
+			.join('\n')
+	}
+}
+
+/** Resolve email: personnel.email hoặc username dạng email */
+export function looksLikeEmail(s: string | null | undefined): boolean {
+	if (!s) return false
+	return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s.trim())
+}

--- a/apps/api/leave-management/personnel.ts
+++ b/apps/api/leave-management/personnel.ts
@@ -1,0 +1,529 @@
+/**
+ * CRUD danh sách quân nhân (catalog phép)
+ */
+import { api, APIError, Query } from 'encore.dev/api'
+import { and, eq, inArray, like, or, sql } from 'drizzle-orm'
+import { getAuthData } from '~encore/auth'
+import orm from '../database'
+import {
+	leaveClasses,
+	leavePersonnel,
+	type LeaveObjectType
+} from '../schema/leave-management'
+import { isLeaveObjectType, normalizeObjectType } from './helpers'
+import { resolveUnitCommander } from './units'
+import { resolveLeaveAccess } from './access'
+
+export interface PersonnelResponse {
+	id: number
+	createdAt: string
+	updatedAt: string
+	code: string
+	fullName: string
+	enlistmentDate: string | null
+	recruitment: string | null
+	objectType: LeaveObjectType
+	rank: string | null
+	position: string | null
+	classId: number | null
+	unitId: number | null
+	unitName: string | null
+	hometown: string | null
+	permanentResidence: string | null
+	userId: number | null
+	email: string | null
+	commanderUserId: number | null
+	commanderName: string | null
+	className: string | null
+	managementArea: string
+}
+
+function mapRow(r: typeof leavePersonnel.$inferSelect): PersonnelResponse {
+	return {
+		id: r.id,
+		createdAt: r.createdAt ?? '',
+		updatedAt: r.updatedAt ?? '',
+		code: r.code,
+		fullName: r.fullName,
+		enlistmentDate: r.enlistmentDate,
+		recruitment: r.recruitment,
+		objectType: r.objectType as LeaveObjectType,
+		rank: r.rank,
+		position: r.position,
+		classId: r.classId ?? null,
+		unitId: r.unitId,
+		unitName: r.unitName,
+		hometown: r.hometown,
+		permanentResidence: r.permanentResidence,
+		userId: r.userId,
+		email: r.email ?? null,
+		commanderUserId: r.commanderUserId ?? null,
+		commanderName: r.commanderName ?? null,
+		className: r.className ?? null,
+		managementArea: r.managementArea
+	}
+}
+
+export const ListLeavePersonnel = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/personnel'
+	},
+	async (q: {
+		search?: Query<string>
+		objectType?: Query<string>
+	}): Promise<{ data: PersonnelResponse[] }> => {
+		const auth = getAuthData()!
+		const access = await resolveLeaveAccess(
+			Number(auth.userID),
+			!!auth.isSuperAdmin
+		)
+		const conditions = []
+		if (!access.isAdmin) {
+			if (access.unitIds.length) {
+				conditions.push(inArray(leavePersonnel.unitId, access.unitIds))
+			} else {
+				conditions.push(eq(leavePersonnel.userId, Number(auth.userID)))
+			}
+		}
+		if (q.objectType && isLeaveObjectType(String(q.objectType))) {
+			conditions.push(
+				eq(leavePersonnel.objectType, q.objectType as LeaveObjectType)
+			)
+		}
+		if (q.search) {
+			const s = `%${String(q.search).trim()}%`
+			conditions.push(
+				or(
+					like(leavePersonnel.code, s),
+					like(leavePersonnel.fullName, s),
+					like(leavePersonnel.unitName, s)
+				)!
+			)
+		}
+		const rows = await orm
+			.select()
+			.from(leavePersonnel)
+			.where(conditions.length ? and(...conditions) : undefined)
+			.orderBy(sql`${leavePersonnel.id} desc`)
+		return { data: rows.map(mapRow) }
+	}
+)
+
+export const GetLeavePersonnel = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/personnel/:id'
+	},
+	async ({ id }: { id: number }): Promise<{ data: PersonnelResponse }> => {
+		const auth = getAuthData()!
+		const access = await resolveLeaveAccess(
+			Number(auth.userID),
+			!!auth.isSuperAdmin
+		)
+		const rows = await orm
+			.select()
+			.from(leavePersonnel)
+			.where(eq(leavePersonnel.id, id))
+			.limit(1)
+		if (!rows[0]) throw APIError.notFound('Không tìm thấy quân nhân')
+		if (
+			!access.isAdmin &&
+			rows[0].userId !== Number(auth.userID) &&
+			(rows[0].unitId == null || !access.unitIds.includes(rows[0].unitId))
+		) {
+			throw APIError.permissionDenied('Không có quyền xem quân nhân này')
+		}
+		return { data: mapRow(rows[0]) }
+	}
+)
+
+export const GetMyLeavePersonnel = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/my-personnel'
+	},
+	async (): Promise<{ data: PersonnelResponse | null }> => {
+		const { getAuthData } = await import('~encore/auth')
+		const auth = getAuthData()
+		if (!auth?.userID) return { data: null }
+		const uid = Number(auth.userID)
+		const rows = await orm
+			.select()
+			.from(leavePersonnel)
+			.where(eq(leavePersonnel.userId, uid))
+			.limit(1)
+		return { data: rows[0] ? mapRow(rows[0]) : null }
+	}
+)
+
+interface CreatePersonnelBody {
+	/** Bỏ trống → hệ thống tự sinh (QN-xxxxxx) */
+	code?: string | null
+	fullName: string
+	enlistmentDate?: string | null
+	recruitment?: string | null
+	objectType: string
+	rank?: string | null
+	position?: string | null
+	classId?: number | null
+	unitId?: number | null
+	unitName?: string | null
+	hometown?: string | null
+	permanentResidence?: string | null
+	userId?: number | null
+	email?: string | null
+	commanderUserId?: number | null
+	commanderName?: string | null
+	className?: string | null
+	managementArea?: string
+}
+
+async function generatePersonnelCode(): Promise<string> {
+	const rows = await orm
+		.select({ id: leavePersonnel.id })
+		.from(leavePersonnel)
+		.orderBy(sql`${leavePersonnel.id} desc`)
+		.limit(1)
+	const next = (rows[0]?.id ?? 0) + 1
+	const base = `QN-${String(next).padStart(6, '0')}`
+	// ensure unique even if ids were deleted
+	const clash = await orm
+		.select({ id: leavePersonnel.id })
+		.from(leavePersonnel)
+		.where(eq(leavePersonnel.code, base))
+		.limit(1)
+	if (!clash[0]) return base
+	return `QN-${Date.now().toString(36).toUpperCase()}`
+}
+
+export const CreateLeavePersonnel = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/personnel'
+	},
+	async (body: CreatePersonnelBody): Promise<{ data: PersonnelResponse }> => {
+		if (!body.fullName?.trim()) {
+			throw APIError.invalidArgument('Tên là bắt buộc')
+		}
+		if (!isLeaveObjectType(body.objectType)) {
+			throw APIError.invalidArgument('Đối tượng không hợp lệ')
+		}
+		const objectType = normalizeObjectType(body.objectType)!
+		const code = body.code?.trim()
+			? body.code.trim()
+			: await generatePersonnelCode()
+		// Chỉ huy CQ lấy cố định theo đơn vị
+		const unitId = body.unitId ?? null
+		const fromUnit = await resolveUnitCommander(unitId)
+		const commanderUserId =
+			fromUnit.commanderUserId ?? body.commanderUserId ?? null
+		const commanderName =
+			fromUnit.commanderName ?? (body.commanderName?.trim() || null)
+		try {
+			const inserted = await orm
+				.insert(leavePersonnel)
+				.values({
+					code,
+					fullName: body.fullName.trim(),
+					enlistmentDate: body.enlistmentDate || null,
+					recruitment: body.recruitment || null,
+					objectType,
+					rank: body.rank || null,
+					position: body.position || null,
+					classId: body.classId ?? null,
+					unitId,
+					unitName: body.unitName || null,
+					hometown: body.hometown || null,
+					permanentResidence: body.permanentResidence || null,
+					userId: body.userId ?? null,
+					email: body.email?.trim() || null,
+					commanderUserId,
+					commanderName,
+					className: body.className || null,
+					managementArea: body.managementArea || 'cán_bộ'
+				})
+				.returning()
+			return { data: mapRow(inserted[0]!) }
+		} catch (e: unknown) {
+			const msg = String((e as Error)?.message || e)
+			if (/unique|UNIQUE/i.test(msg)) {
+				throw APIError.alreadyExists('Mã quân nhân đã tồn tại')
+			}
+			throw e
+		}
+	}
+)
+
+export const UpdateLeavePersonnel = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'PATCH',
+		path: '/leave/personnel/:id'
+	},
+	async ({
+		id,
+		...body
+	}: { id: number } & Partial<CreatePersonnelBody>): Promise<{
+		data: PersonnelResponse
+	}> => {
+		const existing = await orm
+			.select()
+			.from(leavePersonnel)
+			.where(eq(leavePersonnel.id, id))
+			.limit(1)
+		if (!existing[0]) throw APIError.notFound('Không tìm thấy quân nhân')
+		if (body.objectType && !isLeaveObjectType(body.objectType)) {
+			throw APIError.invalidArgument('Đối tượng không hợp lệ')
+		}
+
+		// Khi đổi đơn vị → gán lại chỉ huy CQ theo đơn vị
+		const nextUnitId =
+			body.unitId !== undefined
+				? (body.unitId ?? null)
+				: existing[0].unitId
+		const fromUnit = await resolveUnitCommander(nextUnitId)
+		const commanderUserId =
+			fromUnit.commanderUserId ??
+			(body.commanderUserId !== undefined
+				? (body.commanderUserId ?? null)
+				: existing[0].commanderUserId)
+		const commanderName =
+			fromUnit.commanderName ??
+			(body.commanderName !== undefined
+				? body.commanderName?.trim() || null
+				: existing[0].commanderName)
+
+		const updated = await orm
+			.update(leavePersonnel)
+			.set({
+				...(body.code != null ? { code: body.code.trim() } : {}),
+				...(body.fullName != null
+					? { fullName: body.fullName.trim() }
+					: {}),
+				...(body.enlistmentDate !== undefined
+					? { enlistmentDate: body.enlistmentDate || null }
+					: {}),
+				...(body.recruitment !== undefined
+					? { recruitment: body.recruitment || null }
+					: {}),
+				...(body.objectType
+					? {
+							objectType:
+								normalizeObjectType(body.objectType) ||
+								(body.objectType as LeaveObjectType)
+						}
+					: {}),
+				...(body.rank !== undefined ? { rank: body.rank || null } : {}),
+				...(body.position !== undefined
+					? { position: body.position || null }
+					: {}),
+				...(body.classId !== undefined
+					? { classId: body.classId ?? null }
+					: {}),
+				...(body.unitId !== undefined
+					? { unitId: body.unitId ?? null }
+					: {}),
+				...(body.unitName !== undefined
+					? { unitName: body.unitName || null }
+					: {}),
+				...(body.hometown !== undefined
+					? { hometown: body.hometown || null }
+					: {}),
+				...(body.permanentResidence !== undefined
+					? { permanentResidence: body.permanentResidence || null }
+					: {}),
+				...(body.userId !== undefined
+					? { userId: body.userId ?? null }
+					: {}),
+				...(body.email !== undefined
+					? { email: body.email?.trim() || null }
+					: {}),
+				...(body.className !== undefined
+					? { className: body.className || null }
+					: {}),
+				...(body.managementArea !== undefined
+					? { managementArea: body.managementArea }
+					: {}),
+				commanderUserId,
+				commanderName
+			})
+			.where(eq(leavePersonnel.id, id))
+			.returning()
+		return { data: mapRow(updated[0]!) }
+	}
+)
+
+export const DeleteLeavePersonnel = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'DELETE',
+		path: '/leave/personnel/:id'
+	},
+	async ({ id }: { id: number }): Promise<{ ok: boolean }> => {
+		const res = await orm
+			.delete(leavePersonnel)
+			.where(eq(leavePersonnel.id, id))
+			.returning()
+		if (!res[0]) throw APIError.notFound('Không tìm thấy quân nhân')
+		return { ok: true }
+	}
+)
+
+export interface ImportPersonnelItem {
+	/** Bỏ trống → tự sinh */
+	code?: string | null
+	fullName: string
+	enlistmentDate?: string | null
+	recruitment?: string | null
+	objectType: string
+	rank?: string | null
+	position?: string | null
+	unitId?: number | null
+	unitName?: string | null
+	hometown?: string | null
+	permanentResidence?: string | null
+	userId?: number | null
+}
+
+export interface ImportPersonnelResult {
+	successCount: number
+	errorCount: number
+	totalCount: number
+	errors: { row: number; message: string }[]
+}
+
+/** Import hàng loạt — upsert theo mã (code). */
+export const ImportLeavePersonnel = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/personnel/import'
+	},
+	async (body: {
+		items: ImportPersonnelItem[]
+	}): Promise<{ data: ImportPersonnelResult }> => {
+		const items = body.items || []
+		if (!items.length) {
+			throw APIError.invalidArgument('Danh sách import trống')
+		}
+		if (items.length > 2000) {
+			throw APIError.invalidArgument('Tối đa 2000 dòng mỗi lần import')
+		}
+
+		const errors: { row: number; message: string }[] = []
+		let successCount = 0
+		const maxRow = await orm
+			.select({ id: leavePersonnel.id })
+			.from(leavePersonnel)
+			.orderBy(sql`${leavePersonnel.id} desc`)
+			.limit(1)
+		let nextSeq = (maxRow[0]?.id ?? 0) + 1
+		const usedCodes = new Set<string>()
+
+		for (let i = 0; i < items.length; i++) {
+			const row = i + 1
+			const item = items[i]!
+			let code = String(item.code || '').trim()
+			const fullName = String(item.fullName || '').trim()
+			if (!fullName) {
+				errors.push({ row, message: 'Tên là bắt buộc' })
+				continue
+			}
+			if (!code) {
+				do {
+					code = `QN-${String(nextSeq++).padStart(6, '0')}`
+				} while (usedCodes.has(code))
+			}
+			usedCodes.add(code)
+			const objectTypeRaw = String(item.objectType || 'SQ')
+				.trim()
+				.toUpperCase()
+			if (!isLeaveObjectType(objectTypeRaw)) {
+				errors.push({
+					row,
+					message: `Đối tượng không hợp lệ: ${item.objectType}`
+				})
+				continue
+			}
+			const objectType = normalizeObjectType(objectTypeRaw)!
+			let userId: number | null = null
+			if (item.userId != null && String(item.userId).trim() !== '') {
+				userId = Number(item.userId)
+				if (Number.isNaN(userId) || userId <= 0) {
+					errors.push({ row, message: 'User ID không hợp lệ' })
+					continue
+				}
+			}
+
+			const values = {
+				code,
+				fullName,
+				enlistmentDate: item.enlistmentDate
+					? String(item.enlistmentDate).trim() || null
+					: null,
+				recruitment: item.recruitment
+					? String(item.recruitment).trim() || null
+					: null,
+				objectType,
+				rank: item.rank ? String(item.rank).trim() || null : null,
+				position: item.position
+					? String(item.position).trim() || null
+					: null,
+				unitId: item.unitId ?? null,
+				unitName: item.unitName
+					? String(item.unitName).trim() || null
+					: null,
+				hometown: item.hometown
+					? String(item.hometown).trim() || null
+					: null,
+				permanentResidence: item.permanentResidence
+					? String(item.permanentResidence).trim() || null
+					: null,
+				userId: userId && userId > 0 ? userId : null
+			}
+
+			try {
+				const existing = await orm
+					.select()
+					.from(leavePersonnel)
+					.where(eq(leavePersonnel.code, code))
+					.limit(1)
+				if (existing[0]) {
+					await orm
+						.update(leavePersonnel)
+						.set(values)
+						.where(eq(leavePersonnel.id, existing[0].id))
+				} else {
+					await orm.insert(leavePersonnel).values(values)
+				}
+				successCount++
+			} catch (e: unknown) {
+				errors.push({
+					row,
+					message: String((e as Error)?.message || e)
+				})
+			}
+		}
+
+		return {
+			data: {
+				successCount,
+				errorCount: errors.length,
+				totalCount: items.length,
+				errors
+			}
+		}
+	}
+)

--- a/apps/api/leave-management/positions.ts
+++ b/apps/api/leave-management/positions.ts
@@ -1,0 +1,107 @@
+import { api, APIError, Query } from 'encore.dev/api'
+import { asc, eq } from 'drizzle-orm'
+import orm from '../database'
+import { leavePositions } from '../schema/leave-positions'
+
+type PositionResponse = {
+	id: number
+	name: string
+	sortOrder: number
+	isActive: boolean
+}
+
+const mapPosition = (
+	row: typeof leavePositions.$inferSelect
+): PositionResponse => ({
+	id: row.id,
+	name: row.name,
+	sortOrder: row.sortOrder,
+	isActive: !!row.isActive
+})
+
+export const ListLeavePositions = api(
+	{ auth: true, expose: true, method: 'GET', path: '/leave/positions' },
+	async (q: {
+		activeOnly?: Query<boolean>
+	}): Promise<{ data: PositionResponse[] }> => {
+		const activeOnly = String(q.activeOnly ?? 'true') !== 'false'
+		const rows = await orm
+			.select()
+			.from(leavePositions)
+			.where(activeOnly ? eq(leavePositions.isActive, true) : undefined)
+			.orderBy(asc(leavePositions.sortOrder), asc(leavePositions.name))
+		return { data: rows.map(mapPosition) }
+	}
+)
+
+export const CreateLeavePosition = api(
+	{ auth: true, expose: true, method: 'POST', path: '/leave/positions' },
+	async (body: {
+		name: string
+		sortOrder?: number
+		isActive?: boolean
+	}): Promise<{ data: PositionResponse }> => {
+		if (!body.name?.trim())
+			throw APIError.invalidArgument('Tên chức vụ là bắt buộc')
+		try {
+			const rows = await orm
+				.insert(leavePositions)
+				.values({
+					name: body.name.trim(),
+					sortOrder: body.sortOrder ?? 0,
+					isActive: body.isActive !== false
+				})
+				.returning()
+			return { data: mapPosition(rows[0]!) }
+		} catch {
+			throw APIError.alreadyExists('Chức vụ đã tồn tại')
+		}
+	}
+)
+
+export const UpdateLeavePosition = api(
+	{ auth: true, expose: true, method: 'PATCH', path: '/leave/positions/:id' },
+	async ({
+		id,
+		...body
+	}: {
+		id: number
+		name?: string
+		sortOrder?: number
+		isActive?: boolean
+	}): Promise<{ data: PositionResponse }> => {
+		const rows = await orm
+			.update(leavePositions)
+			.set({
+				...(body.name !== undefined ? { name: body.name.trim() } : {}),
+				...(body.sortOrder !== undefined
+					? { sortOrder: body.sortOrder }
+					: {}),
+				...(body.isActive !== undefined
+					? { isActive: body.isActive }
+					: {}),
+				updatedAt: new Date().toISOString()
+			})
+			.where(eq(leavePositions.id, id))
+			.returning()
+		if (!rows[0]) throw APIError.notFound('Không tìm thấy chức vụ')
+		return { data: mapPosition(rows[0]) }
+	}
+)
+
+export const DeleteLeavePosition = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'DELETE',
+		path: '/leave/positions/:id'
+	},
+	async ({ id }: { id: number }): Promise<{ ok: boolean }> => {
+		const rows = await orm
+			.delete(leavePositions)
+			.where(eq(leavePositions.id, id))
+			.returning()
+		if (!rows[0]) throw APIError.notFound('Không tìm thấy chức vụ')
+		return { ok: true }
+	}
+)

--- a/apps/api/leave-management/records.ts
+++ b/apps/api/leave-management/records.ts
@@ -52,7 +52,7 @@ export interface LeaveRecordResponse {
 	decidedByUsername: string | null
 	decidedAt: string | null
 	archivedAt: string
-	requestScope: 'INDIVIDUAL' | 'CLASS'
+	requestScope: 'INDIVIDUAL' | 'CLASS' | 'SHORT_LEAVE'
 	classId: number | null
 	className: string | null
 	memberCount: number

--- a/apps/api/leave-management/records.ts
+++ b/apps/api/leave-management/records.ts
@@ -1,0 +1,281 @@
+/**
+ * Bảng lưu thông tin nghỉ phép — chỉ công khai bản ghi đã được ký duyệt.
+ */
+import { api, APIError, Query } from 'encore.dev/api'
+import { and, desc, eq, inArray, like, or } from 'drizzle-orm'
+import { getAuthData } from '~encore/auth'
+import orm from '../database'
+import {
+	leaveRecords,
+	leaveRequests,
+	type LeaveObjectType,
+	type LeaveRequestStatus,
+	type LeaveType
+} from '../schema/leave-management'
+import { OBJECT_TYPE_LABELS, objectTypeLabel } from './helpers'
+import { resolveLeaveAccess } from './access'
+import { writeLeaveAudit } from './audit'
+
+export interface LeaveRecordResponse {
+	id: number
+	createdAt: string
+	updatedAt: string
+	requestId: number
+	status: LeaveRequestStatus
+	leaveType: LeaveType
+	personnelId: number | null
+	personnelCode: string | null
+	personnelName: string | null
+	objectType: LeaveObjectType
+	objectTypeLabel: string
+	rank: string | null
+	position: string | null
+	enlistmentDate: string | null
+	unitId: number | null
+	unitName: string | null
+	serviceYears: number
+	baseDays: number
+	travelDays: number
+	extraDays: number
+	extraReasons: string[]
+	totalDays: number
+	startDate: string | null
+	endDate: string | null
+	localityId: number | null
+	localityPath: string | null
+	note: string | null
+	adminNote: string | null
+	proposedByUserId: number | null
+	proposedByUsername: string | null
+	proposedByDisplayName: string | null
+	decidedByUserId: number | null
+	decidedByUsername: string | null
+	decidedAt: string | null
+	archivedAt: string
+	requestScope: 'INDIVIDUAL' | 'CLASS'
+	classId: number | null
+	className: string | null
+	memberCount: number
+}
+
+function parseReasons(raw: string | null): string[] {
+	if (!raw) return []
+	try {
+		const v = JSON.parse(raw)
+		return Array.isArray(v) ? v.map(String) : []
+	} catch {
+		return []
+	}
+}
+
+function mapRow(r: typeof leaveRecords.$inferSelect): LeaveRecordResponse {
+	const ot = r.objectType as LeaveObjectType
+	return {
+		id: r.id,
+		createdAt: r.createdAt ?? '',
+		updatedAt: r.updatedAt ?? '',
+		requestId: r.requestId,
+		status: ((r as { status?: string }).status ||
+			'PENDING') as LeaveRequestStatus,
+		leaveType: r.leaveType as LeaveType,
+		personnelId: r.personnelId,
+		personnelCode: r.personnelCode,
+		personnelName: r.personnelName,
+		objectType: ot,
+		objectTypeLabel: objectTypeLabel(ot) || OBJECT_TYPE_LABELS[ot] || ot,
+		rank: r.rank,
+		position: r.position,
+		enlistmentDate: r.enlistmentDate,
+		unitId: r.unitId,
+		unitName: r.unitName,
+		serviceYears: r.serviceYears,
+		baseDays: r.baseDays,
+		travelDays: r.travelDays,
+		extraDays: r.extraDays,
+		extraReasons: parseReasons(r.extraReasons),
+		totalDays: r.totalDays,
+		startDate: r.startDate,
+		endDate: r.endDate,
+		localityId: r.localityId,
+		localityPath: r.localityPath,
+		note: r.note,
+		adminNote: r.adminNote,
+		proposedByUserId: r.proposedByUserId,
+		proposedByUsername: r.proposedByUsername,
+		proposedByDisplayName: r.proposedByDisplayName,
+		decidedByUserId: r.decidedByUserId,
+		decidedByUsername: r.decidedByUsername,
+		decidedAt: r.decidedAt,
+		archivedAt: r.archivedAt,
+		requestScope: 'INDIVIDUAL',
+		classId: null,
+		className: null,
+		memberCount: 1
+	}
+}
+
+export const ListLeaveRecords = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/records'
+	},
+	async (q: {
+		search?: Query<string>
+		year?: Query<number>
+		leaveType?: Query<string>
+		objectType?: Query<string>
+		status?: Query<string>
+	}): Promise<{ data: LeaveRecordResponse[] }> => {
+		const auth = getAuthData()!
+		const access = await resolveLeaveAccess(
+			Number(auth.userID),
+			!!auth.isSuperAdmin
+		)
+		const conditions = []
+		// Lưu trữ là sổ các giấy phép đã ký, không phải lịch sử luân chuyển đơn.
+		conditions.push(eq(leaveRecords.status, 'APPROVED'))
+		if (!access.isAdmin) {
+			if (!access.unitIds.length) return { data: [] }
+			conditions.push(inArray(leaveRecords.unitId, access.unitIds))
+		}
+		if (q.leaveType === 'ANNUAL' || q.leaveType === 'SPECIAL') {
+			conditions.push(eq(leaveRecords.leaveType, q.leaveType))
+		}
+		if (q.objectType) {
+			conditions.push(
+				eq(
+					leaveRecords.objectType,
+					String(q.objectType) as LeaveObjectType
+				)
+			)
+		}
+		if (q.year) {
+			const y = String(Number(q.year))
+			conditions.push(like(leaveRecords.startDate, `${y}%`))
+		}
+		if (q.search) {
+			const s = `%${String(q.search).trim()}%`
+			conditions.push(
+				or(
+					like(leaveRecords.personnelName, s),
+					like(leaveRecords.personnelCode, s),
+					like(leaveRecords.unitName, s),
+					like(leaveRecords.localityPath, s)
+				)!
+			)
+		}
+		const rows = await orm
+			.select()
+			.from(leaveRecords)
+			.where(conditions.length ? and(...conditions) : undefined)
+			.orderBy(desc(leaveRecords.id))
+			.limit(500)
+		const requestRows = rows.length
+			? await orm
+					.select({
+						id: leaveRequests.id,
+						requestScope: leaveRequests.requestScope,
+						classId: leaveRequests.classId,
+						className: leaveRequests.className,
+						proposedByUserId: leaveRequests.proposedByUserId,
+						createdAt: leaveRequests.createdAt
+					})
+					.from(leaveRequests)
+					.where(
+						inArray(
+							leaveRequests.id,
+							rows.map((r) => r.requestId)
+						)
+					)
+			: []
+		const requestMeta = new Map(requestRows.map((r) => [r.id, r]))
+		const grouped = new Map<string, LeaveRecordResponse>()
+		for (const row of rows) {
+			const mapped = mapRow(row)
+			const meta = requestMeta.get(row.requestId)
+			const isClass =
+				meta?.requestScope === 'CLASS' && meta.classId != null
+			const key = isClass
+				? [
+						'class',
+						meta.classId,
+						meta.proposedByUserId ?? '',
+						row.leaveType,
+						row.startDate ?? '',
+						row.endDate ?? '',
+						row.totalDays,
+						row.note ?? '',
+						String(meta.createdAt).slice(0, 16)
+					].join(':')
+				: `request:${row.requestId}`
+			const existing = grouped.get(key)
+			if (existing) {
+				existing.memberCount += 1
+			} else {
+				grouped.set(
+					key,
+					isClass
+						? {
+								...mapped,
+								requestScope: 'CLASS',
+								classId: meta.classId,
+								className: meta.className,
+								memberCount: 1,
+								personnelId: null,
+								personnelCode: null,
+								personnelName: meta.className || 'Lớp',
+								objectType: 'HV',
+								objectTypeLabel: 'Học viên'
+							}
+						: mapped
+				)
+			}
+		}
+		const result = [...grouped.values()]
+		await writeLeaveAudit({
+			action: 'VIEW',
+			entityType: 'LEAVE_REPORT',
+			details: {
+				year: q.year,
+				leaveType: q.leaveType,
+				count: result.length
+			}
+		})
+		return { data: result }
+	}
+)
+
+export const GetLeaveRecord = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/records/:id'
+	},
+	async ({ id }: { id: number }): Promise<{ data: LeaveRecordResponse }> => {
+		const auth = getAuthData()!
+		const access = await resolveLeaveAccess(
+			Number(auth.userID),
+			!!auth.isSuperAdmin
+		)
+		const rows = await orm
+			.select()
+			.from(leaveRecords)
+			.where(eq(leaveRecords.id, id))
+			.limit(1)
+		if (!rows[0])
+			throw APIError.notFound('Không tìm thấy bản ghi nghỉ phép')
+		if (rows[0].status !== 'APPROVED') {
+			throw APIError.notFound('Bản ghi chưa được ký duyệt')
+		}
+		if (
+			!access.isAdmin &&
+			(rows[0].unitId == null || !access.unitIds.includes(rows[0].unitId))
+		) {
+			throw APIError.permissionDenied('Không có quyền xem bản ghi này')
+		}
+		return { data: mapRow(rows[0]) }
+	}
+)

--- a/apps/api/leave-management/regulations.ts
+++ b/apps/api/leave-management/regulations.ts
@@ -1,0 +1,397 @@
+/**
+ * Quy định về phép + tính ngày phép cơ bản
+ */
+import { api, APIError, Query } from 'encore.dev/api'
+import { and, asc, eq } from 'drizzle-orm'
+import orm from '../database'
+import {
+	leaveRegulations,
+	leaveObjectTypes,
+	leaveExtraStandards,
+	type LeaveObjectType,
+	type LeaveType
+} from '../schema/leave-management'
+import {
+	asOfFromDate,
+	canTakeSpecialLeave,
+	computeServiceYears,
+	isLeaveObjectType,
+	normalizeObjectType,
+	objectTypeLabel,
+	resolveAnnualBaseDays,
+	OBJECT_TYPE_LABELS,
+	EXTRA_5_REASONS,
+	EXTRA_10_REASONS,
+	SPECIAL_REASONS,
+	SPECIAL_MAX_DAYS,
+	CANONICAL_OBJECT_TYPES
+} from './helpers'
+
+export interface RegulationResponse {
+	id: number
+	createdAt: string
+	updatedAt: string
+	leaveType: LeaveType
+	objectType: LeaveObjectType | null
+	objectTypeLabel: string | null
+	minYears: number | null
+	maxYears: number | null
+	baseDays: number
+	label: string | null
+	description: string | null
+	isActive: boolean
+}
+
+function mapRow(r: typeof leaveRegulations.$inferSelect): RegulationResponse {
+	const ot = r.objectType
+		? normalizeObjectType(String(r.objectType)) ||
+			(r.objectType as LeaveObjectType)
+		: null
+	return {
+		id: r.id,
+		createdAt: r.createdAt ?? '',
+		updatedAt: r.updatedAt ?? '',
+		leaveType: r.leaveType as LeaveType,
+		objectType: ot,
+		objectTypeLabel: ot ? objectTypeLabel(ot) : null,
+		minYears: r.minYears,
+		maxYears: r.maxYears,
+		baseDays: r.baseDays,
+		label: r.label,
+		description: r.description,
+		isActive: !!r.isActive
+	}
+}
+
+export const ListLeaveRegulations = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/regulations'
+	},
+	async (q: {
+		leaveType?: Query<string>
+	}): Promise<{ data: RegulationResponse[] }> => {
+		const conditions = []
+		if (q.leaveType === 'ANNUAL' || q.leaveType === 'SPECIAL') {
+			conditions.push(eq(leaveRegulations.leaveType, q.leaveType))
+		}
+		const rows = await orm
+			.select()
+			.from(leaveRegulations)
+			.where(conditions.length ? and(...conditions) : undefined)
+			.orderBy(
+				asc(leaveRegulations.leaveType),
+				asc(leaveRegulations.objectType),
+				asc(leaveRegulations.minYears)
+			)
+		return { data: rows.map(mapRow) }
+	}
+)
+
+/** Metadata form đề xuất: đối tượng, lý do nghỉ thêm */
+export const GetLeaveMeta = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/meta'
+	},
+	async (): Promise<{
+		data: {
+			objectTypes: { code: LeaveObjectType; label: string }[]
+			extra10Reasons: { code: string; label: string }[]
+			extra5Reasons: { code: string; label: string }[]
+			specialReasons: { code: string; label: string }[]
+			specialMaxDays: number
+			specialEligible: LeaveObjectType[]
+		}
+	}> => {
+		// Bảng đối tượng (DB) → fallback hardcode
+		let objectTypes: { code: LeaveObjectType; label: string }[] = []
+		try {
+			const ots = await orm
+				.select()
+				.from(leaveObjectTypes)
+				.where(eq(leaveObjectTypes.isActive, true))
+				.orderBy(asc(leaveObjectTypes.sortOrder))
+			objectTypes = ots.map((o) => ({
+				code: o.code as LeaveObjectType,
+				label: o.name
+			}))
+		} catch {
+			/* table may not exist yet */
+		}
+		if (!objectTypes.length) {
+			objectTypes = CANONICAL_OBJECT_TYPES.map((code) => ({
+				code,
+				label: OBJECT_TYPE_LABELS[code] || code
+			}))
+		}
+
+		// Tiêu chuẩn phép thêm (DB) → fallback
+		let extra10: { code: string; label: string }[] = []
+		let extra5: { code: string; label: string }[] = []
+		try {
+			const extras = await orm
+				.select()
+				.from(leaveExtraStandards)
+				.where(eq(leaveExtraStandards.isActive, true))
+				.orderBy(asc(leaveExtraStandards.sortOrder))
+			extra10 = extras
+				.filter((e) => e.days === 10)
+				.map((e) => ({ code: e.code, label: e.label }))
+			extra5 = extras
+				.filter((e) => e.days === 5)
+				.map((e) => ({ code: e.code, label: e.label }))
+		} catch {
+			/* table may not exist yet */
+		}
+		if (!extra10.length) {
+			extra10 = EXTRA_10_REASONS.filter((r) =>
+				['01', '02', '03'].includes(r.code)
+			).map((r) => ({ code: r.code, label: r.label }))
+		}
+		if (!extra5.length) {
+			extra5 = EXTRA_5_REASONS.filter((r) =>
+				['04', '05', '06'].includes(r.code)
+			).map((r) => ({ code: r.code, label: r.label }))
+		}
+
+		const specialEligible: LeaveObjectType[] = [
+			'SQ',
+			'QNCN',
+			'CNQP',
+			'VCQP'
+		]
+
+		return {
+			data: {
+				objectTypes,
+				extra10Reasons: extra10,
+				extra5Reasons: extra5,
+				specialReasons: SPECIAL_REASONS.map((r) => ({
+					code: r.code,
+					label: r.label
+				})),
+				specialMaxDays: SPECIAL_MAX_DAYS,
+				specialEligible
+			}
+		}
+	}
+)
+
+/** Tính ngày phép cơ bản theo đối tượng + thâm niên */
+export const ComputeLeaveDays = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/compute-days'
+	},
+	async (body: {
+		objectType: string
+		serviceYears?: number
+		enlistmentDate?: string | null
+		/** Ngày bắt đầu nghỉ — dùng tính thâm niên theo tài liệu */
+		startDate?: string | null
+		leaveType?: string
+		travelDays?: number
+		extraDays?: number
+		/** Số ngày phép đặc biệt (1–10) */
+		specialDays?: number
+	}): Promise<{
+		data: {
+			serviceYears: number
+			baseDays: number
+			travelDays: number
+			extraDays: number
+			totalDays: number
+		}
+	}> => {
+		if (!isLeaveObjectType(body.objectType)) {
+			throw APIError.invalidArgument('Đối tượng không hợp lệ')
+		}
+		const objectType = normalizeObjectType(body.objectType)!
+		const serviceYears =
+			body.serviceYears != null
+				? Number(body.serviceYears)
+				: computeServiceYears(
+						body.enlistmentDate,
+						asOfFromDate(body.startDate)
+					)
+		const leaveType = (body.leaveType || 'ANNUAL') as LeaveType
+
+		// Phép đặc biệt: tối đa 10 ngày / lần, không cộng nghỉ thêm/đi đường
+		if (leaveType === 'SPECIAL') {
+			if (!canTakeSpecialLeave(objectType)) {
+				throw APIError.invalidArgument(
+					'Chỉ sỹ quan, QNCN, công nhân QP và viên chức QP được nghỉ phép đặc biệt'
+				)
+			}
+			let specialDays = Number(body.specialDays ?? SPECIAL_MAX_DAYS)
+			if (!Number.isFinite(specialDays)) specialDays = SPECIAL_MAX_DAYS
+			specialDays = Math.min(
+				SPECIAL_MAX_DAYS,
+				Math.max(1, Math.floor(specialDays))
+			)
+			return {
+				data: {
+					serviceYears,
+					baseDays: specialDays,
+					travelDays: 0,
+					extraDays: 0,
+					totalDays: specialDays
+				}
+			}
+		}
+
+		let baseDays = resolveAnnualBaseDays(objectType, serviceYears)
+
+		// Ưu tiên rule DB (so khớp mã đã chuẩn hoá)
+		const rules = await orm
+			.select()
+			.from(leaveRegulations)
+			.where(
+				and(
+					eq(leaveRegulations.leaveType, leaveType),
+					eq(leaveRegulations.isActive, true)
+				)
+			)
+
+		const match = rules.find((r) => {
+			const rot = r.objectType
+				? normalizeObjectType(String(r.objectType))
+				: null
+			if (rot !== objectType) return false
+			const min = r.minYears ?? 0
+			const max = r.maxYears
+			if (serviceYears < min) return false
+			if (max != null && serviceYears >= max) return false
+			return true
+		})
+		if (match) baseDays = match.baseDays
+
+		const travelDays = Math.max(0, Number(body.travelDays || 0))
+		const extraDays = Math.max(0, Number(body.extraDays || 0))
+		return {
+			data: {
+				serviceYears,
+				baseDays,
+				travelDays,
+				extraDays,
+				totalDays: baseDays + travelDays + extraDays
+			}
+		}
+	}
+)
+
+interface CreateRegulationBody {
+	leaveType: string
+	objectType?: string | null
+	minYears?: number | null
+	maxYears?: number | null
+	baseDays: number
+	label?: string | null
+	description?: string | null
+	isActive?: boolean
+}
+
+export const CreateLeaveRegulation = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/regulations'
+	},
+	async (
+		body: CreateRegulationBody
+	): Promise<{ data: RegulationResponse }> => {
+		if (body.leaveType !== 'ANNUAL' && body.leaveType !== 'SPECIAL') {
+			throw APIError.invalidArgument('Loại phép không hợp lệ')
+		}
+		if (body.baseDays == null || body.baseDays < 0) {
+			throw APIError.invalidArgument('Số ngày không hợp lệ')
+		}
+		if (body.objectType && !isLeaveObjectType(body.objectType)) {
+			throw APIError.invalidArgument('Đối tượng không hợp lệ')
+		}
+		const inserted = await orm
+			.insert(leaveRegulations)
+			.values({
+				leaveType: body.leaveType as LeaveType,
+				objectType: (body.objectType as LeaveObjectType) || null,
+				minYears: body.minYears ?? null,
+				maxYears: body.maxYears ?? null,
+				baseDays: body.baseDays,
+				label: body.label || null,
+				description: body.description || null,
+				isActive: body.isActive !== false
+			})
+			.returning()
+		return { data: mapRow(inserted[0]!) }
+	}
+)
+
+export const UpdateLeaveRegulation = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'PATCH',
+		path: '/leave/regulations/:id'
+	},
+	async ({
+		id,
+		...body
+	}: { id: number } & Partial<CreateRegulationBody>): Promise<{
+		data: RegulationResponse
+	}> => {
+		const existing = await orm
+			.select()
+			.from(leaveRegulations)
+			.where(eq(leaveRegulations.id, id))
+			.limit(1)
+		if (!existing[0]) throw APIError.notFound('Không tìm thấy quy định')
+		const updated = await orm
+			.update(leaveRegulations)
+			.set({
+				...(body.baseDays != null ? { baseDays: body.baseDays } : {}),
+				...(body.label !== undefined
+					? { label: body.label || null }
+					: {}),
+				...(body.description !== undefined
+					? { description: body.description || null }
+					: {}),
+				...(body.isActive !== undefined
+					? { isActive: body.isActive }
+					: {}),
+				...(body.minYears !== undefined
+					? { minYears: body.minYears ?? null }
+					: {}),
+				...(body.maxYears !== undefined
+					? { maxYears: body.maxYears ?? null }
+					: {})
+			})
+			.where(eq(leaveRegulations.id, id))
+			.returning()
+		return { data: mapRow(updated[0]!) }
+	}
+)
+
+export const DeleteLeaveRegulation = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'DELETE',
+		path: '/leave/regulations/:id'
+	},
+	async ({ id }: { id: number }): Promise<{ ok: boolean }> => {
+		const res = await orm
+			.delete(leaveRegulations)
+			.where(eq(leaveRegulations.id, id))
+			.returning()
+		if (!res[0]) throw APIError.notFound('Không tìm thấy quy định')
+		return { ok: true }
+	}
+)

--- a/apps/api/leave-management/reports.ts
+++ b/apps/api/leave-management/reports.ts
@@ -1,0 +1,486 @@
+/**
+ * Báo cáo nghỉ phép
+ */
+import { api, APIError, Query } from 'encore.dev/api'
+import { and, desc, eq, inArray, like, or } from 'drizzle-orm'
+import { getAuthData } from '~encore/auth'
+import orm from '../database'
+import {
+	leaveRecords,
+	leaveRequests,
+	leavePersonnel,
+	students,
+	users
+} from '../schema'
+import type { LeaveObjectType } from '../schema/leave-management'
+import { resolveLeaveAccess } from './access'
+import { writeLeaveAudit } from './audit'
+
+export interface TakenListResponse {
+	id: number
+	createdAt: string
+	updatedAt: string
+	requestId: number
+	status: string
+	leaveType: string
+	personnelId: number | null
+	personnelCode: string | null
+	personnelName: string | null
+	objectType: LeaveObjectType
+	objectTypeLabel: string
+	rank: string | null
+	position: string | null
+	enlistmentDate: string | null
+	unitId: number | null
+	unitName: string | null
+	serviceYears: number
+	baseDays: number
+	travelDays: number
+	extraDays: number
+	extraReasons: string[]
+	totalDays: number
+	startDate: string | null
+	endDate: string | null
+	leaveYear: string
+	localityId: number | null
+	localityPath: string | null
+	note: string | null
+	adminNote: string | null
+	proposedByUserId: number | null
+	proposedByUsername: string | null
+	proposedByDisplayName: string | null
+	decidedByUserId: number | null
+	decidedByUsername: string | null
+	decidedAt: string | null
+	archivedAt: string
+}
+
+function parseReasons(raw: string | null): string[] {
+	if (!raw) return []
+	try {
+		const v = JSON.parse(raw)
+		return Array.isArray(v) ? v.map(String) : []
+	} catch {
+		return []
+	}
+}
+
+function objectTypeLabel(ot: LeaveObjectType): string {
+	const labels: Record<string, string> = {
+		SQ: 'Sĩ quan',
+		QNCN: 'Quân nhân chuyên nghiệp',
+		CNQP: 'Cán bộ quân phục',
+		VCQP: 'Viên chức quân phục',
+		HSQBS: 'Hạ sĩ quan - Binh sĩ',
+		HV: 'Học viên',
+		KHAC: 'Khác'
+	}
+	return labels[ot] || ot
+}
+
+function mapRow(r: typeof leaveRecords.$inferSelect): TakenListResponse {
+	const ot = r.objectType as LeaveObjectType
+	return {
+		id: r.id,
+		createdAt: r.createdAt ?? '',
+		updatedAt: r.updatedAt ?? '',
+		requestId: r.requestId,
+		status: (r as { status?: string }).status || 'PENDING',
+		leaveType: r.leaveType,
+		personnelId: r.personnelId,
+		personnelCode: r.personnelCode,
+		personnelName: r.personnelName,
+		objectType: ot,
+		objectTypeLabel: objectTypeLabel(ot),
+		rank: r.rank,
+		position: r.position,
+		enlistmentDate: r.enlistmentDate,
+		unitId: r.unitId,
+		unitName: r.unitName,
+		serviceYears: r.serviceYears,
+		baseDays: r.baseDays,
+		travelDays: r.travelDays,
+		extraDays: r.extraDays,
+		extraReasons: parseReasons(r.extraReasons),
+		totalDays: r.totalDays,
+		startDate: r.startDate,
+		endDate: r.endDate,
+		leaveYear:
+			r.leaveYear ||
+			String(r.startDate || '').slice(0, 4) ||
+			String(new Date().getFullYear()),
+		localityId: r.localityId,
+		localityPath: r.localityPath,
+		note: r.note,
+		adminNote: r.adminNote,
+		proposedByUserId: r.proposedByUserId,
+		proposedByUsername: r.proposedByUsername,
+		proposedByDisplayName: r.proposedByDisplayName,
+		decidedByUserId: r.decidedByUserId,
+		decidedByUsername: r.decidedByUsername,
+		decidedAt: r.decidedAt,
+		archivedAt: r.archivedAt
+	}
+}
+
+export const GetTakenLeaveList = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/reports/taken-list'
+	},
+	async (q: {
+		year: Query<number>
+		leaveType?: Query<string>
+		objectType?: Query<string>
+		search?: Query<string>
+		unitId?: Query<number>
+	}): Promise<{ data: TakenListResponse[] }> => {
+		const auth = getAuthData()!
+		const isAdmin = !!auth.isSuperAdmin
+
+		const conditions = [
+			or(
+				eq(leaveRecords.leaveYear, String(Number(q.year))),
+				like(leaveRecords.startDate, `${Number(q.year)}%`)
+			)!,
+			eq(leaveRecords.status, 'APPROVED')
+		]
+
+		if (!isAdmin) {
+			const access = await resolveLeaveAccess(
+				Number(auth.userID),
+				isAdmin
+			)
+			if (access.isCommander && access.unitIds.length) {
+				conditions.push(inArray(leaveRecords.unitId, access.unitIds))
+			}
+			const user = await orm
+				.select({ diện_quản_lý: users.diện_quản_lý })
+				.from(users)
+				.where(eq(users.id, Number(auth.userID)))
+				.limit(1)
+			const domain = user[0]?.diện_quản_lý
+			if (domain) {
+				const studentIds = (
+					await orm
+						.select({ id: students.id })
+						.from(students)
+						.where(eq(students.diện_quản_lý, domain))
+						.limit(10000)
+				).map((s) => s.id)
+				if (studentIds.length > 0) {
+					conditions.push(
+						inArray(leaveRecords.personnelId, studentIds)
+					)
+				}
+			}
+		}
+
+		if (q.leaveType === 'ANNUAL' || q.leaveType === 'SPECIAL') {
+			conditions.push(eq(leaveRecords.leaveType, q.leaveType))
+		}
+		if (q.objectType) {
+			conditions.push(
+				eq(
+					leaveRecords.objectType,
+					String(q.objectType) as LeaveObjectType
+				)
+			)
+		}
+		if (q.search) {
+			const s = `%${String(q.search).trim()}%`
+			conditions.push(
+				or(
+					like(leaveRecords.personnelName, s),
+					like(leaveRecords.personnelCode, s)
+				)!
+			)
+		}
+		if (q.unitId) {
+			conditions.push(eq(leaveRecords.unitId, Number(q.unitId)))
+		}
+
+		const rows = await orm
+			.select()
+			.from(leaveRecords)
+			.where(and(...conditions))
+			.orderBy(desc(leaveRecords.id))
+			.limit(500)
+		const requestRows = rows.length
+			? await orm
+					.select({
+						id: leaveRequests.id,
+						requestScope: leaveRequests.requestScope,
+						classId: leaveRequests.classId,
+						className: leaveRequests.className,
+						proposedByUserId: leaveRequests.proposedByUserId,
+						createdAt: leaveRequests.createdAt
+					})
+					.from(leaveRequests)
+					.where(
+						inArray(
+							leaveRequests.id,
+							rows.map((r) => r.requestId)
+						)
+					)
+			: []
+		const requestMeta = new Map(requestRows.map((r) => [r.id, r]))
+		const grouped = new Map<string, TakenListResponse>()
+		for (const row of rows) {
+			const mapped = mapRow(row)
+			const meta = requestMeta.get(row.requestId)
+			const isClass =
+				meta?.requestScope === 'CLASS' && meta.classId != null
+			const key = isClass
+				? [
+						'class',
+						meta.classId,
+						meta.proposedByUserId ?? '',
+						row.leaveType,
+						row.startDate ?? '',
+						row.endDate ?? '',
+						row.totalDays,
+						row.note ?? '',
+						String(meta.createdAt).slice(0, 16)
+					].join(':')
+				: `request:${row.requestId}`
+			if (!grouped.has(key)) {
+				grouped.set(
+					key,
+					isClass
+						? {
+								...mapped,
+								personnelId: null,
+								personnelCode: null,
+								personnelName: meta.className || 'Lớp',
+								objectType: 'HV',
+								objectTypeLabel: 'Học viên'
+							}
+						: mapped
+				)
+			}
+		}
+		const result = [...grouped.values()]
+		await writeLeaveAudit({
+			action: 'VIEW',
+			entityType: 'LEAVE_REPORT',
+			details: {
+				report: 'taken-list',
+				year: q.year,
+				count: result.length
+			}
+		})
+
+		return { data: result }
+	}
+)
+
+export const CheckYearLeave = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/reports/check-year'
+	},
+	async (q: {
+		year: Query<number>
+		search?: Query<string>
+		unitId?: Query<number>
+	}): Promise<{
+		data: Array<{
+			personnelCode: string | null
+			personnelName: string | null
+			objectType: string
+			objectTypeLabel: string
+			unitName: string | null
+			totalDays: number
+			remainingDays: number
+			quotaDays: number
+		}>
+	}> => {
+		const conditions = [
+			or(
+				eq(leaveRecords.leaveYear, String(Number(q.year))),
+				like(leaveRecords.startDate, `${Number(q.year)}%`)
+			)!,
+			eq(leaveRecords.status, 'APPROVED'),
+			eq(leaveRecords.leaveType, 'ANNUAL')
+		]
+
+		if (q.search) {
+			const s = `%${String(q.search).trim()}%`
+			conditions.push(
+				or(
+					like(leaveRecords.personnelCode, s),
+					like(leaveRecords.personnelName, s)
+				)!
+			)
+		}
+		if (q.unitId) {
+			conditions.push(eq(leaveRecords.unitId, Number(q.unitId)))
+		}
+
+		const rows = await orm
+			.select()
+			.from(leaveRecords)
+			.where(and(...conditions))
+			.orderBy(desc(leaveRecords.id))
+			.limit(500)
+
+		const today = new Date()
+		today.setHours(0, 0, 0, 0)
+		await writeLeaveAudit({
+			action: 'VIEW',
+			entityType: 'LEAVE_REPORT',
+			details: { report: 'check-year', year: q.year, count: rows.length }
+		})
+		return {
+			data: rows.map((row) => {
+				const start = row.startDate
+					? new Date(`${row.startDate.slice(0, 10)}T00:00:00`)
+					: null
+				const elapsed =
+					start && !Number.isNaN(start.getTime()) && today >= start
+						? Math.floor(
+								(today.getTime() - start.getTime()) / 86_400_000
+							) + 1
+						: 0
+				const usedDays = Math.min(row.totalDays, Math.max(0, elapsed))
+				const ot = row.objectType as LeaveObjectType
+				return {
+					personnelCode: row.personnelCode,
+					personnelName: row.personnelName,
+					objectType: ot,
+					objectTypeLabel: objectTypeLabel(ot),
+					unitName: row.unitName,
+					totalDays: row.totalDays,
+					remainingDays: Math.max(0, row.totalDays - usedDays),
+					quotaDays: row.baseDays
+				}
+			})
+		}
+	}
+)
+
+export const GetNotYetTakenLeave = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/reports/not-yet-taken'
+	},
+	async (q: {
+		year: Query<number>
+		objectType?: Query<string>
+		unitId?: Query<number>
+	}): Promise<{
+		data: Array<{
+			personnelId: number | null
+			personnelCode: string | null
+			personnelName: string | null
+			objectType: string
+			unitId: number | null
+			unitName: string | null
+		}>
+	}> => {
+		const year = String(Number(q.year))
+		const isAdmin = !!(await getAuthData())!.isSuperAdmin
+
+		let personnels: {
+			id: number
+			code: string
+			fullName: string
+			objectType: string
+			unitId: number | null
+			unitName: string | null
+		}[] = []
+
+		const otFilter = q.objectType
+			? String(q.objectType).toUpperCase()
+			: null
+
+		if (isAdmin) {
+			personnels = await orm
+				.select()
+				.from(leavePersonnel)
+				.where(
+					otFilter
+						? eq(leavePersonnel.objectType, otFilter as any)
+						: undefined
+				)
+		} else {
+			const access = await resolveLeaveAccess(
+				Number((await getAuthData())!.userID),
+				false
+			)
+			if (!access.isCommander || access.unitIds.length === 0) {
+				return { data: [] }
+			}
+			const personnelConditions = [
+				inArray(leavePersonnel.unitId, access.unitIds)
+			]
+			if (otFilter) {
+				personnelConditions.push(
+					eq(leavePersonnel.objectType, otFilter as any)
+				)
+			}
+			personnels = await orm
+				.select()
+				.from(leavePersonnel)
+				.where(and(...personnelConditions))
+		}
+
+		if (q.unitId) {
+			const unitId = Number(q.unitId)
+			personnels = personnels.filter((p) => p.unitId === unitId)
+		}
+
+		const result: Array<{
+			personnelId: number | null
+			personnelCode: string | null
+			personnelName: string | null
+			objectType: string
+			unitId: number | null
+			unitName: string | null
+		}> = []
+
+		for (const p of personnels) {
+			const existing = await orm
+				.select()
+				.from(leaveRecords)
+				.where(
+					and(
+						eq(leaveRecords.leaveYear, year),
+						eq(leaveRecords.personnelId, p.id),
+						eq(leaveRecords.status, 'APPROVED'),
+						eq(leaveRecords.leaveType, 'ANNUAL')
+					)
+				)
+				.limit(1)
+
+			if (!existing[0]) {
+				result.push({
+					personnelId: p.id,
+					personnelCode: p.code,
+					personnelName: p.fullName,
+					objectType: p.objectType,
+					unitId: p.unitId,
+					unitName: p.unitName
+				})
+			}
+		}
+
+		await writeLeaveAudit({
+			action: 'VIEW',
+			entityType: 'LEAVE_REPORT',
+			details: {
+				report: 'not-yet-taken',
+				year: q.year,
+				count: result.length
+			}
+		})
+		return { data: result }
+	}
+)

--- a/apps/api/leave-management/units.ts
+++ b/apps/api/leave-management/units.ts
@@ -1,0 +1,318 @@
+/**
+ * Danh mục đơn vị / đầu mối đơn vị trực thuộc (phân hệ phép)
+ */
+import { api, APIError, Query } from 'encore.dev/api'
+import { and, asc, eq, inArray, like, or, sql } from 'drizzle-orm'
+import { getAuthData } from '~encore/auth'
+import orm from '../database'
+import { leaveUnits } from '../schema/leave-management'
+import { resolveLeaveAccess } from './access'
+
+/** Resolve commander assignment for a leave unit.
+ * Personnel-level commander fields remain the fallback when the unit catalog
+ * has not yet been linked to an account.
+ */
+export async function resolveUnitCommander(unitId?: number | null): Promise<{
+	commanderUserId: number | null
+	commanderName: string | null
+}> {
+	if (!unitId) return { commanderUserId: null, commanderName: null }
+	const rows = await orm
+		.select()
+		.from(leaveUnits)
+		.where(eq(leaveUnits.id, unitId))
+		.limit(1)
+	return {
+		commanderUserId: rows[0]?.commanderUserId ?? null,
+		commanderName: rows[0]?.commanderName ?? null
+	}
+}
+
+export interface LeaveUnitResponse {
+	id: number
+	createdAt: string
+	updatedAt: string
+	code: string | null
+	name: string
+	parentId: number | null
+	level: string | null
+	commanderUserId: number | null
+	commanderName: string | null
+	managementArea: string
+	isActive: boolean
+}
+
+function mapRow(r: typeof leaveUnits.$inferSelect): LeaveUnitResponse {
+	return {
+		id: r.id,
+		createdAt: r.createdAt ?? '',
+		updatedAt: r.updatedAt ?? '',
+		code: r.code,
+		name: r.name,
+		parentId: r.parentId,
+		level: r.level,
+		commanderUserId: r.commanderUserId,
+		commanderName: r.commanderName,
+		managementArea: r.managementArea,
+		isActive: !!r.isActive
+	}
+}
+
+export const ListLeaveUnits = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'GET',
+		path: '/leave/units'
+	},
+	async (q: {
+		search?: Query<string>
+		activeOnly?: Query<boolean>
+	}): Promise<{ data: LeaveUnitResponse[] }> => {
+		const auth = getAuthData()!
+		const access = await resolveLeaveAccess(
+			Number(auth.userID),
+			!!auth.isSuperAdmin
+		)
+		const conditions = []
+		if (!access.isAdmin) {
+			if (!access.unitIds.length) return { data: [] }
+			conditions.push(inArray(leaveUnits.id, access.unitIds))
+		}
+		// activeOnly mặc định true; ?activeOnly=false để lấy cả ẩn
+		const activeOnly = String(q.activeOnly ?? 'true') !== 'false'
+		if (activeOnly) {
+			conditions.push(eq(leaveUnits.isActive, true))
+		}
+		if (q.search) {
+			const s = `%${String(q.search).trim()}%`
+			conditions.push(
+				or(like(leaveUnits.name, s), like(leaveUnits.code, s))!
+			)
+		}
+		const rows = await orm
+			.select()
+			.from(leaveUnits)
+			.where(conditions.length ? and(...conditions) : undefined)
+			.orderBy(asc(leaveUnits.name))
+		return { data: rows.map(mapRow) }
+	}
+)
+
+export const CreateLeaveUnit = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/units'
+	},
+	async (body: {
+		name: string
+		code?: string | null
+		parentId?: number | null
+		level?: string | null
+		managementArea?: string
+		isActive?: boolean
+	}): Promise<{ data: LeaveUnitResponse }> => {
+		if (!body.name?.trim()) {
+			throw APIError.invalidArgument('Tên đơn vị là bắt buộc')
+		}
+		const inserted = await orm
+			.insert(leaveUnits)
+			.values({
+				name: body.name.trim(),
+				code: body.code?.trim() || null,
+				parentId: body.parentId ?? null,
+				level: body.level || null,
+				managementArea: body.managementArea || 'cán_bộ',
+				isActive: body.isActive !== false
+			})
+			.returning()
+		return { data: mapRow(inserted[0]!) }
+	}
+)
+
+export const UpdateLeaveUnit = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'PATCH',
+		path: '/leave/units/:id'
+	},
+	async ({
+		id,
+		name,
+		code,
+		parentId,
+		level,
+		managementArea,
+		isActive
+	}: {
+		id: number
+		name?: string
+		code?: string | null
+		parentId?: number | null
+		level?: string | null
+		managementArea?: string
+		isActive?: boolean
+	}): Promise<{ data: LeaveUnitResponse }> => {
+		const existing = await orm
+			.select()
+			.from(leaveUnits)
+			.where(eq(leaveUnits.id, id))
+			.limit(1)
+		if (!existing[0]) throw APIError.notFound('Không tìm thấy đơn vị')
+		const updated = await orm
+			.update(leaveUnits)
+			.set({
+				...(name !== undefined ? { name: name.trim() } : {}),
+				...(code !== undefined ? { code: code?.trim() || null } : {}),
+				...(parentId !== undefined
+					? { parentId: parentId ?? null }
+					: {}),
+				...(level !== undefined ? { level: level || null } : {}),
+				...(managementArea !== undefined ? { managementArea } : {}),
+				...(isActive !== undefined ? { isActive } : {})
+			})
+			.where(eq(leaveUnits.id, id))
+			.returning()
+		return { data: mapRow(updated[0]!) }
+	}
+)
+
+export const DeleteLeaveUnit = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'DELETE',
+		path: '/leave/units/:id'
+	},
+	async ({ id }: { id: number }): Promise<{ ok: boolean }> => {
+		const res = await orm
+			.delete(leaveUnits)
+			.where(eq(leaveUnits.id, id))
+			.returning()
+		if (!res[0]) throw APIError.notFound('Không tìm thấy đơn vị')
+		return { ok: true }
+	}
+)
+
+/** Import hàng loạt đơn vị (theo tên; upsert theo code nếu có) */
+export const ImportLeaveUnits = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/units/import'
+	},
+	async (body: {
+		items: { name: string; code?: string | null }[]
+	}): Promise<{
+		data: {
+			successCount: number
+			errorCount: number
+			totalCount: number
+			errors: { row: number; message: string }[]
+		}
+	}> => {
+		const items = body.items || []
+		if (!items.length) {
+			throw APIError.invalidArgument('Danh sách import trống')
+		}
+		const errors: { row: number; message: string }[] = []
+		let successCount = 0
+		for (let i = 0; i < items.length; i++) {
+			const row = i + 1
+			const name = String(items[i]?.name || '').trim()
+			const code = items[i]?.code
+				? String(items[i]!.code).trim() || null
+				: null
+			if (!name) {
+				errors.push({ row, message: 'Tên đơn vị là bắt buộc' })
+				continue
+			}
+			try {
+				if (code) {
+					const existing = await orm
+						.select()
+						.from(leaveUnits)
+						.where(eq(leaveUnits.code, code))
+						.limit(1)
+					if (existing[0]) {
+						await orm
+							.update(leaveUnits)
+							.set({ name, isActive: true })
+							.where(eq(leaveUnits.id, existing[0].id))
+						successCount++
+						continue
+					}
+				}
+				// match by name
+				const byName = await orm
+					.select()
+					.from(leaveUnits)
+					.where(eq(leaveUnits.name, name))
+					.limit(1)
+				if (byName[0]) {
+					await orm
+						.update(leaveUnits)
+						.set({
+							...(code ? { code } : {}),
+							isActive: true
+						})
+						.where(eq(leaveUnits.id, byName[0].id))
+				} else {
+					await orm.insert(leaveUnits).values({
+						name,
+						code,
+						isActive: true
+					})
+				}
+				successCount++
+			} catch (e: unknown) {
+				errors.push({
+					row,
+					message: String((e as Error)?.message || e)
+				})
+			}
+		}
+		return {
+			data: {
+				successCount,
+				errorCount: errors.length,
+				totalCount: items.length,
+				errors
+			}
+		}
+	}
+)
+
+/** Seed từ bảng units (tiểu đoàn/đại đội) nếu leave_units trống */
+export const SeedLeaveUnitsFromSystem = api(
+	{
+		auth: true,
+		expose: true,
+		method: 'POST',
+		path: '/leave/units/seed-from-system'
+	},
+	async (): Promise<{ data: { inserted: number } }> => {
+		const { units } = await import('../schema/units')
+		const existing = await orm
+			.select({ c: sql<number>`count(*)` })
+			.from(leaveUnits)
+		if ((existing[0]?.c ?? 0) > 0) {
+			return { data: { inserted: 0 } }
+		}
+		const sys = await orm.select().from(units).orderBy(asc(units.id))
+		let inserted = 0
+		for (const u of sys) {
+			await orm.insert(leaveUnits).values({
+				code: u.alias,
+				name: u.name,
+				isActive: true
+			})
+			inserted++
+		}
+		return { data: { inserted } }
+	}
+)

--- a/apps/api/migrations/0042_lying_greymalkin.sql
+++ b/apps/api/migrations/0042_lying_greymalkin.sql
@@ -1,0 +1,871 @@
+CREATE TABLE `account_audit_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`action` text NOT NULL,
+	`actor_user_id` integer,
+	`actor_username` text,
+	`actor_display_name` text,
+	`actor_is_admin` integer DEFAULT 0 NOT NULL,
+	`room_id` integer,
+	`room_code` text,
+	`room_name` text,
+	`address` text,
+	`floor_name` text,
+	`building_code` text,
+	`building_name` text,
+	`account_label` text,
+	`summary` text NOT NULL,
+	`details` text
+);
+--> statement-breakpoint
+CREATE TABLE `asset_broken_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`event_type` text NOT NULL,
+	`source_type` text DEFAULT 'OTHER' NOT NULL,
+	`source_id` integer,
+	`proposal_id` integer,
+	`repair_request_id` integer,
+	`room_asset_id` integer,
+	`source_asset_id` integer,
+	`asset_code` text,
+	`original_code` text,
+	`asset_name` text NOT NULL,
+	`category` text,
+	`quantity` integer DEFAULT 1 NOT NULL,
+	`original_grade` integer,
+	`grade_after` integer,
+	`status_after` text,
+	`room_id` integer,
+	`room_code` text,
+	`room_name` text,
+	`floor_name` text,
+	`building_code` text,
+	`building_name` text,
+	`unit_name` text,
+	`nganh_code` text,
+	`reason` text,
+	`result_note` text,
+	`performer` text,
+	`event_at` text NOT NULL,
+	`actor_user_id` integer,
+	`actor_username` text,
+	`actor_display_name` text
+);
+--> statement-breakpoint
+CREATE TABLE `asset_movement_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`room_asset_id` integer,
+	`movement_type` text NOT NULL,
+	`executed_at` text NOT NULL,
+	`executing_unit` text,
+	`install_address` text,
+	`asset_code` text,
+	`asset_name` text NOT NULL,
+	`quantity` integer DEFAULT 0 NOT NULL,
+	`quantity_before` integer DEFAULT 0 NOT NULL,
+	`quantity_after` integer DEFAULT 0 NOT NULL,
+	`grade` integer DEFAULT 1 NOT NULL,
+	`manufacture_year` integer,
+	`usage_year` integer,
+	`reason_code` text,
+	`reason_other` text,
+	`decision_date` text,
+	`decision_number` text,
+	`signer` text,
+	`performer` text,
+	`explanation` text,
+	`note` text,
+	`building_code` text,
+	`building_name` text,
+	`room_code` text,
+	`room_name` text,
+	`floor_name` text,
+	FOREIGN KEY (`room_asset_id`) REFERENCES `room_assets`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE TABLE `asset_proposal_items` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`proposal_id` integer NOT NULL,
+	`material_id` integer,
+	`material_code` text,
+	`material_name` text NOT NULL,
+	`room_asset_id` integer,
+	`source_asset_id` integer,
+	`original_grade` integer,
+	`original_code` text,
+	`quantity` integer DEFAULT 1 NOT NULL,
+	`unit` text,
+	`category` text,
+	`nganh_code` text,
+	`chuyen_nganh_code` text,
+	`note` text,
+	`from_room_id` integer,
+	`from_room_code` text,
+	`from_room_name` text,
+	`location_note` text,
+	`target_room_id` integer,
+	`target_room_code` text,
+	`target_room_name` text
+);
+--> statement-breakpoint
+CREATE TABLE `asset_proposal_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`proposal_id` integer,
+	`action` text NOT NULL,
+	`proposal_type` text,
+	`summary` text NOT NULL,
+	`details` text,
+	`actor_user_id` integer,
+	`actor_username` text,
+	`actor_display_name` text,
+	`actor_is_admin` integer DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `asset_proposals` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`proposal_type` text NOT NULL,
+	`status` text DEFAULT 'PENDING' NOT NULL,
+	`title` text NOT NULL,
+	`description` text,
+	`unit_id` integer,
+	`unit_name` text,
+	`nganh_code` text,
+	`proposed_by_user_id` integer,
+	`proposed_by_username` text,
+	`proposed_by_display_name` text,
+	`admin_note` text,
+	`decision_number` text,
+	`decision_nganh_code` text,
+	`decision_issuing_level` text,
+	`decision_signer` text,
+	`decision_at` text,
+	`decided_by_user_id` integer,
+	`decided_by_username` text,
+	`decided_by_display_name` text,
+	`completed_at` text
+);
+--> statement-breakpoint
+CREATE TABLE `buildings` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`manager_code` text,
+	`area` text,
+	`address` text,
+	`description` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `buildings_code_unique` ON `buildings` (`code`);--> statement-breakpoint
+CREATE TABLE `catalog_audit_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`action` text NOT NULL,
+	`entity_type` text NOT NULL,
+	`actor_user_id` integer,
+	`actor_username` text,
+	`actor_display_name` text,
+	`actor_is_admin` integer DEFAULT 0 NOT NULL,
+	`entity_id` integer,
+	`entity_code` text,
+	`entity_name` text,
+	`parent_code` text,
+	`parent_name` text,
+	`summary` text NOT NULL,
+	`details` text
+);
+--> statement-breakpoint
+CREATE TABLE `catalog_stock_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`movement_type` text NOT NULL,
+	`executed_at` text NOT NULL,
+	`material_id` integer,
+	`material_code` text,
+	`material_name` text NOT NULL,
+	`nganh_code` text NOT NULL,
+	`chuyen_nganh_code` text,
+	`chuyen_nganh_name` text,
+	`quantity` integer DEFAULT 0 NOT NULL,
+	`quantity_before` integer DEFAULT 0 NOT NULL,
+	`quantity_after` integer DEFAULT 0 NOT NULL,
+	`unit` text,
+	`is_new_material` integer DEFAULT 0 NOT NULL,
+	`reason` text,
+	`note` text,
+	`actor_user_id` integer,
+	`actor_username` text,
+	`actor_display_name` text,
+	`actor_is_admin` integer DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `categories` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`description` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `categories_code_unique` ON `categories` (`code`);--> statement-breakpoint
+CREATE TABLE `exam_classes` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`major_id` integer,
+	`faculty_id` integer,
+	`cohort` text,
+	`description` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `exam_classes_code_unique` ON `exam_classes` (`code`);--> statement-breakpoint
+CREATE TABLE `exam_draw_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`draw_id` integer,
+	`action` text NOT NULL,
+	`summary` text NOT NULL,
+	`details` text,
+	`actor_user_id` integer,
+	`actor_username` text,
+	`actor_display_name` text
+);
+--> statement-breakpoint
+CREATE TABLE `exam_draws` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`draw_code` text NOT NULL,
+	`exam_id` integer NOT NULL,
+	`exam_code` text,
+	`paper_number` integer,
+	`subject_id` integer,
+	`major_id` integer,
+	`draw_type` text NOT NULL,
+	`class_id` integer,
+	`class_name` text,
+	`drawn_by_user_id` integer,
+	`drawn_by_username` text,
+	`drawn_by_display_name` text,
+	`drawn_at` text NOT NULL,
+	`printed_at` text,
+	`printed_by_user_id` integer,
+	`printed_by_username` text,
+	`print_blocked` integer DEFAULT false NOT NULL,
+	`print_blocked_at` text,
+	`print_blocked_reason` text,
+	`exam_date` text,
+	`exam_time` text,
+	`location` text,
+	`note` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `exam_draws_draw_code_unique` ON `exam_draws` (`draw_code`);--> statement-breakpoint
+CREATE TABLE `exam_faculties` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`major_id` integer NOT NULL,
+	`description` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `exam_faculties_major_code_uq` ON `exam_faculties` (`major_id`,`code`);--> statement-breakpoint
+CREATE TABLE `exam_faculty_heads` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL,
+	`faculty_code` text NOT NULL,
+	`faculty_name` text,
+	`user_id` integer NOT NULL,
+	`username` text,
+	`display_name` text,
+	`note` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `exam_faculty_heads_user_fac_uq` ON `exam_faculty_heads` (`user_id`,`faculty_code`);--> statement-breakpoint
+CREATE TABLE `exam_major_heads` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL,
+	`major_id` integer NOT NULL,
+	`user_id` integer NOT NULL,
+	`username` text,
+	`display_name` text,
+	`note` text
+);
+--> statement-breakpoint
+CREATE TABLE `exam_majors` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`system_id` integer NOT NULL,
+	`level_code` text,
+	`short_code` text,
+	`description` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `exam_majors_code_unique` ON `exam_majors` (`code`);--> statement-breakpoint
+CREATE TABLE `exam_questions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`exam_id` integer NOT NULL,
+	`question_number` integer DEFAULT 1 NOT NULL,
+	`content` text NOT NULL,
+	`answer` text,
+	`points` integer DEFAULT 1 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `exam_subjects` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`base_code` text,
+	`name` text NOT NULL,
+	`credit_hours` integer DEFAULT 0,
+	`lesson_hours` integer DEFAULT 0,
+	`faculty_id` integer NOT NULL,
+	`major_id` integer NOT NULL,
+	`description` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `exam_subjects_code_unique` ON `exam_subjects` (`code`);--> statement-breakpoint
+CREATE TABLE `exam_systems` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`letter` text NOT NULL,
+	`description` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `exam_systems_code_unique` ON `exam_systems` (`code`);--> statement-breakpoint
+CREATE UNIQUE INDEX `exam_systems_letter_unique` ON `exam_systems` (`letter`);--> statement-breakpoint
+CREATE TABLE `exam_teachers` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`user_id` integer NOT NULL,
+	`username` text,
+	`display_name` text,
+	`faculty_code` text NOT NULL,
+	`faculty_name` text,
+	`note` text,
+	`created_by_user_id` integer,
+	`created_by_username` text,
+	`created_by_display_name` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `exam_teachers_user_uq` ON `exam_teachers` (`user_id`);--> statement-breakpoint
+CREATE TABLE `exam_teaching_assignment_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`action` text NOT NULL,
+	`subject_id` integer,
+	`subject_code` text,
+	`subject_name` text,
+	`major_id` integer,
+	`major_code` text,
+	`faculty_id` integer,
+	`faculty_code` text,
+	`class_id` integer,
+	`class_code` text,
+	`class_name` text,
+	`teacher_user_id` integer,
+	`teacher_username` text,
+	`teacher_display_name` text,
+	`note` text,
+	`actor_user_id` integer,
+	`actor_username` text,
+	`actor_display_name` text,
+	`summary` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `exam_teaching_assignments` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`subject_id` integer NOT NULL,
+	`class_id` integer,
+	`user_id` integer NOT NULL,
+	`username` text,
+	`display_name` text,
+	`note` text,
+	`teaching_start` text,
+	`teaching_end` text,
+	`assigned_by_user_id` integer,
+	`assigned_by_username` text,
+	`assigned_by_display_name` text
+);
+--> statement-breakpoint
+CREATE TABLE `exam_workflow_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`exam_id` integer NOT NULL,
+	`action` text NOT NULL,
+	`from_status` text,
+	`to_status` text,
+	`note` text,
+	`actor_user_id` integer,
+	`actor_username` text,
+	`actor_display_name` text
+);
+--> statement-breakpoint
+CREATE TABLE `exams` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`title` text NOT NULL,
+	`subject_id` integer NOT NULL,
+	`paper_number` integer,
+	`status` text DEFAULT 'DRAFT' NOT NULL,
+	`created_by_user_id` integer,
+	`created_by_username` text,
+	`created_by_display_name` text,
+	`approved_by_user_id` integer,
+	`approved_by_username` text,
+	`approved_by_display_name` text,
+	`approved_at` text,
+	`approved_by_rank` text,
+	`approved_by_position` text,
+	`approved_by_signature_url` text,
+	`approved_by_title` text,
+	`dept_head_user_id` integer,
+	`dept_head_username` text,
+	`dept_head_display_name` text,
+	`dept_head_rank` text,
+	`dept_head_signature_url` text,
+	`dept_head_approved_at` text,
+	`qr_code` text,
+	`locked` integer DEFAULT false NOT NULL,
+	`class_id` integer,
+	`class_name` text,
+	`duration_minutes` integer DEFAULT 60,
+	`question_file_url` text,
+	`question_file_name` text,
+	`answer_file_url` text,
+	`answer_file_name` text,
+	`note` text,
+	`return_note` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `exams_code_unique` ON `exams` (`code`);--> statement-breakpoint
+CREATE TABLE `floors` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`building_id` integer NOT NULL,
+	`code` text,
+	`floor_number` integer NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	FOREIGN KEY (`building_id`) REFERENCES `buildings`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `rooms` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`floor_id` integer NOT NULL,
+	`room_code` text NOT NULL,
+	`room_name` text NOT NULL,
+	`room_type` text,
+	`manager` text,
+	`manager_code` text,
+	`account_password` text,
+	`capacity` integer DEFAULT 0 NOT NULL,
+	`status` text DEFAULT 'ACTIVE' NOT NULL,
+	`description` text,
+	`class_id` integer,
+	FOREIGN KEY (`floor_id`) REFERENCES `floors`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`class_id`) REFERENCES `classes`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `rooms_room_code_unique` ON `rooms` (`room_code`);--> statement-breakpoint
+CREATE TABLE `room_images` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`room_id` integer NOT NULL,
+	`image_url` text NOT NULL,
+	`title` text,
+	`description` text,
+	FOREIGN KEY (`room_id`) REFERENCES `rooms`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `room_assets` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`room_id` integer NOT NULL,
+	`code` text,
+	`name` text NOT NULL,
+	`category` text NOT NULL,
+	`quantity` integer DEFAULT 1 NOT NULL,
+	`broken_quantity` integer DEFAULT 0 NOT NULL,
+	`unit` text,
+	`holding_unit_id` integer,
+	`grade` integer DEFAULT 1 NOT NULL,
+	`manufacture_year` integer,
+	`usage_year` integer,
+	`install_address` text,
+	`status` text DEFAULT 'NORMAL' NOT NULL,
+	`purchase_date` text,
+	`expiry_date` text,
+	`broken_at` text,
+	`repair_started_at` text,
+	`repair_completed_at` text,
+	`repair_performer` text,
+	`description` text,
+	FOREIGN KEY (`room_id`) REFERENCES `rooms`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`holding_unit_id`) REFERENCES `units`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `room_assets_code_unique` ON `room_assets` (`code`);--> statement-breakpoint
+CREATE TABLE `repair_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`room_asset_id` integer NOT NULL,
+	`repair_date` text NOT NULL,
+	`content` text NOT NULL,
+	`cost` integer DEFAULT 0 NOT NULL,
+	`performer` text,
+	`note` text,
+	FOREIGN KEY (`room_asset_id`) REFERENCES `room_assets`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `inventory_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`room_asset_id` integer NOT NULL,
+	`inventory_date` text NOT NULL,
+	`actual_quantity` integer DEFAULT 0 NOT NULL,
+	`expected_quantity` integer DEFAULT 0 NOT NULL,
+	`result` text,
+	`note` text,
+	FOREIGN KEY (`room_asset_id`) REFERENCES `room_assets`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `replacement_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`room_asset_id` integer NOT NULL,
+	`replacement_date` text NOT NULL,
+	`old_asset` text NOT NULL,
+	`new_asset` text NOT NULL,
+	`reason` text,
+	`performer` text,
+	`note` text,
+	FOREIGN KEY (`room_asset_id`) REFERENCES `room_assets`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `user_nganh` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`user_id` integer NOT NULL,
+	`nganh_code` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `user_nganh_user_nganh_uq` ON `user_nganh` (`user_id`,`nganh_code`);--> statement-breakpoint
+CREATE TABLE `repair_requests` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`room_id` integer NOT NULL,
+	`room_asset_id` integer,
+	`source_asset_id` integer,
+	`quantity` integer DEFAULT 1 NOT NULL,
+	`original_grade` integer,
+	`asset_name` text NOT NULL,
+	`category` text,
+	`description` text,
+	`status` text DEFAULT 'PENDING' NOT NULL,
+	`broken_at` text NOT NULL,
+	`reported_by_name` text NOT NULL,
+	`reported_by_user_id` integer,
+	`assigned_to_name` text,
+	`assigned_at` text,
+	`assigned_by_name` text,
+	`repair_started_at` text,
+	`completed_at` text,
+	`admin_note` text,
+	FOREIGN KEY (`room_id`) REFERENCES `rooms`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`room_asset_id`) REFERENCES `room_assets`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`source_asset_id`) REFERENCES `room_assets`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`reported_by_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE TABLE `suppliers` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`phone` text,
+	`email` text,
+	`address` text,
+	`contact_person` text,
+	`description` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `suppliers_code_unique` ON `suppliers` (`code`);--> statement-breakpoint
+CREATE TABLE `materials` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`category_id` integer NOT NULL,
+	`supplier_id` integer,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`unit` text NOT NULL,
+	`quantity` integer DEFAULT 0 NOT NULL,
+	`min_quantity` integer DEFAULT 0 NOT NULL,
+	`price` real DEFAULT 0,
+	`status` text DEFAULT 'ACTIVE' NOT NULL,
+	`description` text,
+	FOREIGN KEY (`category_id`) REFERENCES `categories`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`supplier_id`) REFERENCES `suppliers`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `materials_code_unique` ON `materials` (`code`);--> statement-breakpoint
+CREATE TABLE `warehouses` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`location` text,
+	`manager` text,
+	`phone` text,
+	`description` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `warehouses_code_unique` ON `warehouses` (`code`);--> statement-breakpoint
+CREATE TABLE `warehouse_items` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`warehouse_id` integer NOT NULL,
+	`material_id` integer NOT NULL,
+	`quantity` integer DEFAULT 0 NOT NULL,
+	`min_quantity` integer DEFAULT 0 NOT NULL,
+	FOREIGN KEY (`warehouse_id`) REFERENCES `warehouses`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`material_id`) REFERENCES `materials`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_actions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`name` text NOT NULL,
+	`display_name` text NOT NULL,
+	`description` text
+);
+--> statement-breakpoint
+INSERT INTO `__new_actions`("id", "createdAt", "updatedAt", "name", "display_name", "description") SELECT "id", "createdAt", "updatedAt", "name", "display_name", "description" FROM `actions`;--> statement-breakpoint
+DROP TABLE `actions`;--> statement-breakpoint
+ALTER TABLE `__new_actions` RENAME TO `actions`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `actions_name_unique` ON `actions` (`name`);--> statement-breakpoint
+CREATE TABLE `__new_classes` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`name` text NOT NULL,
+	`description` text DEFAULT '',
+	`graduatedAt` text,
+	`status` text DEFAULT 'ongoing',
+	`unitId` integer NOT NULL,
+	FOREIGN KEY (`unitId`) REFERENCES `units`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_classes`("id", "createdAt", "updatedAt", "name", "description", "graduatedAt", "status", "unitId") SELECT "id", "createdAt", "updatedAt", "name", "description", "graduatedAt", "status", "unitId" FROM `classes`;--> statement-breakpoint
+DROP TABLE `classes`;--> statement-breakpoint
+ALTER TABLE `__new_classes` RENAME TO `classes`;--> statement-breakpoint
+CREATE UNIQUE INDEX `class_unit_unique_constraint` ON `classes` (`name`,`unitId`);--> statement-breakpoint
+CREATE TABLE `__new_notification_items` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`notifiableType` text NOT NULL,
+	`notifiableId` integer NOT NULL,
+	`notificationId` text NOT NULL,
+	FOREIGN KEY (`notificationId`) REFERENCES `notifications`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_notification_items`("id", "createdAt", "updatedAt", "notifiableType", "notifiableId", "notificationId") SELECT "id", "createdAt", "updatedAt", "notifiableType", "notifiableId", "notificationId" FROM `notification_items`;--> statement-breakpoint
+DROP TABLE `notification_items`;--> statement-breakpoint
+ALTER TABLE `__new_notification_items` RENAME TO `notification_items`;--> statement-breakpoint
+CREATE INDEX `notification_items_notification_idx` ON `notification_items` (`notificationId`);--> statement-breakpoint
+CREATE INDEX `notification_items_item_idx` ON `notification_items` (`notifiableType`,`notifiableId`);--> statement-breakpoint
+CREATE TABLE `__new_permissions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`name` text NOT NULL,
+	`display_name` text NOT NULL,
+	`description` text,
+	`resource_id` integer NOT NULL,
+	`action_id` integer NOT NULL,
+	FOREIGN KEY (`resource_id`) REFERENCES `resources`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`action_id`) REFERENCES `actions`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_permissions`("id", "createdAt", "updatedAt", "name", "display_name", "description", "resource_id", "action_id") SELECT "id", "createdAt", "updatedAt", "name", "display_name", "description", "resource_id", "action_id" FROM `permissions`;--> statement-breakpoint
+DROP TABLE `permissions`;--> statement-breakpoint
+ALTER TABLE `__new_permissions` RENAME TO `permissions`;--> statement-breakpoint
+CREATE UNIQUE INDEX `permissions_name_unique` ON `permissions` (`name`);--> statement-breakpoint
+CREATE TABLE `__new_resources` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`name` text NOT NULL,
+	`display_name` text NOT NULL,
+	`description` text
+);
+--> statement-breakpoint
+INSERT INTO `__new_resources`("id", "createdAt", "updatedAt", "name", "display_name", "description") SELECT "id", "createdAt", "updatedAt", "name", "display_name", "description" FROM `resources`;--> statement-breakpoint
+DROP TABLE `resources`;--> statement-breakpoint
+ALTER TABLE `__new_resources` RENAME TO `resources`;--> statement-breakpoint
+CREATE UNIQUE INDEX `resources_name_unique` ON `resources` (`name`);--> statement-breakpoint
+CREATE TABLE `__new_roles` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`name` text NOT NULL,
+	`description` text
+);
+--> statement-breakpoint
+INSERT INTO `__new_roles`("id", "createdAt", "updatedAt", "name", "description") SELECT "id", "createdAt", "updatedAt", "name", "description" FROM `roles`;--> statement-breakpoint
+DROP TABLE `roles`;--> statement-breakpoint
+ALTER TABLE `__new_roles` RENAME TO `roles`;--> statement-breakpoint
+CREATE UNIQUE INDEX `roles_name_unique` ON `roles` (`name`);--> statement-breakpoint
+CREATE TABLE `__new_students` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`fullName` text DEFAULT '',
+	`birthPlace` text DEFAULT '',
+	`address` text DEFAULT '',
+	`dob` text DEFAULT '',
+	`rank` text DEFAULT '',
+	`previousUnit` text DEFAULT '',
+	`previousPosition` text DEFAULT '',
+	`position` text DEFAULT 'Học viên',
+	`ethnic` text DEFAULT '',
+	`religion` text DEFAULT 'Không',
+	`enlistmentPeriod` text DEFAULT '',
+	`politicalOrg` text NOT NULL,
+	`politicalOrgOfficialDate` text DEFAULT '',
+	`cpvId` text,
+	`educationLevel` text DEFAULT '',
+	`schoolName` text DEFAULT '',
+	`major` text DEFAULT '',
+	`isGraduated` integer DEFAULT false,
+	`talent` text DEFAULT 'Không',
+	`shortcoming` text DEFAULT 'Không',
+	`policyBeneficiaryGroup` text DEFAULT 'Không',
+	`fatherName` text DEFAULT '',
+	`fatherDob` text DEFAULT '',
+	`fatherPhoneNumber` text DEFAULT '',
+	`fatherJob` text DEFAULT '',
+	`motherName` text DEFAULT '',
+	`motherDob` text DEFAULT '',
+	`motherPhoneNumber` text DEFAULT '',
+	`motherJob` text DEFAULT '',
+	`isMarried` integer DEFAULT false,
+	`spouseName` text DEFAULT '',
+	`spouseDob` text DEFAULT '',
+	`spouseJob` text DEFAULT '',
+	`spousePhoneNumber` text DEFAULT '',
+	`childrenInfos` text DEFAULT '[]',
+	`familySize` integer,
+	`familyBackground` text DEFAULT 'Không',
+	`familyBirthOrder` text DEFAULT '',
+	`achievement` text DEFAULT 'Không',
+	`disciplinaryHistory` text DEFAULT 'Không',
+	`phone` text DEFAULT '',
+	`classId` integer NOT NULL,
+	`cpvOfficialAt` text,
+	`avatar` text,
+	`siblings` text DEFAULT '[]',
+	`contactPerson` text DEFAULT '{}',
+	`studentId` text,
+	`relatedDocumentations` text,
+	`status` text DEFAULT 'pending' NOT NULL,
+	FOREIGN KEY (`classId`) REFERENCES `classes`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_students`("id", "createdAt", "updatedAt", "fullName", "birthPlace", "address", "dob", "rank", "previousUnit", "previousPosition", "position", "ethnic", "religion", "enlistmentPeriod", "politicalOrg", "politicalOrgOfficialDate", "cpvId", "educationLevel", "schoolName", "major", "isGraduated", "talent", "shortcoming", "policyBeneficiaryGroup", "fatherName", "fatherDob", "fatherPhoneNumber", "fatherJob", "motherName", "motherDob", "motherPhoneNumber", "motherJob", "isMarried", "spouseName", "spouseDob", "spouseJob", "spousePhoneNumber", "childrenInfos", "familySize", "familyBackground", "familyBirthOrder", "achievement", "disciplinaryHistory", "phone", "classId", "cpvOfficialAt", "avatar", "siblings", "contactPerson", "studentId", "relatedDocumentations", "status") SELECT "id", "createdAt", "updatedAt", "fullName", "birthPlace", "address", "dob", "rank", "previousUnit", "previousPosition", "position", "ethnic", "religion", "enlistmentPeriod", "politicalOrg", "politicalOrgOfficialDate", "cpvId", "educationLevel", "schoolName", "major", "isGraduated", "talent", "shortcoming", "policyBeneficiaryGroup", "fatherName", "fatherDob", "fatherPhoneNumber", "fatherJob", "motherName", "motherDob", "motherPhoneNumber", "motherJob", "isMarried", "spouseName", "spouseDob", "spouseJob", "spousePhoneNumber", "childrenInfos", "familySize", "familyBackground", "familyBirthOrder", "achievement", "disciplinaryHistory", "phone", "classId", "cpvOfficialAt", "avatar", "siblings", "contactPerson", "studentId", "relatedDocumentations", "status" FROM `students`;--> statement-breakpoint
+DROP TABLE `students`;--> statement-breakpoint
+ALTER TABLE `__new_students` RENAME TO `students`;--> statement-breakpoint
+CREATE TABLE `__new_units` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`alias` text NOT NULL,
+	`name` text NOT NULL,
+	`level` integer NOT NULL,
+	`parentId` integer,
+	FOREIGN KEY (`parentId`) REFERENCES `units`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_units`("id", "createdAt", "updatedAt", "alias", "name", "level", "parentId") SELECT "id", "createdAt", "updatedAt", "alias", "name", "level", "parentId" FROM `units`;--> statement-breakpoint
+DROP TABLE `units`;--> statement-breakpoint
+ALTER TABLE `__new_units` RENAME TO `units`;--> statement-breakpoint
+CREATE UNIQUE INDEX `units_alias_unique` ON `units` (`alias`);--> statement-breakpoint
+CREATE UNIQUE INDEX `units_name_unique` ON `units` (`name`);--> statement-breakpoint
+CREATE TABLE `__new_users` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`username` text NOT NULL,
+	`password` text NOT NULL,
+	`displayName` text DEFAULT '' NOT NULL,
+	`isSuperUser` integer DEFAULT false NOT NULL,
+	`unitId` integer,
+	`status` text DEFAULT 'pending',
+	`rank` text,
+	`position` text,
+	`alias` text,
+	`signature_url` text,
+	FOREIGN KEY (`unitId`) REFERENCES `units`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_users`("id", "createdAt", "updatedAt", "username", "password", "displayName", "isSuperUser", "unitId", "status", "rank", "position", "alias", "signature_url") SELECT "id", "createdAt", "updatedAt", "username", "password", "displayName", "isSuperUser", "unitId", "status", "rank", "position", "alias", "signature_url" FROM `users`;--> statement-breakpoint
+DROP TABLE `users`;--> statement-breakpoint
+ALTER TABLE `__new_users` RENAME TO `users`;--> statement-breakpoint
+CREATE UNIQUE INDEX `users_username_unique` ON `users` (`username`);

--- a/apps/api/migrations/0043_leave_management.sql
+++ b/apps/api/migrations/0043_leave_management.sql
@@ -1,0 +1,117 @@
+CREATE TABLE IF NOT EXISTS `leave_object_types` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `code` text NOT NULL UNIQUE, `name` text NOT NULL,
+	`sort_order` integer DEFAULT 0 NOT NULL, `is_active` integer DEFAULT 1 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_units` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `code` text, `name` text NOT NULL,
+	`level` text, `parent_id` integer, `is_active` integer DEFAULT 1 NOT NULL,
+	`commander_user_id` integer, `commander_name` text,
+	`management_area` text DEFAULT 'cán_bộ' NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_extra_standards` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `code` text NOT NULL UNIQUE, `label` text NOT NULL,
+	`days` integer NOT NULL, `sort_order` integer DEFAULT 0 NOT NULL, `is_active` integer DEFAULT 1 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_classes` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `unit_id` integer NOT NULL,
+	`name` text NOT NULL, `is_active` integer DEFAULT 1 NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `leave_classes_unit_name_unique` ON `leave_classes` (`unit_id`,`name`);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_personnel` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `code` text NOT NULL UNIQUE, `full_name` text NOT NULL,
+	`enlistment_date` text, `recruitment` text, `object_type` text NOT NULL, `rank` text, `position` text, `class_id` integer,
+	`unit_id` integer, `unit_name` text, `hometown` text, `permanent_residence` text, `user_id` integer,
+	`email` text, `commander_user_id` integer, `commander_name` text,
+	`class_name` text, `management_area` text DEFAULT 'cán_bộ' NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_localities` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `name` text NOT NULL, `level` text NOT NULL,
+	`parent_id` integer, `code` text
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_regulations` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `leave_type` text NOT NULL, `object_type` text,
+	`min_years` integer, `max_years` integer, `base_days` integer NOT NULL, `label` text,
+	`description` text, `is_active` integer DEFAULT 1 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_requests` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `leave_type` text NOT NULL,
+	`request_scope` text DEFAULT 'OTHER' NOT NULL, `class_id` integer, `class_name` text,
+	`status` text DEFAULT 'PENDING' NOT NULL,
+	`personnel_id` integer, `personnel_code` text, `personnel_name` text, `object_type` text NOT NULL,
+	`rank` text, `position` text, `enlistment_date` text, `unit_id` integer, `unit_name` text,
+	`service_years` integer DEFAULT 0 NOT NULL, `base_days` integer DEFAULT 0 NOT NULL,
+	`travel_days` integer DEFAULT 0 NOT NULL, `extra_days` integer DEFAULT 0 NOT NULL,
+	`extra_reasons` text DEFAULT '[]', `total_days` integer DEFAULT 0 NOT NULL, `start_date` text,
+	`end_date` text, `leave_year` text, `locality_id` integer, `locality_path` text, `note` text,
+	`proposed_by_user_id` integer, `proposed_by_username` text, `proposed_by_display_name` text,
+	`proposer_email` text, `commander_user_id` integer, `commander_name` text, `admin_note` text,
+	`decided_by_user_id` integer, `decided_by_username` text, `decided_at` text
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_mail_log` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `request_id` integer, `to_email` text NOT NULL,
+	`subject` text NOT NULL, `body` text, `mode` text, `ok` integer DEFAULT 0 NOT NULL, `error` text,
+	`preview_url` text, `kind` text
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_alerts` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `user_id` integer NOT NULL, `request_id` integer NOT NULL,
+	`kind` text NOT NULL, `title` text NOT NULL, `message` text NOT NULL, `read_at` text
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_records` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `request_id` integer NOT NULL, `status` text DEFAULT 'PENDING' NOT NULL,
+	`leave_type` text NOT NULL, `personnel_id` integer, `personnel_code` text, `personnel_name` text,
+	`object_type` text NOT NULL, `rank` text, `position` text, `enlistment_date` text, `unit_id` integer,
+	`unit_name` text, `service_years` integer DEFAULT 0 NOT NULL, `base_days` integer DEFAULT 0 NOT NULL,
+	`travel_days` integer DEFAULT 0 NOT NULL, `extra_days` integer DEFAULT 0 NOT NULL,
+	`extra_reasons` text DEFAULT '[]', `total_days` integer DEFAULT 0 NOT NULL, `start_date` text,
+	`end_date` text, `leave_year` text, `locality_id` integer, `locality_path` text, `note` text,
+	`admin_note` text, `proposed_by_user_id` integer, `proposed_by_username` text,
+	`proposed_by_display_name` text, `decided_by_user_id` integer, `decided_by_username` text,
+	`decided_at` text, `archived_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `leave_records_request_id_unique` ON `leave_records` (`request_id`);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_batches` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updated_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `request_id` integer NOT NULL, `personnel_id` integer,
+	`personnel_code` text, `personnel_name` text, `object_type` text NOT NULL, `leave_type` text NOT NULL,
+	`batch_index` integer DEFAULT 1 NOT NULL, `batch_label` text DEFAULT '' NOT NULL, `start_date` text,
+	`end_date` text, `total_days` integer DEFAULT 0 NOT NULL, `note` text, `created_by_user_id` integer
+);
+--> statement-breakpoint
+INSERT OR IGNORE INTO `leave_object_types` (`code`,`name`,`sort_order`) VALUES
+('SQ','Sĩ quan',1),('QNCN','Quân nhân chuyên nghiệp',2),('CNQP','Công nhân quốc phòng',3),
+('VCQP','Viên chức quốc phòng',4),('HSQBS','Hạ sĩ quan, binh sĩ',5),('HV','Học viên',6),('KHAC','Khác',7);
+--> statement-breakpoint
+INSERT OR IGNORE INTO `leave_extra_standards` (`code`,`label`,`days`,`sort_order`) VALUES
+('01','Đóng quân xa gia đình',5,1),('02','Gia đình ở vùng đặc biệt khó khăn',5,2),
+('03','Có cha mẹ già yếu',5,3),('04','Vợ hoặc chồng công tác xa',5,4),
+('05','Có con nhỏ dưới 12 tháng',5,5),('06','Trường hợp đặc biệt khác',5,6);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_positions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL, `name` text NOT NULL UNIQUE,
+	`sort_order` integer DEFAULT 0 NOT NULL, `is_active` integer DEFAULT 1 NOT NULL
+);

--- a/apps/api/migrations/0044_restore_leave_structure.sql
+++ b/apps/api/migrations/0044_restore_leave_structure.sql
@@ -1,0 +1,30 @@
+ALTER TABLE `leave_units` ADD `level` text;
+--> statement-breakpoint
+ALTER TABLE `leave_units` ADD `commander_user_id` integer;
+--> statement-breakpoint
+ALTER TABLE `leave_units` ADD `commander_name` text;
+--> statement-breakpoint
+ALTER TABLE `leave_units` ADD `management_area` text DEFAULT 'cán_bộ' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `leave_personnel` ADD `class_name` text;
+--> statement-breakpoint
+ALTER TABLE `leave_personnel` ADD `management_area` text DEFAULT 'cán_bộ' NOT NULL;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `leave_classes` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`unit_id` integer NOT NULL,
+	`name` text NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `leave_classes_unit_name_unique` ON `leave_classes` (`unit_id`, `name`);
+--> statement-breakpoint
+ALTER TABLE `leave_personnel` ADD `class_id` integer;
+--> statement-breakpoint
+ALTER TABLE `leave_requests` ADD `request_scope` text DEFAULT 'OTHER' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `leave_requests` ADD `class_id` integer;
+--> statement-breakpoint
+ALTER TABLE `leave_requests` ADD `class_name` text;

--- a/apps/api/migrations/0045_leave_user_account_fields.sql
+++ b/apps/api/migrations/0045_leave_user_account_fields.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `users` ADD `leave_unit_id` integer;
+--> statement-breakpoint
+ALTER TABLE `users` ADD `management_area` text;

--- a/apps/api/migrations/0046_restore_roles_and_leave_roles.sql
+++ b/apps/api/migrations/0046_restore_roles_and_leave_roles.sql
@@ -1,0 +1,75 @@
+-- Khôi phục danh mục RBAC nếu database cũ đã có schema nhưng thiếu dữ liệu seed.
+INSERT OR IGNORE INTO actions (name, display_name, description) VALUES
+('create', 'Tạo', 'Tạo dữ liệu'),
+('read', 'Xem', 'Xem dữ liệu'),
+('update', 'Cập nhật', 'Cập nhật dữ liệu'),
+('delete', 'Xóa', 'Xóa dữ liệu');
+--> statement-breakpoint
+
+INSERT OR IGNORE INTO resources (name, display_name, description) VALUES
+('actions', 'Hành vi', 'Quản lý hành vi'),
+('resources', 'Tài nguyên', 'Quản lý tài nguyên'),
+('users', 'Người dùng', 'Quản lý người dùng'),
+('permissions', 'Quyền', 'Quản lý quyền'),
+('roles', 'Vai trò', 'Quản lý vai trò'),
+('classes', 'Lớp', 'Quản lý lớp'),
+('students', 'Học viên', 'Quản lý học viên'),
+('units', 'Đơn vị', 'Quản lý đơn vị'),
+('leave_management', 'Quản lý phép', 'Phân hệ quản lý nghỉ phép');
+--> statement-breakpoint
+
+INSERT OR IGNORE INTO roles (name, description) VALUES
+('super_admin', 'Siêu quản trị viên — toàn quyền hệ thống'),
+('admin', 'Quản trị viên — toàn quyền quản lý'),
+('battalion_commander', 'Chỉ huy tiểu đoàn'),
+('company_commander', 'Chỉ huy đại đội'),
+('viewer', 'Người xem'),
+('user_don_vi', 'Người dùng đơn vị'),
+('user_nganh', 'Người dùng ngành'),
+('exam_lecturer', 'Giảng viên soạn đề thi'),
+('exam_dept_head', 'Chủ nhiệm khoa duyệt đề thi'),
+('exam_office', 'Ban Khảo thí'),
+('leave_admin', 'Quản trị phép — toàn quyền phân hệ phép'),
+('leave_commander', 'Chỉ huy cơ quan — quản lý, đề xuất và duyệt phép trong đơn vị'),
+('leave_agency', 'Cơ quan quản lý — quản lý và duyệt phép, không được đề xuất');
+--> statement-breakpoint
+
+INSERT OR IGNORE INTO permissions
+	(resource_id, action_id, name, display_name, description)
+SELECT
+	r.id,
+	a.id,
+	r.name || ':' || a.name,
+	a.display_name || ' - ' || r.display_name,
+	a.display_name || ' ' || r.display_name
+FROM resources r
+CROSS JOIN actions a;
+--> statement-breakpoint
+
+INSERT OR IGNORE INTO role_permissions (role_id, permission_id)
+SELECT roles.id, permissions.id
+FROM roles CROSS JOIN permissions
+WHERE roles.name IN ('super_admin', 'admin', 'leave_admin');
+--> statement-breakpoint
+
+INSERT OR IGNORE INTO role_permissions (role_id, permission_id)
+SELECT roles.id, permissions.id
+FROM roles
+CROSS JOIN permissions
+WHERE roles.name = 'leave_commander'
+	AND permissions.name IN (
+		'leave_management:create',
+		'leave_management:read',
+		'leave_management:update'
+	);
+--> statement-breakpoint
+
+INSERT OR IGNORE INTO role_permissions (role_id, permission_id)
+SELECT roles.id, permissions.id
+FROM roles
+CROSS JOIN permissions
+WHERE roles.name = 'leave_agency'
+	AND permissions.name IN (
+		'leave_management:read',
+		'leave_management:update'
+	);

--- a/apps/api/migrations/0047_add_leave_personnel_role.sql
+++ b/apps/api/migrations/0047_add_leave_personnel_role.sql
@@ -1,0 +1,16 @@
+INSERT OR IGNORE INTO roles (name, description)
+VALUES (
+	'leave_personnel',
+	'Quân nhân — tự đề xuất nghỉ phép và xem quy định phép'
+);
+--> statement-breakpoint
+
+INSERT OR IGNORE INTO role_permissions (role_id, permission_id)
+SELECT roles.id, permissions.id
+FROM roles
+CROSS JOIN permissions
+WHERE roles.name = 'leave_personnel'
+	AND permissions.name IN (
+		'leave_management:create',
+		'leave_management:read'
+	);

--- a/apps/api/migrations/0048_leave_audit_logs.sql
+++ b/apps/api/migrations/0048_leave_audit_logs.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS `leave_audit_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`user_id` integer,
+	`action` text NOT NULL,
+	`entity_type` text NOT NULL,
+	`entity_id` integer,
+	`details` text
+);

--- a/apps/api/migrations/0049_backfill_approved_leave_data.sql
+++ b/apps/api/migrations/0049_backfill_approved_leave_data.sql
@@ -1,0 +1,19 @@
+UPDATE `leave_records`
+SET `leave_year` = substr(`start_date`, 1, 4)
+WHERE (`leave_year` IS NULL OR `leave_year` = '')
+  AND `start_date` IS NOT NULL;
+--> statement-breakpoint
+INSERT INTO `leave_batches` (
+	`request_id`, `personnel_id`, `personnel_code`, `personnel_name`,
+	`object_type`, `leave_type`, `batch_index`, `batch_label`,
+	`start_date`, `end_date`, `total_days`, `note`, `created_by_user_id`
+)
+SELECT
+	r.`id`, r.`personnel_id`, r.`personnel_code`,
+	CASE WHEN r.`request_scope` = 'CLASS' THEN COALESCE(r.`class_name`, r.`personnel_name`) ELSE r.`personnel_name` END,
+	r.`object_type`, r.`leave_type`, 1,
+	CASE WHEN r.`request_scope` = 'CLASS' THEN 'Đợt nghỉ ' || COALESCE(r.`class_name`, 'lớp') ELSE 'Đợt nghỉ theo đơn đã duyệt' END,
+	r.`start_date`, r.`end_date`, r.`total_days`, r.`note`, r.`decided_by_user_id`
+FROM `leave_requests` r
+WHERE r.`status` = 'APPROVED'
+  AND NOT EXISTS (SELECT 1 FROM `leave_batches` b WHERE b.`request_id` = r.`id`);

--- a/apps/api/migrations/0050_restore_leave_regulations.sql
+++ b/apps/api/migrations/0050_restore_leave_regulations.sql
@@ -1,0 +1,30 @@
+-- Tiêu chuẩn phép hằng năm mặc định.
+-- SQ/QNCN/CNQP/VCQP: dưới 15 năm = 20 ngày; 15-<25 = 25; từ 25 = 30.
+INSERT INTO `leave_regulations` (`leave_type`,`object_type`,`min_years`,`max_years`,`base_days`,`label`,`description`,`is_active`)
+SELECT 'ANNUAL', v.object_type, v.min_years, v.max_years, v.base_days, v.label, v.description, 1
+FROM (
+	SELECT 'SQ' object_type, 0 min_years, 15 max_years, 20 base_days, 'Sỹ quan dưới 15 năm công tác' label, 'Tiêu chuẩn phép hằng năm' description UNION ALL
+	SELECT 'SQ', 15, 25, 25, 'Sỹ quan từ 15 đến dưới 25 năm', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'SQ', 25, NULL, 30, 'Sỹ quan từ 25 năm trở lên', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'QNCN', 0, 15, 20, 'QNCN dưới 15 năm công tác', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'QNCN', 15, 25, 25, 'QNCN từ 15 đến dưới 25 năm', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'QNCN', 25, NULL, 30, 'QNCN từ 25 năm trở lên', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'CNQP', 0, 15, 20, 'Công nhân QP dưới 15 năm công tác', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'CNQP', 15, 25, 25, 'Công nhân QP từ 15 đến dưới 25 năm', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'CNQP', 25, NULL, 30, 'Công nhân QP từ 25 năm trở lên', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'VCQP', 0, 15, 20, 'Viên chức QP dưới 15 năm công tác', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'VCQP', 15, 25, 25, 'Viên chức QP từ 15 đến dưới 25 năm', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'VCQP', 25, NULL, 30, 'Viên chức QP từ 25 năm trở lên', 'Tiêu chuẩn phép hằng năm' UNION ALL
+	SELECT 'HSQBS', 0, NULL, 10, 'Hạ sỹ quan, binh sỹ', 'Tiêu chuẩn 10 ngày phép hằng năm'
+) v
+WHERE NOT EXISTS (
+	SELECT 1 FROM `leave_regulations` r
+	WHERE r.`leave_type` = 'ANNUAL' AND r.`object_type` = v.object_type
+	  AND COALESCE(r.`min_years`, -1) = COALESCE(v.min_years, -1)
+	  AND COALESCE(r.`max_years`, -1) = COALESCE(v.max_years, -1)
+);
+--> statement-breakpoint
+-- MS 01–03 thuộc nhóm nghỉ thêm 10 ngày; MS 04–06 thuộc nhóm 5 ngày.
+UPDATE `leave_extra_standards` SET `days` = 10 WHERE `code` IN ('01','02','03');
+--> statement-breakpoint
+UPDATE `leave_extra_standards` SET `days` = 5 WHERE `code` IN ('04','05','06');

--- a/apps/api/migrations/0051_seed_leave_objects_and_extra_standards.sql
+++ b/apps/api/migrations/0051_seed_leave_objects_and_extra_standards.sql
@@ -1,0 +1,34 @@
+INSERT INTO `leave_object_types` (`code`,`name`,`sort_order`,`is_active`)
+SELECT v.code, v.name, v.sort_order, 1 FROM (
+	SELECT 'SQ' code, 'Sĩ quan' name, 1 sort_order UNION ALL
+	SELECT 'QNCN', 'Quân nhân chuyên nghiệp', 2 UNION ALL
+	SELECT 'CNQP', 'Công nhân quốc phòng', 3 UNION ALL
+	SELECT 'VCQP', 'Viên chức quốc phòng', 4 UNION ALL
+	SELECT 'HSQBS', 'Hạ sĩ quan, binh sĩ', 5 UNION ALL
+	SELECT 'HV', 'Học viên', 6 UNION ALL
+	SELECT 'KHAC', 'Đối tượng khác', 7
+) v
+WHERE NOT EXISTS (SELECT 1 FROM `leave_object_types` o WHERE o.`code` = v.code);
+--> statement-breakpoint
+INSERT INTO `leave_extra_standards` (`code`,`label`,`days`,`sort_order`,`is_active`)
+SELECT v.code, v.label, v.days, v.sort_order, 1 FROM (
+	SELECT '01' code, 'Đóng quân ở đơn vị xa nơi đăng ký nghỉ phép từ 500 km trở lên' label, 10 days, 1 sort_order UNION ALL
+	SELECT '02', 'Đóng quân ở địa bàn đặc biệt khó khăn, vùng sâu, vùng xa, biên giới cách nơi đăng ký nghỉ phép từ 300 km trở lên', 10, 2 UNION ALL
+	SELECT '03', 'Đóng quân tại các đảo thuộc quần đảo Trường Sa và Nhà giàn DK', 10, 3 UNION ALL
+	SELECT '04', 'Đơn vị đóng quân cách nơi đăng ký nghỉ phép từ 300 km đến dưới 500 km', 5, 4 UNION ALL
+	SELECT '05', 'Đóng quân ở vùng sâu, vùng xa, biên giới cách nơi đăng ký nghỉ phép từ 200 km đến dưới 300 km', 5, 5 UNION ALL
+	SELECT '06', 'Đóng quân tại các đảo được hưởng phụ cấp khu vực', 5, 6
+) v
+WHERE NOT EXISTS (SELECT 1 FROM `leave_extra_standards` e WHERE e.`code` = v.code);
+--> statement-breakpoint
+UPDATE `leave_extra_standards` SET `label` = 'Đóng quân ở đơn vị xa nơi đăng ký nghỉ phép từ 500 km trở lên', `days` = 10, `sort_order` = 1, `is_active` = 1 WHERE `code` = '01';
+--> statement-breakpoint
+UPDATE `leave_extra_standards` SET `label` = 'Đóng quân ở địa bàn đặc biệt khó khăn, vùng sâu, vùng xa, biên giới cách nơi đăng ký nghỉ phép từ 300 km trở lên', `days` = 10, `sort_order` = 2, `is_active` = 1 WHERE `code` = '02';
+--> statement-breakpoint
+UPDATE `leave_extra_standards` SET `label` = 'Đóng quân tại các đảo thuộc quần đảo Trường Sa và Nhà giàn DK', `days` = 10, `sort_order` = 3, `is_active` = 1 WHERE `code` = '03';
+--> statement-breakpoint
+UPDATE `leave_extra_standards` SET `label` = 'Đơn vị đóng quân cách nơi đăng ký nghỉ phép từ 300 km đến dưới 500 km', `days` = 5, `sort_order` = 4, `is_active` = 1 WHERE `code` = '04';
+--> statement-breakpoint
+UPDATE `leave_extra_standards` SET `label` = 'Đóng quân ở vùng sâu, vùng xa, biên giới cách nơi đăng ký nghỉ phép từ 200 km đến dưới 300 km', `days` = 5, `sort_order` = 5, `is_active` = 1 WHERE `code` = '05';
+--> statement-breakpoint
+UPDATE `leave_extra_standards` SET `label` = 'Đóng quân tại các đảo được hưởng phụ cấp khu vực', `days` = 5, `sort_order` = 6, `is_active` = 1 WHERE `code` = '06';

--- a/apps/api/migrations/meta/0042_snapshot.json
+++ b/apps/api/migrations/meta/0042_snapshot.json
@@ -1,0 +1,5848 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "486386d6-5317-4c8e-a7fe-01df6b7b7355",
+	"prevId": "a5c20505-8e51-4f27-9505-000000000005",
+	"tables": {
+		"account_audit_logs": {
+			"name": "account_audit_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_is_admin": {
+					"name": "actor_is_admin",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_code": {
+					"name": "room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_name": {
+					"name": "room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"floor_name": {
+					"name": "floor_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_code": {
+					"name": "building_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_name": {
+					"name": "building_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"account_label": {
+					"name": "account_label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"details": {
+					"name": "details",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"actions": {
+			"name": "actions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"actions_name_unique": {
+					"name": "actions_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_broken_logs": {
+			"name": "asset_broken_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_type": {
+					"name": "source_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'OTHER'"
+				},
+				"source_id": {
+					"name": "source_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_request_id": {
+					"name": "repair_request_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source_asset_id": {
+					"name": "source_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_code": {
+					"name": "asset_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"original_code": {
+					"name": "original_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_name": {
+					"name": "asset_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"original_grade": {
+					"name": "original_grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"grade_after": {
+					"name": "grade_after",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status_after": {
+					"name": "status_after",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_code": {
+					"name": "room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_name": {
+					"name": "room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"floor_name": {
+					"name": "floor_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_code": {
+					"name": "building_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_name": {
+					"name": "building_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_name": {
+					"name": "unit_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"result_note": {
+					"name": "result_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"performer": {
+					"name": "performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"event_at": {
+					"name": "event_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_movement_logs": {
+			"name": "asset_movement_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"movement_type": {
+					"name": "movement_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"executed_at": {
+					"name": "executed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"executing_unit": {
+					"name": "executing_unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"install_address": {
+					"name": "install_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_code": {
+					"name": "asset_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_name": {
+					"name": "asset_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"quantity_before": {
+					"name": "quantity_before",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"quantity_after": {
+					"name": "quantity_after",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"grade": {
+					"name": "grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"manufacture_year": {
+					"name": "manufacture_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"usage_year": {
+					"name": "usage_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reason_code": {
+					"name": "reason_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reason_other": {
+					"name": "reason_other",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_date": {
+					"name": "decision_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_number": {
+					"name": "decision_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"signer": {
+					"name": "signer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"performer": {
+					"name": "performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"explanation": {
+					"name": "explanation",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_code": {
+					"name": "building_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_name": {
+					"name": "building_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_code": {
+					"name": "room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_name": {
+					"name": "room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"floor_name": {
+					"name": "floor_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"asset_movement_logs_room_asset_id_room_assets_id_fk": {
+					"name": "asset_movement_logs_room_asset_id_room_assets_id_fk",
+					"tableFrom": "asset_movement_logs",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_proposal_items": {
+			"name": "asset_proposal_items",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"material_id": {
+					"name": "material_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"material_code": {
+					"name": "material_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"material_name": {
+					"name": "material_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source_asset_id": {
+					"name": "source_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"original_grade": {
+					"name": "original_grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"original_code": {
+					"name": "original_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"unit": {
+					"name": "unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"chuyen_nganh_code": {
+					"name": "chuyen_nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"from_room_id": {
+					"name": "from_room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"from_room_code": {
+					"name": "from_room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"from_room_name": {
+					"name": "from_room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"location_note": {
+					"name": "location_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"target_room_id": {
+					"name": "target_room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"target_room_code": {
+					"name": "target_room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"target_room_name": {
+					"name": "target_room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_proposal_logs": {
+			"name": "asset_proposal_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"proposal_type": {
+					"name": "proposal_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"details": {
+					"name": "details",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_is_admin": {
+					"name": "actor_is_admin",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_proposals": {
+			"name": "asset_proposals",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"proposal_type": {
+					"name": "proposal_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'PENDING'"
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_id": {
+					"name": "unit_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_name": {
+					"name": "unit_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_user_id": {
+					"name": "proposed_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_username": {
+					"name": "proposed_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_display_name": {
+					"name": "proposed_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"admin_note": {
+					"name": "admin_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_number": {
+					"name": "decision_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_nganh_code": {
+					"name": "decision_nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_issuing_level": {
+					"name": "decision_issuing_level",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_signer": {
+					"name": "decision_signer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_at": {
+					"name": "decision_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_user_id": {
+					"name": "decided_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_username": {
+					"name": "decided_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_display_name": {
+					"name": "decided_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"buildings": {
+			"name": "buildings",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"manager_code": {
+					"name": "manager_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"area": {
+					"name": "area",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"buildings_code_unique": {
+					"name": "buildings_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"catalog_audit_logs": {
+			"name": "catalog_audit_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"entity_type": {
+					"name": "entity_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_is_admin": {
+					"name": "actor_is_admin",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"entity_id": {
+					"name": "entity_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"entity_code": {
+					"name": "entity_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"entity_name": {
+					"name": "entity_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"parent_code": {
+					"name": "parent_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"parent_name": {
+					"name": "parent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"details": {
+					"name": "details",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"catalog_stock_logs": {
+			"name": "catalog_stock_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"movement_type": {
+					"name": "movement_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"executed_at": {
+					"name": "executed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"material_id": {
+					"name": "material_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"material_code": {
+					"name": "material_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"material_name": {
+					"name": "material_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"chuyen_nganh_code": {
+					"name": "chuyen_nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"chuyen_nganh_name": {
+					"name": "chuyen_nganh_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"quantity_before": {
+					"name": "quantity_before",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"quantity_after": {
+					"name": "quantity_after",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"unit": {
+					"name": "unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_new_material": {
+					"name": "is_new_material",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_is_admin": {
+					"name": "actor_is_admin",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"categories": {
+			"name": "categories",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"categories_code_unique": {
+					"name": "categories_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"classes": {
+			"name": "classes",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"graduatedAt": {
+					"name": "graduatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'ongoing'"
+				},
+				"unitId": {
+					"name": "unitId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"class_unit_unique_constraint": {
+					"name": "class_unit_unique_constraint",
+					"columns": ["name", "unitId"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"classes_unitId_units_id_fk": {
+					"name": "classes_unitId_units_id_fk",
+					"tableFrom": "classes",
+					"tableTo": "units",
+					"columnsFrom": ["unitId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_classes": {
+			"name": "exam_classes",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"faculty_id": {
+					"name": "faculty_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"cohort": {
+					"name": "cohort",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_classes_code_unique": {
+					"name": "exam_classes_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_draw_logs": {
+			"name": "exam_draw_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"draw_id": {
+					"name": "draw_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"details": {
+					"name": "details",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_draws": {
+			"name": "exam_draws",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"draw_code": {
+					"name": "draw_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"exam_id": {
+					"name": "exam_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"exam_code": {
+					"name": "exam_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"paper_number": {
+					"name": "paper_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"subject_id": {
+					"name": "subject_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"draw_type": {
+					"name": "draw_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_name": {
+					"name": "class_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"drawn_by_user_id": {
+					"name": "drawn_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"drawn_by_username": {
+					"name": "drawn_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"drawn_by_display_name": {
+					"name": "drawn_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"drawn_at": {
+					"name": "drawn_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"printed_at": {
+					"name": "printed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"printed_by_user_id": {
+					"name": "printed_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"printed_by_username": {
+					"name": "printed_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"print_blocked": {
+					"name": "print_blocked",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"print_blocked_at": {
+					"name": "print_blocked_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"print_blocked_reason": {
+					"name": "print_blocked_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"exam_date": {
+					"name": "exam_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"exam_time": {
+					"name": "exam_time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"location": {
+					"name": "location",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_draws_draw_code_unique": {
+					"name": "exam_draws_draw_code_unique",
+					"columns": ["draw_code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_faculties": {
+			"name": "exam_faculties",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_faculties_major_code_uq": {
+					"name": "exam_faculties_major_code_uq",
+					"columns": ["major_id", "code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_faculty_heads": {
+			"name": "exam_faculty_heads",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"faculty_code": {
+					"name": "faculty_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"faculty_name": {
+					"name": "faculty_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_faculty_heads_user_fac_uq": {
+					"name": "exam_faculty_heads_user_fac_uq",
+					"columns": ["user_id", "faculty_code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_major_heads": {
+			"name": "exam_major_heads",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_majors": {
+			"name": "exam_majors",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"system_id": {
+					"name": "system_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"level_code": {
+					"name": "level_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"short_code": {
+					"name": "short_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_majors_code_unique": {
+					"name": "exam_majors_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_questions": {
+			"name": "exam_questions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"exam_id": {
+					"name": "exam_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"question_number": {
+					"name": "question_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"answer": {
+					"name": "answer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"points": {
+					"name": "points",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_subjects": {
+			"name": "exam_subjects",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"base_code": {
+					"name": "base_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"credit_hours": {
+					"name": "credit_hours",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 0
+				},
+				"lesson_hours": {
+					"name": "lesson_hours",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 0
+				},
+				"faculty_id": {
+					"name": "faculty_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_subjects_code_unique": {
+					"name": "exam_subjects_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_systems": {
+			"name": "exam_systems",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"letter": {
+					"name": "letter",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_systems_code_unique": {
+					"name": "exam_systems_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				},
+				"exam_systems_letter_unique": {
+					"name": "exam_systems_letter_unique",
+					"columns": ["letter"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_teachers": {
+			"name": "exam_teachers",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"faculty_code": {
+					"name": "faculty_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"faculty_name": {
+					"name": "faculty_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_user_id": {
+					"name": "created_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_username": {
+					"name": "created_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_display_name": {
+					"name": "created_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_teachers_user_uq": {
+					"name": "exam_teachers_user_uq",
+					"columns": ["user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_teaching_assignment_logs": {
+			"name": "exam_teaching_assignment_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"subject_id": {
+					"name": "subject_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"subject_code": {
+					"name": "subject_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"subject_name": {
+					"name": "subject_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"major_code": {
+					"name": "major_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"faculty_id": {
+					"name": "faculty_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"faculty_code": {
+					"name": "faculty_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_code": {
+					"name": "class_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_name": {
+					"name": "class_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teacher_user_id": {
+					"name": "teacher_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teacher_username": {
+					"name": "teacher_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teacher_display_name": {
+					"name": "teacher_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_teaching_assignments": {
+			"name": "exam_teaching_assignments",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"subject_id": {
+					"name": "subject_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teaching_start": {
+					"name": "teaching_start",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teaching_end": {
+					"name": "teaching_end",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_by_user_id": {
+					"name": "assigned_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_by_username": {
+					"name": "assigned_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_by_display_name": {
+					"name": "assigned_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_workflow_logs": {
+			"name": "exam_workflow_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"exam_id": {
+					"name": "exam_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"from_status": {
+					"name": "from_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"to_status": {
+					"name": "to_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exams": {
+			"name": "exams",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"subject_id": {
+					"name": "subject_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"paper_number": {
+					"name": "paper_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'DRAFT'"
+				},
+				"created_by_user_id": {
+					"name": "created_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_username": {
+					"name": "created_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_display_name": {
+					"name": "created_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_user_id": {
+					"name": "approved_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_username": {
+					"name": "approved_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_display_name": {
+					"name": "approved_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_at": {
+					"name": "approved_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_rank": {
+					"name": "approved_by_rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_position": {
+					"name": "approved_by_position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_signature_url": {
+					"name": "approved_by_signature_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_title": {
+					"name": "approved_by_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_user_id": {
+					"name": "dept_head_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_username": {
+					"name": "dept_head_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_display_name": {
+					"name": "dept_head_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_rank": {
+					"name": "dept_head_rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_signature_url": {
+					"name": "dept_head_signature_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_approved_at": {
+					"name": "dept_head_approved_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"qr_code": {
+					"name": "qr_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"locked": {
+					"name": "locked",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_name": {
+					"name": "class_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration_minutes": {
+					"name": "duration_minutes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 60
+				},
+				"question_file_url": {
+					"name": "question_file_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"question_file_name": {
+					"name": "question_file_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"answer_file_url": {
+					"name": "answer_file_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"answer_file_name": {
+					"name": "answer_file_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"return_note": {
+					"name": "return_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exams_code_unique": {
+					"name": "exams_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"floors": {
+			"name": "floors",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"building_id": {
+					"name": "building_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"floor_number": {
+					"name": "floor_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"floors_building_id_buildings_id_fk": {
+					"name": "floors_building_id_buildings_id_fk",
+					"tableFrom": "floors",
+					"tableTo": "buildings",
+					"columnsFrom": ["building_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"resources": {
+			"name": "resources",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"resources_name_unique": {
+					"name": "resources_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"permissions": {
+			"name": "permissions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"resource_id": {
+					"name": "resource_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"action_id": {
+					"name": "action_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"permissions_name_unique": {
+					"name": "permissions_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"permissions_resource_id_resources_id_fk": {
+					"name": "permissions_resource_id_resources_id_fk",
+					"tableFrom": "permissions",
+					"tableTo": "resources",
+					"columnsFrom": ["resource_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"permissions_action_id_actions_id_fk": {
+					"name": "permissions_action_id_actions_id_fk",
+					"tableFrom": "permissions",
+					"tableTo": "actions",
+					"columnsFrom": ["action_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"roles": {
+			"name": "roles",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"roles_name_unique": {
+					"name": "roles_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"role_permissions": {
+			"name": "role_permissions",
+			"columns": {
+				"role_id": {
+					"name": "role_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"permission_id": {
+					"name": "permission_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"role_permissions_role_id_roles_id_fk": {
+					"name": "role_permissions_role_id_roles_id_fk",
+					"tableFrom": "role_permissions",
+					"tableTo": "roles",
+					"columnsFrom": ["role_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"role_permissions_permission_id_permissions_id_fk": {
+					"name": "role_permissions_permission_id_permissions_id_fk",
+					"tableFrom": "role_permissions",
+					"tableTo": "permissions",
+					"columnsFrom": ["permission_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"role_permissions_role_id_permission_id_pk": {
+					"columns": ["role_id", "permission_id"],
+					"name": "role_permissions_role_id_permission_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_roles": {
+			"name": "user_roles",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role_id": {
+					"name": "role_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_roles_user_id_users_id_fk": {
+					"name": "user_roles_user_id_users_id_fk",
+					"tableFrom": "user_roles",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"user_roles_role_id_roles_id_fk": {
+					"name": "user_roles_role_id_roles_id_fk",
+					"tableFrom": "user_roles",
+					"tableTo": "roles",
+					"columnsFrom": ["role_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_roles_user_id_role_id_pk": {
+					"columns": ["user_id", "role_id"],
+					"name": "user_roles_user_id_role_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"displayName": {
+					"name": "displayName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"isSuperUser": {
+					"name": "isSuperUser",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"unitId": {
+					"name": "unitId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"rank": {
+					"name": "rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"position": {
+					"name": "position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"alias": {
+					"name": "alias",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"signature_url": {
+					"name": "signature_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"users_username_unique": {
+					"name": "users_username_unique",
+					"columns": ["username"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"users_unitId_units_id_fk": {
+					"name": "users_unitId_units_id_fk",
+					"tableFrom": "users",
+					"tableTo": "units",
+					"columnsFrom": ["unitId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"units": {
+			"name": "units",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"alias": {
+					"name": "alias",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"level": {
+					"name": "level",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parentId": {
+					"name": "parentId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"units_alias_unique": {
+					"name": "units_alias_unique",
+					"columns": ["alias"],
+					"isUnique": true
+				},
+				"units_name_unique": {
+					"name": "units_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"parent_id_fk": {
+					"name": "parent_id_fk",
+					"tableFrom": "units",
+					"tableTo": "units",
+					"columnsFrom": ["parentId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"students": {
+			"name": "students",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"fullName": {
+					"name": "fullName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"birthPlace": {
+					"name": "birthPlace",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"dob": {
+					"name": "dob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"rank": {
+					"name": "rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"previousUnit": {
+					"name": "previousUnit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"previousPosition": {
+					"name": "previousPosition",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"position": {
+					"name": "position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Học viên'"
+				},
+				"ethnic": {
+					"name": "ethnic",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"religion": {
+					"name": "religion",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"enlistmentPeriod": {
+					"name": "enlistmentPeriod",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"politicalOrg": {
+					"name": "politicalOrg",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"politicalOrgOfficialDate": {
+					"name": "politicalOrgOfficialDate",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"cpvId": {
+					"name": "cpvId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"educationLevel": {
+					"name": "educationLevel",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"schoolName": {
+					"name": "schoolName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"major": {
+					"name": "major",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"isGraduated": {
+					"name": "isGraduated",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": false
+				},
+				"talent": {
+					"name": "talent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"shortcoming": {
+					"name": "shortcoming",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"policyBeneficiaryGroup": {
+					"name": "policyBeneficiaryGroup",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"fatherName": {
+					"name": "fatherName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"fatherDob": {
+					"name": "fatherDob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"fatherPhoneNumber": {
+					"name": "fatherPhoneNumber",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"fatherJob": {
+					"name": "fatherJob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"motherName": {
+					"name": "motherName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"motherDob": {
+					"name": "motherDob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"motherPhoneNumber": {
+					"name": "motherPhoneNumber",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"motherJob": {
+					"name": "motherJob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"isMarried": {
+					"name": "isMarried",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": false
+				},
+				"spouseName": {
+					"name": "spouseName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"spouseDob": {
+					"name": "spouseDob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"spouseJob": {
+					"name": "spouseJob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"spousePhoneNumber": {
+					"name": "spousePhoneNumber",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"childrenInfos": {
+					"name": "childrenInfos",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"familySize": {
+					"name": "familySize",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"familyBackground": {
+					"name": "familyBackground",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"familyBirthOrder": {
+					"name": "familyBirthOrder",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"achievement": {
+					"name": "achievement",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"disciplinaryHistory": {
+					"name": "disciplinaryHistory",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"phone": {
+					"name": "phone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"classId": {
+					"name": "classId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cpvOfficialAt": {
+					"name": "cpvOfficialAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"avatar": {
+					"name": "avatar",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"siblings": {
+					"name": "siblings",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"contactPerson": {
+					"name": "contactPerson",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'{}'"
+				},
+				"studentId": {
+					"name": "studentId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"relatedDocumentations": {
+					"name": "relatedDocumentations",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"students_classId_classes_id_fk": {
+					"name": "students_classId_classes_id_fk",
+					"tableFrom": "students",
+					"tableTo": "classes",
+					"columnsFrom": ["classId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"rooms": {
+			"name": "rooms",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"floor_id": {
+					"name": "floor_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_code": {
+					"name": "room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_name": {
+					"name": "room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_type": {
+					"name": "room_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"manager": {
+					"name": "manager",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"manager_code": {
+					"name": "manager_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"account_password": {
+					"name": "account_password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"capacity": {
+					"name": "capacity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'ACTIVE'"
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"rooms_room_code_unique": {
+					"name": "rooms_room_code_unique",
+					"columns": ["room_code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"rooms_floor_id_floors_id_fk": {
+					"name": "rooms_floor_id_floors_id_fk",
+					"tableFrom": "rooms",
+					"tableTo": "floors",
+					"columnsFrom": ["floor_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"rooms_class_id_classes_id_fk": {
+					"name": "rooms_class_id_classes_id_fk",
+					"tableFrom": "rooms",
+					"tableTo": "classes",
+					"columnsFrom": ["class_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"room_images": {
+			"name": "room_images",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"image_url": {
+					"name": "image_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"room_images_room_id_rooms_id_fk": {
+					"name": "room_images_room_id_rooms_id_fk",
+					"tableFrom": "room_images",
+					"tableTo": "rooms",
+					"columnsFrom": ["room_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"room_assets": {
+			"name": "room_assets",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"broken_quantity": {
+					"name": "broken_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"unit": {
+					"name": "unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"holding_unit_id": {
+					"name": "holding_unit_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"grade": {
+					"name": "grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"manufacture_year": {
+					"name": "manufacture_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"usage_year": {
+					"name": "usage_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"install_address": {
+					"name": "install_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'NORMAL'"
+				},
+				"purchase_date": {
+					"name": "purchase_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expiry_date": {
+					"name": "expiry_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"broken_at": {
+					"name": "broken_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_started_at": {
+					"name": "repair_started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_completed_at": {
+					"name": "repair_completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_performer": {
+					"name": "repair_performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"room_assets_code_unique": {
+					"name": "room_assets_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"room_assets_room_id_rooms_id_fk": {
+					"name": "room_assets_room_id_rooms_id_fk",
+					"tableFrom": "room_assets",
+					"tableTo": "rooms",
+					"columnsFrom": ["room_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"room_assets_holding_unit_id_units_id_fk": {
+					"name": "room_assets_holding_unit_id_units_id_fk",
+					"tableFrom": "room_assets",
+					"tableTo": "units",
+					"columnsFrom": ["holding_unit_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"repair_logs": {
+			"name": "repair_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"repair_date": {
+					"name": "repair_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cost": {
+					"name": "cost",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"performer": {
+					"name": "performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"repair_logs_room_asset_id_room_assets_id_fk": {
+					"name": "repair_logs_room_asset_id_room_assets_id_fk",
+					"tableFrom": "repair_logs",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"inventory_logs": {
+			"name": "inventory_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"inventory_date": {
+					"name": "inventory_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actual_quantity": {
+					"name": "actual_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"expected_quantity": {
+					"name": "expected_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"result": {
+					"name": "result",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"inventory_logs_room_asset_id_room_assets_id_fk": {
+					"name": "inventory_logs_room_asset_id_room_assets_id_fk",
+					"tableFrom": "inventory_logs",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"replacement_logs": {
+			"name": "replacement_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"replacement_date": {
+					"name": "replacement_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"old_asset": {
+					"name": "old_asset",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"new_asset": {
+					"name": "new_asset",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"performer": {
+					"name": "performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"replacement_logs_room_asset_id_room_assets_id_fk": {
+					"name": "replacement_logs_room_asset_id_room_assets_id_fk",
+					"tableFrom": "replacement_logs",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_nganh": {
+			"name": "user_nganh",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_nganh_user_nganh_uq": {
+					"name": "user_nganh_user_nganh_uq",
+					"columns": ["user_id", "nganh_code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"user_nganh_user_id_users_id_fk": {
+					"name": "user_nganh_user_id_users_id_fk",
+					"tableFrom": "user_nganh",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"repair_requests": {
+			"name": "repair_requests",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source_asset_id": {
+					"name": "source_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"original_grade": {
+					"name": "original_grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_name": {
+					"name": "asset_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'PENDING'"
+				},
+				"broken_at": {
+					"name": "broken_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reported_by_name": {
+					"name": "reported_by_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reported_by_user_id": {
+					"name": "reported_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_to_name": {
+					"name": "assigned_to_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_at": {
+					"name": "assigned_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_by_name": {
+					"name": "assigned_by_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_started_at": {
+					"name": "repair_started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"admin_note": {
+					"name": "admin_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"repair_requests_room_id_rooms_id_fk": {
+					"name": "repair_requests_room_id_rooms_id_fk",
+					"tableFrom": "repair_requests",
+					"tableTo": "rooms",
+					"columnsFrom": ["room_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"repair_requests_room_asset_id_room_assets_id_fk": {
+					"name": "repair_requests_room_asset_id_room_assets_id_fk",
+					"tableFrom": "repair_requests",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"repair_requests_source_asset_id_room_assets_id_fk": {
+					"name": "repair_requests_source_asset_id_room_assets_id_fk",
+					"tableFrom": "repair_requests",
+					"tableTo": "room_assets",
+					"columnsFrom": ["source_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"repair_requests_reported_by_user_id_users_id_fk": {
+					"name": "repair_requests_reported_by_user_id_users_id_fk",
+					"tableFrom": "repair_requests",
+					"tableTo": "users",
+					"columnsFrom": ["reported_by_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"suppliers": {
+			"name": "suppliers",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"contact_person": {
+					"name": "contact_person",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"suppliers_code_unique": {
+					"name": "suppliers_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"materials": {
+			"name": "materials",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"category_id": {
+					"name": "category_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"supplier_id": {
+					"name": "supplier_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"unit": {
+					"name": "unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"min_quantity": {
+					"name": "min_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"price": {
+					"name": "price",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'ACTIVE'"
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"materials_code_unique": {
+					"name": "materials_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"materials_category_id_categories_id_fk": {
+					"name": "materials_category_id_categories_id_fk",
+					"tableFrom": "materials",
+					"tableTo": "categories",
+					"columnsFrom": ["category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"materials_supplier_id_suppliers_id_fk": {
+					"name": "materials_supplier_id_suppliers_id_fk",
+					"tableFrom": "materials",
+					"tableTo": "suppliers",
+					"columnsFrom": ["supplier_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"warehouses": {
+			"name": "warehouses",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"location": {
+					"name": "location",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"manager": {
+					"name": "manager",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"warehouses_code_unique": {
+					"name": "warehouses_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"warehouse_items": {
+			"name": "warehouse_items",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"warehouse_id": {
+					"name": "warehouse_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"material_id": {
+					"name": "material_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"min_quantity": {
+					"name": "min_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"warehouse_items_warehouse_id_warehouses_id_fk": {
+					"name": "warehouse_items_warehouse_id_warehouses_id_fk",
+					"tableFrom": "warehouse_items",
+					"tableTo": "warehouses",
+					"columnsFrom": ["warehouse_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"warehouse_items_material_id_materials_id_fk": {
+					"name": "warehouse_items_material_id_materials_id_fk",
+					"tableFrom": "warehouse_items",
+					"tableTo": "materials",
+					"columnsFrom": ["material_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"notification_items": {
+			"name": "notification_items",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"notifiableType": {
+					"name": "notifiableType",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"notifiableId": {
+					"name": "notifiableId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"notificationId": {
+					"name": "notificationId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"notification_items_notification_idx": {
+					"name": "notification_items_notification_idx",
+					"columns": ["notificationId"],
+					"isUnique": false
+				},
+				"notification_items_item_idx": {
+					"name": "notification_items_item_idx",
+					"columns": ["notifiableType", "notifiableId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"notification_items_notificationId_notifications_id_fk": {
+					"name": "notification_items_notificationId_notifications_id_fk",
+					"tableFrom": "notification_items",
+					"tableTo": "notifications",
+					"columnsFrom": ["notificationId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"notifications": {
+			"name": "notifications",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"readAt": {
+					"name": "readAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notificationType": {
+					"name": "notificationType",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'birthday'"
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"message": {
+					"name": "message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"isBatch": {
+					"name": "isBatch",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": false
+				},
+				"batchKey": {
+					"name": "batchKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"totalCount": {
+					"name": "totalCount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 1
+				},
+				"recipientId": {
+					"name": "recipientId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actorId": {
+					"name": "actorId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"recipient_idx": {
+					"name": "recipient_idx",
+					"columns": ["recipientId"],
+					"isUnique": false
+				},
+				"batch_idx": {
+					"name": "batch_idx",
+					"columns": ["batchKey"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"notifications_recipientId_users_id_fk": {
+					"name": "notifications_recipientId_users_id_fk",
+					"tableFrom": "notifications",
+					"tableTo": "users",
+					"columnsFrom": ["recipientId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"notifications_actorId_users_id_fk": {
+					"name": "notifications_actorId_users_id_fk",
+					"tableFrom": "notifications",
+					"tableTo": "users",
+					"columnsFrom": ["actorId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/apps/api/migrations/meta/_journal.json
+++ b/apps/api/migrations/meta/_journal.json
@@ -299,43 +299,57 @@
 		{
 			"idx": 42,
 			"version": "6",
-			"when": 1785552000000,
-			"tag": "0042_exam_academic_titles",
+			"when": 1785376116953,
+			"tag": "0042_lying_greymalkin",
 			"breakpoints": true
 		},
 		{
 			"idx": 43,
 			"version": "6",
-			"when": 1785552600000,
-			"tag": "0043_restore_exam_classes",
+			"when": 1785420000000,
+			"tag": "0043_leave_management",
 			"breakpoints": true
 		},
 		{
 			"idx": 44,
 			"version": "6",
-			"when": 1785553200000,
-			"tag": "0044_restore_exam_runtime_tables",
+			"when": 1785422100000,
+			"tag": "0046_restore_roles_and_leave_roles",
 			"breakpoints": true
 		},
 		{
 			"idx": 45,
 			"version": "6",
-			"when": 1785553800000,
-			"tag": "0045_exam_major_official_catalog",
+			"when": 1785422700000,
+			"tag": "0047_add_leave_personnel_role",
 			"breakpoints": true
 		},
 		{
 			"idx": 46,
 			"version": "6",
-			"when": 1785554400000,
-			"tag": "0046_use_catalog_number_as_major_code",
+			"when": 1785423300000,
+			"tag": "0048_leave_audit_logs",
 			"breakpoints": true
 		},
 		{
 			"idx": 47,
 			"version": "6",
-			"when": 1785555000000,
-			"tag": "0047_sync_exam_log_major_codes",
+			"when": 1785423900000,
+			"tag": "0049_backfill_approved_leave_data",
+			"breakpoints": true
+		},
+		{
+			"idx": 48,
+			"version": "6",
+			"when": 1785424500000,
+			"tag": "0050_restore_leave_regulations",
+			"breakpoints": true
+		},
+		{
+			"idx": 49,
+			"version": "6",
+			"when": 1785425100000,
+			"tag": "0051_seed_leave_objects_and_extra_standards",
 			"breakpoints": true
 		}
 	]

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -50,6 +50,7 @@
 		"jsonwebtoken": "^9.0.2",
 		"mysql2": "^3.12.0",
 		"node": "link:@libsql/client/node",
+		"nodemailer": "^9.0.3",
 		"uuid": "^11.1.0",
 		"valibot": "^1.1.0",
 		"xlsx-template": "^1.4.4"

--- a/apps/api/schema/index.ts
+++ b/apps/api/schema/index.ts
@@ -31,6 +31,7 @@ export * from './asset-movement-logs'
 export * from './account-audit-logs'
 export * from './catalog-audit-logs'
 export * from './catalog-stock-logs'
+export * from './leave-audit-logs'
 export * from './asset-broken-logs'
 export * from './user-nganh'
 export * from './asset-proposals'
@@ -51,3 +52,8 @@ export * from './notifications'
 
 // Đề thi tự luận
 export * from './exam-bank'
+
+// Quản lý nghỉ phép
+export * from './leave-management'
+export * from './leave-batches'
+export * from './leave-positions'

--- a/apps/api/schema/leave-audit-logs.ts
+++ b/apps/api/schema/leave-audit-logs.ts
@@ -1,0 +1,11 @@
+import { int, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { baseSchema } from './base'
+
+export const leaveAuditLogs = sqliteTable('leave_audit_logs', {
+	...baseSchema,
+	userId: int('user_id'),
+	action: text('action').notNull(),
+	entityType: text('entity_type').notNull(),
+	entityId: int('entity_id'),
+	details: text('details')
+})

--- a/apps/api/schema/leave-batches.ts
+++ b/apps/api/schema/leave-batches.ts
@@ -1,0 +1,62 @@
+import { int, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { sql } from 'drizzle-orm'
+import { Base } from './base'
+import type { LeaveObjectType, LeaveType } from './leave-management'
+
+export const leaveBatches = sqliteTable('leave_batches', {
+	id: int('id').primaryKey({ autoIncrement: true }),
+	createdAt: text('created_at')
+		.notNull()
+		.default(sql`CURRENT_TIMESTAMP`),
+	updatedAt: text('updated_at')
+		.notNull()
+		.default(sql`CURRENT_TIMESTAMP`),
+	requestId: int('request_id').notNull(),
+	personnelId: int('personnel_id'),
+	personnelCode: text('personnel_code'),
+	personnelName: text('personnel_name'),
+	objectType: text('object_type').notNull().$type<LeaveObjectType>(),
+	leaveType: text('leave_type').notNull().$type<LeaveType>(),
+	batchIndex: int('batch_index').notNull().default(1),
+	batchLabel: text('batch_label').notNull().default(''),
+	startDate: text('start_date'),
+	endDate: text('end_date'),
+	totalDays: int('total_days').notNull().default(0),
+	note: text('note'),
+	createdByUserId: int('created_by_user_id')
+})
+
+export interface LeaveBatchDB extends Base {
+	requestId: number
+	personnelId: number | null
+	personnelCode: string | null
+	personnelName: string | null
+	objectType: LeaveObjectType
+	leaveType: LeaveType
+	batchIndex: number
+	batchLabel: string
+	startDate: string | null
+	endDate: string | null
+	totalDays: number
+	note: string | null
+	createdByUserId: number | null
+}
+
+export interface LeaveBatchResponse {
+	id: number
+	createdAt: string
+	updatedAt: string
+	requestId: number
+	personnelId: number | null
+	personnelCode: string | null
+	personnelName: string | null
+	objectType: LeaveObjectType
+	leaveType: LeaveType
+	batchIndex: number
+	batchLabel: string
+	startDate: string | null
+	endDate: string | null
+	totalDays: number
+	note: string | null
+	createdByUserId: number | null
+}

--- a/apps/api/schema/leave-management.ts
+++ b/apps/api/schema/leave-management.ts
@@ -1,0 +1,401 @@
+import { int, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { Base, baseSchema } from './base'
+
+/**
+ * Mã đối tượng theo quy định (Ma_DT):
+ * SQ | QNCN | CNQP | VCQP | HSQBS | HV | KHAC
+ * Legacy (map khi đọc/ghi): QN→SQ, CN→CNQP, HSQ|BS→HSQBS
+ */
+export type LeaveObjectType =
+	| 'SQ'
+	| 'QNCN'
+	| 'CNQP'
+	| 'VCQP'
+	| 'HSQBS'
+	| 'HV'
+	| 'KHAC'
+	/** @deprecated dùng SQ */
+	| 'QN'
+	/** @deprecated dùng CNQP */
+	| 'CN'
+	/** @deprecated dùng HSQBS */
+	| 'HSQ'
+	/** @deprecated dùng HSQBS */
+	| 'BS'
+
+/** ANNUAL = phép hằng năm | SPECIAL = phép đặc biệt */
+export type LeaveType = 'ANNUAL' | 'SPECIAL'
+
+/** Cấp địa phương */
+export type LeaveLocalityLevel = 'province' | 'ward' | 'village'
+
+/**
+ * DRAFT — nháp
+ * PENDING_COMMANDER — chờ chỉ huy cơ quan duyệt
+ * PENDING_AGENCY — chờ cơ quan quản lý (in / BGH–quân lực ký)
+ * PENDING — legacy (= chờ duyệt, map như PENDING_COMMANDER)
+ * APPROVED — đã duyệt (sau khi ký)
+ * RETURNED — trả lại
+ * REJECTED — từ chối (legacy, map như RETURNED)
+ * CANCELLED — đã hủy
+ */
+export type LeaveRequestStatus =
+	| 'DRAFT'
+	| 'PENDING'
+	| 'PENDING_COMMANDER'
+	| 'PENDING_AGENCY'
+	| 'APPROVED'
+	| 'RETURNED'
+	| 'REJECTED'
+	| 'CANCELLED'
+
+/** Bảng đối tượng (Ma_DT, Tên_ĐT) */
+export const leaveObjectTypes = sqliteTable('leave_object_types', {
+	...baseSchema,
+	code: text('code').notNull().unique(),
+	name: text('name').notNull(),
+	sortOrder: int('sort_order').notNull().default(0),
+	isActive: int('is_active', { mode: 'boolean' }).notNull().default(true)
+})
+
+/** Danh mục đơn vị / đầu mối đơn vị trực thuộc */
+export const leaveUnits = sqliteTable('leave_units', {
+	...baseSchema,
+	code: text('code'),
+	name: text('name').notNull(),
+	level: text('level'),
+	parentId: int('parent_id'),
+	isActive: int('is_active', { mode: 'boolean' }).notNull().default(true),
+	commanderUserId: int('commander_user_id'),
+	commanderName: text('commander_name'),
+	managementArea: text('management_area').notNull().default('cán_bộ')
+})
+
+/** Lớp học viên thuộc đại đội (mỗi đại đội tối đa 2 lớp A1–A10). */
+export const leaveClasses = sqliteTable('leave_classes', {
+	...baseSchema,
+	unitId: int('unit_id').notNull(),
+	name: text('name').notNull(),
+	isActive: int('is_active', { mode: 'boolean' }).notNull().default(true)
+})
+
+/** Tiêu chuẩn phép thêm (MS 01–06) */
+export const leaveExtraStandards = sqliteTable('leave_extra_standards', {
+	...baseSchema,
+	code: text('code').notNull().unique(),
+	label: text('label').notNull(),
+	days: int('days').notNull(),
+	sortOrder: int('sort_order').notNull().default(0),
+	isActive: int('is_active', { mode: 'boolean' }).notNull().default(true)
+})
+
+/** Danh sách quân nhân (catalog phép) */
+export const leavePersonnel = sqliteTable('leave_personnel', {
+	...baseSchema,
+	code: text('code').notNull().unique(),
+	fullName: text('full_name').notNull(),
+	/** Ngày nhập ngũ YYYY-MM-DD */
+	enlistmentDate: text('enlistment_date'),
+	/** Tuyển dụng (đợt / hình thức) */
+	recruitment: text('recruitment'),
+	objectType: text('object_type').notNull().$type<LeaveObjectType>(),
+	rank: text('rank'),
+	position: text('position'),
+	classId: int('class_id'),
+	/** FK leave_units.id (ưu tiên) hoặc units.id */
+	unitId: int('unit_id'),
+	unitName: text('unit_name'),
+	hometown: text('hometown'),
+	permanentResidence: text('permanent_residence'),
+	/** Liên kết user đăng nhập (optional) */
+	userId: int('user_id'),
+	/** Email nhận thông báo duyệt / trả đơn */
+	email: text('email'),
+	/** Chỉ huy cơ quan (user id) — nhận đơn đề xuất bước 1 */
+	commanderUserId: int('commander_user_id'),
+	/** Tên chỉ huy (cache) */
+	commanderName: text('commander_name'),
+	className: text('class_name'),
+	managementArea: text('management_area').notNull().default('cán_bộ')
+})
+
+/** Cây địa phương: Tỉnh → Xã/Phường → Thôn */
+export const leaveLocalities = sqliteTable('leave_localities', {
+	...baseSchema,
+	name: text('name').notNull(),
+	level: text('level').notNull().$type<LeaveLocalityLevel>(),
+	parentId: int('parent_id'),
+	code: text('code')
+})
+
+/**
+ * Quy định / tiêu chuẩn phép hằng năm (và SPECIAL).
+ * ANNUAL: object_type + min/max service years → base days
+ * SPECIAL: rule riêng (base_days cấu hình)
+ */
+export const leaveRegulations = sqliteTable('leave_regulations', {
+	...baseSchema,
+	leaveType: text('leave_type').notNull().$type<LeaveType>(),
+	objectType: text('object_type').$type<LeaveObjectType | null>(),
+	/** Thâm niên từ (năm), inclusive; null = không giới hạn dưới */
+	minYears: int('min_years'),
+	/** Thâm niên đến (năm), exclusive; null = không giới hạn trên */
+	maxYears: int('max_years'),
+	baseDays: int('base_days').notNull(),
+	label: text('label'),
+	description: text('description'),
+	isActive: int('is_active', { mode: 'boolean' }).notNull().default(true)
+})
+
+/** Đơn / danh sách phép (workflow) */
+export const leaveRequests = sqliteTable('leave_requests', {
+	...baseSchema,
+	leaveType: text('leave_type').notNull().$type<LeaveType>(),
+	requestScope: text('request_scope').notNull().default('OTHER'),
+	classId: int('class_id'),
+	className: text('class_name'),
+	status: text('status')
+		.notNull()
+		.default('PENDING')
+		.$type<LeaveRequestStatus>(),
+	personnelId: int('personnel_id'),
+	personnelCode: text('personnel_code'),
+	personnelName: text('personnel_name'),
+	objectType: text('object_type').notNull().$type<LeaveObjectType>(),
+	rank: text('rank'),
+	/** Snapshot chức vụ từ hồ sơ QN */
+	position: text('position'),
+	/** Snapshot ngày nhập ngũ / tuyển dụng */
+	enlistmentDate: text('enlistment_date'),
+	unitId: int('unit_id'),
+	unitName: text('unit_name'),
+	/** Thâm niên (năm) tại thời điểm đề xuất (theo ngày bắt đầu nghỉ) */
+	serviceYears: int('service_years').notNull().default(0),
+	baseDays: int('base_days').notNull().default(0),
+	/** Ngày đi đường */
+	travelDays: int('travel_days').notNull().default(0),
+	/** 0 | 5 | 10 */
+	extraDays: int('extra_days').notNull().default(0),
+	/** JSON string[] reason codes */
+	extraReasons: text('extra_reasons').default('[]'),
+	totalDays: int('total_days').notNull().default(0),
+	startDate: text('start_date'),
+	endDate: text('end_date'),
+	leaveYear: text('leave_year'),
+	/** Nơi đăng ký nghỉ phép (thôn / xã / tỉnh) */
+	localityId: int('locality_id'),
+	localityPath: text('locality_path'),
+	note: text('note'),
+	proposedByUserId: int('proposed_by_user_id'),
+	proposedByUsername: text('proposed_by_username'),
+	proposedByDisplayName: text('proposed_by_display_name'),
+	/** Email người đề xuất (snapshot) */
+	proposerEmail: text('proposer_email'),
+	/** Chỉ huy cơ quan phụ trách đơn này */
+	commanderUserId: int('commander_user_id'),
+	commanderName: text('commander_name'),
+	adminNote: text('admin_note'),
+	decidedByUserId: int('decided_by_user_id'),
+	decidedByUsername: text('decided_by_username'),
+	decidedAt: text('decided_at')
+})
+
+/** Nhật ký gửi mail (để kiểm tra khi SMTP dev / lỗi) */
+export const leaveMailLog = sqliteTable('leave_mail_log', {
+	...baseSchema,
+	requestId: int('request_id'),
+	toEmail: text('to_email').notNull(),
+	subject: text('subject').notNull(),
+	body: text('body'),
+	mode: text('mode'),
+	ok: int('ok', { mode: 'boolean' }).notNull().default(false),
+	error: text('error'),
+	previewUrl: text('preview_url'),
+	/** DECISION | SUBMITTED | TEST | ... */
+	kind: text('kind')
+})
+
+/**
+ * Thông báo in-app cho chỉ huy / CQQL / người đề xuất (duyệt phép).
+ */
+export const leaveAlerts = sqliteTable('leave_alerts', {
+	...baseSchema,
+	userId: int('user_id').notNull(),
+	requestId: int('request_id').notNull(),
+	/** NEED_COMMANDER | NEED_AGENCY | DECIDED | RETURNED */
+	kind: text('kind').notNull(),
+	title: text('title').notNull(),
+	message: text('message').notNull(),
+	readAt: text('read_at')
+})
+
+/**
+ * Bảng lưu thông tin nghỉ phép (lưu trữ / tra cứu).
+ * Khi giải quyết phép (ký phê duyệt) → đẩy snapshot vào đây.
+ */
+export const leaveRecords = sqliteTable('leave_records', {
+	...baseSchema,
+	requestId: int('request_id').notNull(),
+	/** Snapshot trạng thái đơn (ghi khi gửi duyệt, cập nhật khi xử lý) */
+	status: text('status')
+		.notNull()
+		.default('PENDING')
+		.$type<LeaveRequestStatus>(),
+	leaveType: text('leave_type').notNull().$type<LeaveType>(),
+	personnelId: int('personnel_id'),
+	personnelCode: text('personnel_code'),
+	personnelName: text('personnel_name'),
+	objectType: text('object_type').notNull().$type<LeaveObjectType>(),
+	rank: text('rank'),
+	position: text('position'),
+	enlistmentDate: text('enlistment_date'),
+	unitId: int('unit_id'),
+	unitName: text('unit_name'),
+	serviceYears: int('service_years').notNull().default(0),
+	baseDays: int('base_days').notNull().default(0),
+	travelDays: int('travel_days').notNull().default(0),
+	extraDays: int('extra_days').notNull().default(0),
+	extraReasons: text('extra_reasons').default('[]'),
+	totalDays: int('total_days').notNull().default(0),
+	startDate: text('start_date'),
+	endDate: text('end_date'),
+	leaveYear: text('leave_year'),
+	localityId: int('locality_id'),
+	localityPath: text('locality_path'),
+	note: text('note'),
+	adminNote: text('admin_note'),
+	proposedByUserId: int('proposed_by_user_id'),
+	proposedByUsername: text('proposed_by_username'),
+	proposedByDisplayName: text('proposed_by_display_name'),
+	decidedByUserId: int('decided_by_user_id'),
+	decidedByUsername: text('decided_by_username'),
+	decidedAt: text('decided_at'),
+	archivedAt: text('archived_at').notNull()
+})
+
+export interface LeaveObjectTypeDB extends Base {
+	code: string
+	name: string
+	sortOrder: number
+	isActive: boolean
+}
+
+export interface LeaveUnitDB extends Base {
+	code: string | null
+	name: string
+	parentId: number | null
+	isActive: boolean
+}
+
+export interface LeaveExtraStandardDB extends Base {
+	code: string
+	label: string
+	days: number
+	sortOrder: number
+	isActive: boolean
+}
+
+export interface LeavePersonnelDB extends Base {
+	code: string
+	fullName: string
+	enlistmentDate: string | null
+	recruitment: string | null
+	objectType: LeaveObjectType
+	rank: string | null
+	position: string | null
+	unitId: number | null
+	unitName: string | null
+	hometown: string | null
+	permanentResidence: string | null
+	userId: number | null
+	email: string | null
+	commanderUserId: number | null
+	commanderName: string | null
+}
+
+export interface LeaveLocalityDB extends Base {
+	name: string
+	level: LeaveLocalityLevel
+	parentId: number | null
+	code: string | null
+}
+
+export interface LeaveRegulationDB extends Base {
+	leaveType: LeaveType
+	objectType: LeaveObjectType | null
+	minYears: number | null
+	maxYears: number | null
+	baseDays: number
+	label: string | null
+	description: string | null
+	isActive: boolean
+}
+
+export interface LeaveRequestDB extends Base {
+	leaveType: LeaveType
+	status: LeaveRequestStatus
+	personnelId: number | null
+	personnelCode: string | null
+	personnelName: string | null
+	objectType: LeaveObjectType
+	rank: string | null
+	position: string | null
+	enlistmentDate: string | null
+	unitId: number | null
+	unitName: string | null
+	serviceYears: number
+	baseDays: number
+	travelDays: number
+	extraDays: number
+	extraReasons: string | null
+	totalDays: number
+	startDate: string | null
+	endDate: string | null
+	localityId: number | null
+	localityPath: string | null
+	note: string | null
+	proposedByUserId: number | null
+	proposedByUsername: string | null
+	proposedByDisplayName: string | null
+	proposerEmail: string | null
+	commanderUserId: number | null
+	commanderName: string | null
+	adminNote: string | null
+	decidedByUserId: number | null
+	decidedByUsername: string | null
+	decidedAt: string | null
+}
+
+export interface LeaveRecordDB extends Base {
+	requestId: number
+	status: LeaveRequestStatus
+	leaveType: LeaveType
+	personnelId: number | null
+	personnelCode: string | null
+	personnelName: string | null
+	objectType: LeaveObjectType
+	rank: string | null
+	position: string | null
+	enlistmentDate: string | null
+	unitId: number | null
+	unitName: string | null
+	serviceYears: number
+	baseDays: number
+	travelDays: number
+	extraDays: number
+	extraReasons: string | null
+	totalDays: number
+	startDate: string | null
+	endDate: string | null
+	localityId: number | null
+	localityPath: string | null
+	note: string | null
+	adminNote: string | null
+	proposedByUserId: number | null
+	proposedByUsername: string | null
+	proposedByDisplayName: string | null
+	decidedByUserId: number | null
+	decidedByUsername: string | null
+	decidedAt: string | null
+	archivedAt: string
+}

--- a/apps/api/schema/leave-positions.ts
+++ b/apps/api/schema/leave-positions.ts
@@ -1,0 +1,9 @@
+import { int, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { baseSchema } from './base'
+
+export const leavePositions = sqliteTable('leave_positions', {
+	...baseSchema,
+	name: text('name').notNull().unique(),
+	sortOrder: int('sort_order').notNull().default(0),
+	isActive: int('is_active', { mode: 'boolean' }).notNull().default(true)
+})

--- a/apps/api/schema/users.ts
+++ b/apps/api/schema/users.ts
@@ -35,6 +35,8 @@ export const users = p.sqliteTable('users', {
 	rank: p.text(),
 	position: p.text(),
 	alias: p.text(),
+	leaveUnitId: p.int('leave_unit_id'),
+	managementArea: p.text('management_area'),
 	/** Ảnh chữ ký số (URL / data URL) — BGH dùng khi phê duyệt đề */
 	signatureUrl: p.text('signature_url')
 })
@@ -57,6 +59,8 @@ export interface UserDB extends Base {
 	rank?: string | null
 	position?: string | null
 	alias?: string | null
+	leaveUnitId?: number | null
+	managementArea?: string | null
 	signatureUrl?: string | null
 }
 

--- a/apps/web/src/api/leave.ts
+++ b/apps/web/src/api/leave.ts
@@ -96,7 +96,7 @@ export interface LeaveRegulation {
 	createdAt: string
 	updatedAt: string
 	leaveType: LeaveType
-	requestScope: 'INDIVIDUAL' | 'CLASS'
+	requestScope: 'INDIVIDUAL' | 'CLASS' | 'SHORT_LEAVE'
 	classId: number | null
 	className: string | null
 	objectType: LeaveObjectType | null
@@ -114,7 +114,7 @@ export interface LeaveRequest {
 	createdAt: string
 	updatedAt: string
 	leaveType: LeaveType
-	requestScope: 'INDIVIDUAL' | 'CLASS'
+	requestScope: 'INDIVIDUAL' | 'CLASS' | 'SHORT_LEAVE'
 	classId: number | null
 	className: string | null
 	status: LeaveRequestStatus
@@ -215,7 +215,7 @@ export interface LeaveRecord {
 	decidedByUsername: string | null
 	decidedAt: string | null
 	archivedAt: string
-	requestScope: 'INDIVIDUAL' | 'CLASS'
+	requestScope: 'INDIVIDUAL' | 'CLASS' | 'SHORT_LEAVE'
 	classId: number | null
 	className: string | null
 	memberCount: number
@@ -430,7 +430,7 @@ export function ListLeaveRequests(params?: {
 
 export function CreateLeaveRequest(body: {
 	leaveType?: string
-	requestScope?: 'INDIVIDUAL' | 'CLASS'
+	requestScope?: 'INDIVIDUAL' | 'CLASS' | 'SHORT_LEAVE'
 	classId?: number | null
 	className?: string | null
 	manualDays?: number

--- a/apps/web/src/api/leave.ts
+++ b/apps/web/src/api/leave.ts
@@ -1,0 +1,1047 @@
+/**
+ * Quản lý phép — API wrappers (json fetch + appFetcher auth)
+ */
+import { appFetcher } from '@/lib/axios'
+import { ApiUrl } from '@/lib/const'
+
+async function jsonFetch<T>(path: string, init?: RequestInit): Promise<T> {
+	const url = `${ApiUrl.replace(/\/$/, '')}${path}`
+	const resp = await appFetcher(url, {
+		...init,
+		headers: {
+			'Content-Type': 'application/json',
+			...(init?.headers ?? {})
+		}
+	})
+	if (!resp.ok) {
+		let message = `HTTP ${resp.status}`
+		try {
+			const body = await resp.json()
+			message =
+				body?.message ||
+				body?.error ||
+				body?.internal_message ||
+				message
+		} catch {
+			/* ignore */
+		}
+		throw new Error(message)
+	}
+	if (resp.status === 204) return undefined as T
+	return resp.json() as Promise<T>
+}
+
+/** Mã đối tượng theo quy định (legacy: QN|CN|HSQ|BS vẫn map được phía API) */
+export type LeaveObjectType =
+	| 'SQ'
+	| 'QNCN'
+	| 'CNQP'
+	| 'VCQP'
+	| 'HSQBS'
+	| 'HV'
+	| 'KHAC'
+	| 'QN'
+	| 'CN'
+	| 'HSQ'
+	| 'BS'
+export type LeaveType = 'ANNUAL' | 'SPECIAL'
+export type LeaveLocalityLevel = 'province' | 'ward' | 'village'
+export type LeaveRequestStatus =
+	| 'DRAFT'
+	| 'PENDING'
+	| 'PENDING_COMMANDER'
+	| 'PENDING_AGENCY'
+	| 'APPROVED'
+	| 'RETURNED'
+	| 'REJECTED'
+	| 'CANCELLED'
+
+export interface LeavePersonnel {
+	id: number
+	createdAt: string
+	updatedAt: string
+	code: string
+	fullName: string
+	enlistmentDate: string | null
+	recruitment: string | null
+	objectType: LeaveObjectType
+	rank: string | null
+	position: string | null
+	classId: number | null
+	unitId: number | null
+	unitName: string | null
+	hometown: string | null
+	permanentResidence: string | null
+	userId: number | null
+	email: string | null
+	commanderUserId: number | null
+	commanderName: string | null
+	className: string | null
+	managementArea: string
+}
+
+export interface LeaveLocality {
+	id: number
+	createdAt: string
+	updatedAt: string
+	name: string
+	level: LeaveLocalityLevel
+	parentId: number | null
+	code: string | null
+	children?: LeaveLocality[]
+}
+
+export interface LeaveRegulation {
+	id: number
+	createdAt: string
+	updatedAt: string
+	leaveType: LeaveType
+	requestScope: 'INDIVIDUAL' | 'CLASS'
+	classId: number | null
+	className: string | null
+	objectType: LeaveObjectType | null
+	objectTypeLabel: string | null
+	minYears: number | null
+	maxYears: number | null
+	baseDays: number
+	label: string | null
+	description: string | null
+	isActive: boolean
+}
+
+export interface LeaveRequest {
+	id: number
+	createdAt: string
+	updatedAt: string
+	leaveType: LeaveType
+	requestScope: 'INDIVIDUAL' | 'CLASS'
+	classId: number | null
+	className: string | null
+	status: LeaveRequestStatus
+	personnelId: number | null
+	personnelCode: string | null
+	personnelName: string | null
+	objectType: LeaveObjectType
+	objectTypeLabel: string
+	rank: string | null
+	position: string | null
+	enlistmentDate: string | null
+	unitId: number | null
+	unitName: string | null
+	serviceYears: number
+	baseDays: number
+	travelDays: number
+	extraDays: number
+	extraReasons: string[]
+	totalDays: number
+	startDate: string | null
+	endDate: string | null
+	localityId: number | null
+	localityPath: string | null
+	note: string | null
+	proposedByUserId: number | null
+	proposedByUsername: string | null
+	proposedByDisplayName: string | null
+	proposerEmail: string | null
+	commanderUserId: number | null
+	commanderName: string | null
+	adminNote: string | null
+	decidedByUserId: number | null
+	decidedByUsername: string | null
+	decidedAt: string | null
+	/** Số ngày đã đi (đơn đã duyệt cùng năm) */
+	usedDays?: number
+	/** Số ngày còn lại theo hạn mức năm (ANNUAL) */
+	remainingDays?: number | null
+	/** Hạn mức ngày phép cơ bản năm */
+	quotaDays?: number | null
+}
+
+export interface LeaveUnit {
+	id: number
+	createdAt: string
+	updatedAt: string
+	code: string | null
+	name: string
+	parentId: number | null
+	level: string | null
+	commanderUserId: number | null
+	commanderName: string | null
+	managementArea: string
+	isActive: boolean
+}
+
+export interface LeaveClass {
+	id: number
+	unitId: number
+	unitName: string
+	name: string
+	isActive: boolean
+}
+
+export interface LeaveRecord {
+	id: number
+	createdAt: string
+	updatedAt: string
+	requestId: number
+	status: LeaveRequestStatus
+	leaveType: LeaveType
+	personnelId: number | null
+	personnelCode: string | null
+	personnelName: string | null
+	objectType: LeaveObjectType
+	objectTypeLabel: string
+	rank: string | null
+	position: string | null
+	enlistmentDate: string | null
+	unitId: number | null
+	unitName: string | null
+	serviceYears: number
+	baseDays: number
+	travelDays: number
+	extraDays: number
+	extraReasons: string[]
+	totalDays: number
+	startDate: string | null
+	endDate: string | null
+	localityId: number | null
+	localityPath: string | null
+	note: string | null
+	adminNote: string | null
+	proposedByUserId: number | null
+	proposedByUsername: string | null
+	proposedByDisplayName: string | null
+	decidedByUserId: number | null
+	decidedByUsername: string | null
+	decidedAt: string | null
+	archivedAt: string
+	requestScope: 'INDIVIDUAL' | 'CLASS'
+	classId: number | null
+	className: string | null
+	memberCount: number
+}
+
+export interface LeaveMeta {
+	objectTypes: { code: LeaveObjectType; label: string }[]
+	extra10Reasons: { code: string; label: string }[]
+	extra5Reasons: { code: string; label: string }[]
+	specialReasons: { code: string; label: string }[]
+	specialMaxDays: number
+	specialEligible: LeaveObjectType[]
+}
+
+// ── Personnel ──────────────────────────────────────────────
+
+export function ListLeavePersonnel(params?: {
+	search?: string
+	objectType?: string
+}) {
+	const qs = new URLSearchParams()
+	if (params?.search) qs.set('search', params.search)
+	if (params?.objectType) qs.set('objectType', params.objectType)
+	const q = qs.toString()
+	return jsonFetch<{ data: LeavePersonnel[] }>(
+		`/leave/personnel${q ? `?${q}` : ''}`
+	).then((r) => r.data)
+}
+
+export function GetMyLeavePersonnel() {
+	return jsonFetch<{ data: LeavePersonnel | null }>(
+		'/leave/my-personnel'
+	).then((r) => r.data)
+}
+
+export function CreateLeavePersonnel(
+	body: Partial<Omit<LeavePersonnel, 'id' | 'createdAt' | 'updatedAt'>> & {
+		fullName: string
+		objectType: LeaveObjectType
+	}
+) {
+	return jsonFetch<{ data: LeavePersonnel }>('/leave/personnel', {
+		method: 'POST',
+		body: JSON.stringify(body)
+	}).then((r) => r.data)
+}
+
+export function UpdateLeavePersonnel(
+	id: number,
+	body: Partial<LeavePersonnel>
+) {
+	return jsonFetch<{ data: LeavePersonnel }>(`/leave/personnel/${id}`, {
+		method: 'PATCH',
+		body: JSON.stringify(body)
+	}).then((r) => r.data)
+}
+
+export function DeleteLeavePersonnel(id: number) {
+	return jsonFetch<{ ok: boolean }>(`/leave/personnel/${id}`, {
+		method: 'DELETE'
+	})
+}
+
+export interface ImportLeaveResult {
+	successCount: number
+	errorCount: number
+	totalCount: number
+	errors: { row: number; message: string }[]
+	createdCount?: number
+	skippedCount?: number
+}
+
+export function ImportLeavePersonnel(
+	items: Array<
+		Partial<Omit<LeavePersonnel, 'id' | 'createdAt' | 'updatedAt'>> & {
+			fullName: string
+			objectType: LeaveObjectType
+		}
+	>
+) {
+	return jsonFetch<{ data: ImportLeaveResult }>('/leave/personnel/import', {
+		method: 'POST',
+		body: JSON.stringify({ items })
+	}).then((r) => r.data)
+}
+
+// ── Localities ─────────────────────────────────────────────
+
+export function ListLeaveLocalities(params?: {
+	level?: string
+	parentId?: number
+	tree?: boolean
+}) {
+	const qs = new URLSearchParams()
+	if (params?.level) qs.set('level', params.level)
+	if (params?.parentId != null) qs.set('parentId', String(params.parentId))
+	if (params?.tree) qs.set('tree', 'true')
+	const q = qs.toString()
+	return jsonFetch<{ data: LeaveLocality[] }>(
+		`/leave/localities${q ? `?${q}` : ''}`
+	).then((r) => r.data)
+}
+
+export function CreateLeaveLocality(body: {
+	name: string
+	level: LeaveLocalityLevel
+	parentId?: number | null
+	code?: string | null
+}) {
+	return jsonFetch<{ data: LeaveLocality }>('/leave/localities', {
+		method: 'POST',
+		body: JSON.stringify(body)
+	}).then((r) => r.data)
+}
+
+export function UpdateLeaveLocality(
+	id: number,
+	body: { name?: string; code?: string | null }
+) {
+	return jsonFetch<{ data: LeaveLocality }>(`/leave/localities/${id}`, {
+		method: 'PATCH',
+		body: JSON.stringify(body)
+	}).then((r) => r.data)
+}
+
+export function DeleteLeaveLocality(id: number) {
+	return jsonFetch<{ ok: boolean }>(`/leave/localities/${id}`, {
+		method: 'DELETE'
+	})
+}
+
+export function ImportLeaveLocalities(
+	items: {
+		province: string
+		ward?: string | null
+		village?: string | null
+		provinceCode?: string | null
+		wardCode?: string | null
+		villageCode?: string | null
+	}[]
+) {
+	return jsonFetch<{ data: ImportLeaveResult }>('/leave/localities/import', {
+		method: 'POST',
+		body: JSON.stringify({ items })
+	}).then((r) => r.data)
+}
+
+// ── Regulations ────────────────────────────────────────────
+
+export function ListLeaveRegulations(leaveType?: string) {
+	const q = leaveType ? `?leaveType=${leaveType}` : ''
+	return jsonFetch<{ data: LeaveRegulation[] }>(
+		`/leave/regulations${q}`
+	).then((r) => r.data)
+}
+
+export function GetLeaveMeta() {
+	return jsonFetch<{ data: LeaveMeta }>('/leave/meta').then((r) => r.data)
+}
+
+export function ComputeLeaveDays(body: {
+	objectType: string
+	serviceYears?: number
+	enlistmentDate?: string | null
+	/** Ngày bắt đầu nghỉ — dùng tính thâm niên */
+	startDate?: string | null
+	leaveType?: string
+	travelDays?: number
+	extraDays?: number
+	specialDays?: number
+}) {
+	return jsonFetch<{
+		data: {
+			serviceYears: number
+			baseDays: number
+			travelDays: number
+			extraDays: number
+			totalDays: number
+		}
+	}>('/leave/compute-days', {
+		method: 'POST',
+		body: JSON.stringify(body)
+	}).then((r) => r.data)
+}
+
+// ── Requests ───────────────────────────────────────────────
+
+export function ListLeaveRequests(params?: {
+	status?: string
+	mine?: boolean
+	leaveType?: string
+	/** Tìm mã QN hoặc họ tên */
+	search?: string
+	/** Lọc theo chỉ huy (user id) */
+	commanderUserId?: number
+	/** mine | commander | agency | all | related */
+	inbox?: string
+}) {
+	const qs = new URLSearchParams()
+	if (params?.status) qs.set('status', params.status)
+	if (params?.mine) qs.set('mine', 'true')
+	if (params?.leaveType) qs.set('leaveType', params.leaveType)
+	if (params?.search) qs.set('search', params.search)
+	if (params?.commanderUserId != null)
+		qs.set('commanderUserId', String(params.commanderUserId))
+	if (params?.inbox) qs.set('inbox', params.inbox)
+	const q = qs.toString()
+	return jsonFetch<{ data: LeaveRequest[] }>(
+		`/leave/requests${q ? `?${q}` : ''}`
+	).then((r) => r.data)
+}
+
+export function CreateLeaveRequest(body: {
+	leaveType?: string
+	requestScope?: 'INDIVIDUAL' | 'CLASS'
+	classId?: number | null
+	className?: string | null
+	manualDays?: number
+	personnelId?: number | null
+	objectType?: string
+	rank?: string | null
+	unitId?: number | null
+	unitName?: string | null
+	travelDays?: number
+	extraDays?: number
+	extraReasons?: string[]
+	specialDays?: number
+	startDate?: string | null
+	endDate?: string | null
+	localityId?: number | null
+	/** Địa chỉ cụ thể (số nhà, đường…) */
+	localityDetail?: string | null
+	note?: string | null
+}) {
+	return jsonFetch<{ data: LeaveRequest }>('/leave/requests', {
+		method: 'POST',
+		body: JSON.stringify(body)
+	}).then((r) => r.data)
+}
+
+export type LeaveMailResult = {
+	ok: boolean
+	to: string
+	mode: string
+	error?: string
+	previewUrl?: string
+	isTestInbox: boolean
+	message: string
+}
+
+export function DecideLeaveRequest(
+	id: number,
+	body: {
+		decision: 'APPROVED' | 'REJECTED' | 'RETURNED'
+		adminNote?: string | null
+		travelDays?: number
+		extraDays?: number
+		extraReasons?: string[]
+	}
+) {
+	return jsonFetch<{ data: LeaveRequest; mail?: LeaveMailResult | null }>(
+		`/leave/requests/${id}/decide`,
+		{
+			method: 'POST',
+			body: JSON.stringify(body)
+		}
+	)
+}
+
+export function ListLeaveMailLog(limit = 30) {
+	return jsonFetch<{
+		data: {
+			id: number
+			createdAt: string
+			requestId: number | null
+			toEmail: string
+			subject: string
+			body: string | null
+			mode: string | null
+			ok: boolean
+			error: string | null
+			previewUrl: string | null
+			kind: string | null
+		}[]
+	}>(`/leave/mail/log?limit=${limit}`).then((r) => r.data)
+}
+
+/** Lưu SMTP Gmail thật (App Password) */
+export function SaveLeaveMailConfig(body: {
+	host?: string
+	port?: string | number
+	user: string
+	pass: string
+	from?: string
+}) {
+	return jsonFetch<{
+		data: { ok: boolean; message: string; status: LeaveMailStatus }
+	}>('/leave/mail/config', {
+		method: 'POST',
+		body: JSON.stringify(body)
+	}).then((r) => r.data)
+}
+
+export function PatchLeaveRequest(
+	id: number,
+	body: {
+		travelDays?: number
+		extraDays?: number
+		extraReasons?: string[]
+		startDate?: string | null
+		endDate?: string | null
+		adminNote?: string | null
+	}
+) {
+	return jsonFetch<{ data: LeaveRequest }>(`/leave/requests/${id}`, {
+		method: 'PATCH',
+		body: JSON.stringify(body)
+	}).then((r) => r.data)
+}
+
+export function GetLeaveRequest(id: number) {
+	return jsonFetch<{ data: LeaveRequest }>(`/leave/requests/${id}`).then(
+		(r) => r.data
+	)
+}
+
+export function CancelLeaveRequest(id: number) {
+	return jsonFetch<{ data: LeaveRequest }>(`/leave/requests/${id}/cancel`, {
+		method: 'POST',
+		body: '{}'
+	}).then((r) => r.data)
+}
+
+// ── Units (danh mục đơn vị) ────────────────────────────────
+
+export function ListLeaveUnits(params?: {
+	search?: string
+	activeOnly?: boolean
+}) {
+	const qs = new URLSearchParams()
+	if (params?.search) qs.set('search', params.search)
+	if (params?.activeOnly === false) qs.set('activeOnly', 'false')
+	const q = qs.toString()
+	return jsonFetch<{ data: LeaveUnit[] }>(
+		`/leave/units${q ? `?${q}` : ''}`
+	).then((r) => r.data)
+}
+
+export type LeaveAccountKind = 'personnel' | 'commander' | 'management'
+
+export function AssignLeaveAccount(body: {
+	userId: number
+	kind: LeaveAccountKind
+	personnelId?: number
+	unitId?: number
+	managementArea?: 'cán_bộ' | 'quân_lực'
+}) {
+	return jsonFetch<{ ok: boolean }>('/leave/accounts/assign', {
+		method: 'POST',
+		body: JSON.stringify(body)
+	})
+}
+
+export function ListLeaveClasses(unitId?: number) {
+	const q = unitId != null ? `?unitId=${unitId}` : ''
+	return jsonFetch<{ data: LeaveClass[] }>(`/leave/classes${q}`).then(
+		(r) => r.data
+	)
+}
+
+export interface LeaveAuditLog {
+	id: number
+	createdAt: string
+	userId: number | null
+	action: string
+	entityType: string
+	entityId: number | null
+	details: string | null
+}
+
+export function ListLeaveAuditLogs(entityType?: string) {
+	const q = entityType ? `?entityType=${encodeURIComponent(entityType)}` : ''
+	return jsonFetch<{ data: LeaveAuditLog[] }>(`/leave/audit-logs${q}`).then(
+		(r) => r.data
+	)
+}
+
+export function CreateLeaveUnit(body: {
+	name: string
+	code?: string | null
+	parentId?: number | null
+	isActive?: boolean
+	commanderUserId?: number | null
+}) {
+	return jsonFetch<{ data: LeaveUnit }>('/leave/units', {
+		method: 'POST',
+		body: JSON.stringify(body)
+	}).then((r) => r.data)
+}
+
+export function UpdateLeaveUnit(
+	id: number,
+	body: Partial<{
+		name: string
+		code: string | null
+		parentId: number | null
+		isActive: boolean
+		commanderUserId: number | null
+	}>
+) {
+	return jsonFetch<{ data: LeaveUnit }>(`/leave/units/${id}`, {
+		method: 'PATCH',
+		body: JSON.stringify(body)
+	}).then((r) => r.data)
+}
+
+export function DeleteLeaveUnit(id: number) {
+	return jsonFetch<{ ok: boolean }>(`/leave/units/${id}`, {
+		method: 'DELETE'
+	})
+}
+
+export function ImportLeaveUnits(
+	items: { name: string; code?: string | null }[]
+) {
+	return jsonFetch<{ data: ImportLeaveResult }>('/leave/units/import', {
+		method: 'POST',
+		body: JSON.stringify({ items })
+	}).then((r) => r.data)
+}
+
+// ── Records (lưu trữ nghỉ phép) ────────────────────────────
+
+export function ListLeaveRecords(params?: {
+	search?: string
+	year?: number
+	leaveType?: string
+	objectType?: string
+	status?: string
+}) {
+	const qs = new URLSearchParams()
+	if (params?.search) qs.set('search', params.search)
+	if (params?.year != null) qs.set('year', String(params.year))
+	if (params?.leaveType) qs.set('leaveType', params.leaveType)
+	if (params?.objectType) qs.set('objectType', params.objectType)
+	if (params?.status) qs.set('status', params.status)
+	const q = qs.toString()
+	return jsonFetch<{ data: LeaveRecord[] }>(
+		`/leave/records${q ? `?${q}` : ''}`
+	).then((r) => r.data)
+}
+
+// ── Object types (bảng đối tượng) ──────────────────────────
+
+export interface LeaveObjectTypeRow {
+	id: number
+	createdAt: string
+	updatedAt: string
+	code: string
+	name: string
+	sortOrder: number
+	isActive: boolean
+}
+
+export function ListLeaveObjectTypes(activeOnly = false) {
+	const q = activeOnly ? '' : '?activeOnly=false'
+	return jsonFetch<{ data: LeaveObjectTypeRow[] }>(
+		`/leave/object-types${q}`
+	).then((r) => r.data)
+}
+
+export function CreateLeaveObjectType(body: {
+	code: string
+	name: string
+	sortOrder?: number
+	isActive?: boolean
+}) {
+	return jsonFetch<{ data: LeaveObjectTypeRow }>('/leave/object-types', {
+		method: 'POST',
+		body: JSON.stringify(body)
+	}).then((r) => r.data)
+}
+
+export function UpdateLeaveObjectType(
+	id: number,
+	body: Partial<{ name: string; sortOrder: number; isActive: boolean }>
+) {
+	return jsonFetch<{ data: LeaveObjectTypeRow }>(
+		`/leave/object-types/${id}`,
+		{ method: 'PATCH', body: JSON.stringify(body) }
+	).then((r) => r.data)
+}
+
+export function DeleteLeaveObjectType(id: number) {
+	return jsonFetch<{ ok: boolean }>(`/leave/object-types/${id}`, {
+		method: 'DELETE'
+	})
+}
+
+// ── Extra standards (tiêu chuẩn phép thêm) ─────────────────
+
+export interface LeaveExtraStandard {
+	id: number
+	createdAt: string
+	updatedAt: string
+	code: string
+	label: string
+	days: number
+	sortOrder: number
+	isActive: boolean
+}
+
+export function ListLeaveExtraStandards(params?: {
+	activeOnly?: boolean
+	days?: number
+}) {
+	const qs = new URLSearchParams()
+	if (params?.activeOnly === false) qs.set('activeOnly', 'false')
+	if (params?.days != null) qs.set('days', String(params.days))
+	const q = qs.toString()
+	return jsonFetch<{ data: LeaveExtraStandard[] }>(
+		`/leave/extra-standards${q ? `?${q}` : ''}`
+	).then((r) => r.data)
+}
+
+export function CreateLeaveExtraStandard(body: {
+	code: string
+	label: string
+	days: number
+	sortOrder?: number
+	isActive?: boolean
+}) {
+	return jsonFetch<{ data: LeaveExtraStandard }>('/leave/extra-standards', {
+		method: 'POST',
+		body: JSON.stringify(body)
+	}).then((r) => r.data)
+}
+
+export function UpdateLeaveExtraStandard(
+	id: number,
+	body: Partial<{
+		label: string
+		days: number
+		sortOrder: number
+		isActive: boolean
+	}>
+) {
+	return jsonFetch<{ data: LeaveExtraStandard }>(
+		`/leave/extra-standards/${id}`,
+		{ method: 'PATCH', body: JSON.stringify(body) }
+	).then((r) => r.data)
+}
+
+export function DeleteLeaveExtraStandard(id: number) {
+	return jsonFetch<{ ok: boolean }>(`/leave/extra-standards/${id}`, {
+		method: 'DELETE'
+	})
+}
+
+// ── Regulations CRUD ───────────────────────────────────────
+
+export function CreateLeaveRegulation(body: {
+	leaveType: string
+	objectType?: string | null
+	minYears?: number | null
+	maxYears?: number | null
+	baseDays: number
+	label?: string | null
+	description?: string | null
+	isActive?: boolean
+}) {
+	return jsonFetch<{ data: LeaveRegulation }>('/leave/regulations', {
+		method: 'POST',
+		body: JSON.stringify(body)
+	}).then((r) => r.data)
+}
+
+export function UpdateLeaveRegulation(
+	id: number,
+	body: Partial<{
+		baseDays: number
+		label: string | null
+		description: string | null
+		isActive: boolean
+		minYears: number | null
+		maxYears: number | null
+	}>
+) {
+	return jsonFetch<{ data: LeaveRegulation }>(`/leave/regulations/${id}`, {
+		method: 'PATCH',
+		body: JSON.stringify(body)
+	}).then((r) => r.data)
+}
+
+export function DeleteLeaveRegulation(id: number) {
+	return jsonFetch<{ ok: boolean }>(`/leave/regulations/${id}`, {
+		method: 'DELETE'
+	})
+}
+
+// ── Alerts (thông báo duyệt) ───────────────────────────────
+
+export interface LeaveAlert {
+	id: number
+	createdAt: string
+	userId: number
+	requestId: number
+	kind: 'NEED_COMMANDER' | 'NEED_AGENCY' | 'DECIDED' | 'RETURNED'
+	title: string
+	message: string
+	readAt: string | null
+	personnelName?: string | null
+	personnelCode?: string | null
+	status?: string | null
+	totalDays?: number | null
+	startDate?: string | null
+	endDate?: string | null
+}
+
+export function ListLeaveAlerts(params?: {
+	unreadOnly?: boolean
+	limit?: number
+}) {
+	const qs = new URLSearchParams()
+	if (params?.unreadOnly) qs.set('unreadOnly', 'true')
+	if (params?.limit != null) qs.set('limit', String(params.limit))
+	const q = qs.toString()
+	return jsonFetch<{ data: LeaveAlert[] }>(
+		`/leave/alerts${q ? `?${q}` : ''}`
+	).then((r) => r.data)
+}
+
+export function GetLeaveAlertCount() {
+	return jsonFetch<{ data: { count: number; pendingApprove: number } }>(
+		'/leave/alerts/unread-count'
+	).then((r) => r.data)
+}
+
+export function MarkLeaveAlertsRead(body: {
+	ids?: number[]
+	requestId?: number
+	all?: boolean
+}) {
+	return jsonFetch<{ ok: boolean }>('/leave/alerts/mark-read', {
+		method: 'POST',
+		body: JSON.stringify(body)
+	})
+}
+
+export function GetLeavePersonnel(id: number) {
+	return jsonFetch<{ data: LeavePersonnel }>(`/leave/personnel/${id}`).then(
+		(r) => r.data
+	)
+}
+
+// ── Mail status / test ─────────────────────────────────────
+
+export interface LeaveMailStatus {
+	configured: boolean
+	mode: string
+	host: string | null
+	port: number | null
+	user: string | null
+	from: string | null
+	devMode: boolean
+	lastPreviewUrl: string | null
+	hint: string
+}
+
+export function GetLeaveMailStatus() {
+	return jsonFetch<{ data: LeaveMailStatus }>('/leave/mail/status').then(
+		(r) => r.data
+	)
+}
+
+export function TestLeaveMail(to: string) {
+	return jsonFetch<{
+		data: {
+			ok: boolean
+			mode: string
+			error?: string
+			previewUrl?: string
+			to: string
+			isTestInbox?: boolean
+		}
+	}>('/leave/mail/test', {
+		method: 'POST',
+		body: JSON.stringify({ to })
+	}).then((r) => r.data)
+}
+
+export interface LeaveBatch {
+	id: number
+	createdAt: string
+	updatedAt: string
+	requestId: number
+	personnelId: number | null
+	personnelCode: string | null
+	personnelName: string | null
+	objectType: string
+	leaveType: string
+	batchIndex: number
+	batchLabel: string
+	startDate: string | null
+	endDate: string | null
+	totalDays: number
+	note: string | null
+	createdByUserId: number | null
+}
+
+export function ListLeaveBatches(requestId?: number) {
+	const q = requestId ? `?requestId=${requestId}` : ''
+	return jsonFetch<{ data: LeaveBatch[] }>(`/leave/batches${q}`).then(
+		(r) => r.data
+	)
+}
+
+export function CreateLeaveBatch(
+	body: Partial<LeaveBatch> & { requestId: number }
+) {
+	return jsonFetch<{ data: LeaveBatch }>('/leave/batches', {
+		method: 'POST',
+		body: JSON.stringify(body)
+	}).then((r) => r.data)
+}
+
+export function UpdateLeaveBatch(id: number, body: Partial<LeaveBatch>) {
+	return jsonFetch<{ data: LeaveBatch }>(`/leave/batches/${id}`, {
+		method: 'PUT',
+		body: JSON.stringify(body)
+	}).then((r) => r.data)
+}
+
+export function DeleteLeaveBatch(id: number) {
+	return jsonFetch<{ ok: boolean }>(`/leave/batches/${id}`, {
+		method: 'DELETE'
+	})
+}
+
+export interface LeaveTakenReportItem extends LeaveRecord {}
+export interface LeaveCheckYearItem extends LeavePersonnel {
+	takenDays: number
+	remainingDays: number
+}
+export interface LeaveNotYetTakenItem {
+	personnelId: number
+	personnelCode: string
+	personnelName: string
+	objectType: string
+	unitId: number | null
+	unitName: string | null
+}
+
+export function GetLeaveTakenReport(year: number) {
+	return jsonFetch<{ data: LeaveTakenReportItem[] }>(
+		`/leave/reports/taken-list?year=${year}`
+	).then((r) => r.data)
+}
+
+export function GetLeaveCheckYearReport(params: {
+	year: number
+	search?: string
+}) {
+	const qs = new URLSearchParams({ year: String(params.year) })
+	if (params.search) qs.set('search', params.search)
+	return jsonFetch<{ data: LeaveCheckYearItem[] }>(
+		`/leave/reports/check-year?${qs}`
+	).then((r) => r.data)
+}
+
+export function GetLeaveNotYetTakenReport(year: number) {
+	return jsonFetch<{ data: LeaveNotYetTakenItem[] }>(
+		`/leave/reports/not-yet-taken?year=${year}`
+	).then((r) => r.data)
+}
+
+export interface LeaveAccess {
+	role: 'admin' | 'commander' | 'agency' | 'personnel' | 'none'
+	isAdmin: boolean
+	isCommander: boolean
+	isAgency: boolean
+	isPersonnel: boolean
+	canPropose: boolean
+	managementArea: string | null
+	unitIds: number[]
+	unitNames: string[]
+}
+
+export function GetLeaveMyAccess() {
+	return jsonFetch<{ data: LeaveAccess }>('/leave/my-access').then(
+		(r) => r.data
+	)
+}
+
+export interface LeavePosition {
+	id: number
+	name: string
+	sortOrder: number
+	isActive: boolean
+}
+
+export function ListLeavePositions(activeOnly = true) {
+	return jsonFetch<{ data: LeavePosition[] }>(
+		`/leave/positions?activeOnly=${activeOnly}`
+	).then((r) => r.data)
+}
+
+export function CreateLeavePosition(body: Omit<LeavePosition, 'id'>) {
+	return jsonFetch<{ data: LeavePosition }>('/leave/positions', {
+		method: 'POST',
+		body: JSON.stringify(body)
+	}).then((r) => r.data)
+}
+
+export function UpdateLeavePosition(
+	id: number,
+	body: Partial<Omit<LeavePosition, 'id'>>
+) {
+	return jsonFetch<{ data: LeavePosition }>(`/leave/positions/${id}`, {
+		method: 'PATCH',
+		body: JSON.stringify(body)
+	}).then((r) => r.data)
+}
+
+export function DeleteLeavePosition(id: number) {
+	return jsonFetch<{ ok: boolean }>(`/leave/positions/${id}`, {
+		method: 'DELETE'
+	})
+}

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -81,6 +81,7 @@ import {
 import useIsNganhUser from '@/hooks/useIsNganhUser'
 import { useQuery } from '@tanstack/react-query'
 import { GetPendingExamCount } from '@/api/exam'
+import { GetLeaveMyAccess } from '@/api/leave'
 import {
 	examNavAllowed,
 	isExamOffice,
@@ -171,6 +172,69 @@ const data = {
 					title: 'Import học viên',
 					url: '/import-students',
 					icon: UserPlus
+				}
+			]
+		},
+		{
+			title: 'Quản lý phép',
+			url: '#',
+			superAdminOnly: false,
+			icon: Calendar,
+			items: [
+				{
+					title: 'Đề xuất nghỉ phép',
+					url: '/quan-ly-phep/de-xuat',
+					icon: FileText
+				},
+				{
+					title: 'Duyệt đề xuất phép',
+					url: '/quan-ly-phep/duyet',
+					icon: ClipboardCheck
+				},
+				{
+					title: 'Danh sách phép',
+					url: '/quan-ly-phep/danh-sach',
+					icon: List
+				},
+				{
+					title: 'Danh sách quân nhân',
+					url: '/quan-ly-phep/quan-nhan',
+					icon: UsersRound
+				},
+				{
+					title: 'Danh mục đơn vị',
+					url: '/quan-ly-phep/don-vi',
+					icon: Building
+				},
+				{
+					title: 'Danh mục chức vụ',
+					url: '/quan-ly-phep/chuc-vu',
+					icon: UserRoundCog
+				},
+				{
+					title: 'Danh mục địa phương',
+					url: '/quan-ly-phep/dia-phuong',
+					icon: Building2
+				},
+				{
+					title: 'Quy định phép',
+					url: '/quan-ly-phep/quy-dinh',
+					icon: FileText
+				},
+				{
+					title: 'Lưu trữ nghỉ phép',
+					url: '/quan-ly-phep/luu-tru',
+					icon: FileStack
+				},
+				{
+					title: 'Quản lý đợt nghỉ phép',
+					url: '/quan-ly-phep/dot-nghi',
+					icon: Calendar
+				},
+				{
+					title: 'Báo cáo nghỉ phép',
+					url: '/quan-ly-phep/bao-cao',
+					icon: PieChart
 				}
 			]
 		},
@@ -555,6 +619,12 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 	const { state } = useSidebar()
 	const isCollapsed = state === 'collapsed'
 	const { user } = useAuth()
+	const { data: leaveAccess } = useQuery({
+		queryKey: ['leave-my-access'],
+		queryFn: GetLeaveMyAccess,
+		enabled: Boolean(user),
+		retry: false
+	})
 
 	const getUnitsQuery: GetUnitQuery | undefined =
 		user?.isSuperUser === true
@@ -1153,6 +1223,86 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 	})
 
 	const examOfficeUser = isExamOffice() && !isSuperAdmin() && !nganhUser
+	const leaveOperator =
+		!isSuperAdmin() &&
+		Boolean(
+			leaveAccess?.isCommander ||
+				leaveAccess?.isAgency ||
+				leaveAccess?.isPersonnel
+		)
+	const leavePersonnelOnly =
+		Boolean(leaveAccess?.isPersonnel) &&
+		!leaveAccess?.isCommander &&
+		!leaveAccess?.isAgency
+	const leaveRoleNav: typeof data.navMain = [
+		{
+			title: 'Chung',
+			url: '#',
+			superAdminOnly: false,
+			items: [{ title: 'Trang chủ', url: '/', icon: Home }]
+		},
+		{
+			title: 'Quản lý phép',
+			url: '#',
+			superAdminOnly: false,
+			icon: Calendar,
+			items: [
+				...(leaveAccess?.canPropose
+					? [
+							{
+								title: 'Đề xuất nghỉ phép',
+								url: '/quan-ly-phep/de-xuat',
+								icon: FileText
+							}
+						]
+					: []),
+				{
+					title: 'Quy định phép',
+					url: '/quan-ly-phep/quy-dinh',
+					icon: FileText
+				},
+				...(!leavePersonnelOnly
+					? [
+							{
+								title: 'Duyệt đề xuất phép',
+								url: '/quan-ly-phep/duyet',
+								icon: ClipboardCheck
+							},
+							{
+								title: 'Danh sách quân nhân',
+								url: '/quan-ly-phep/quan-nhan',
+								icon: UsersRound
+							},
+							{
+								title: 'Đơn vị của tôi',
+								url: '/quan-ly-phep/don-vi',
+								icon: Building
+							},
+							{
+								title: 'Danh mục chức vụ',
+								url: '/quan-ly-phep/chuc-vu',
+								icon: UserRoundCog
+							},
+							{
+								title: 'Danh mục địa phương',
+								url: '/quan-ly-phep/dia-phuong',
+								icon: Building2
+							},
+							{
+								title: 'Quản lý đợt nghỉ phép',
+								url: '/quan-ly-phep/dot-nghi',
+								icon: Calendar
+							},
+							{
+								title: 'Lưu trữ nghỉ phép',
+								url: '/quan-ly-phep/luu-tru',
+								icon: FileStack
+							}
+						]
+					: [])
+			]
+		}
+	]
 	/** GV soạn đề (gv.cntt…) — không super / ngành / BGH / Ban KT / phòng dạy */
 	const pureExamLecturer =
 		isPureExamLecturer() &&
@@ -1162,27 +1312,29 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 		!nganhUser &&
 		!bghOnly
 
-	const allNavItems = roomTeacher
-		? roomTeacherNav
-		: pureExamLecturer
-			? examLecturerNav
-			: donViUser
-				? donViUserNav
-				: examOfficeUser
-					? examOfficeNavWithBadge
-					: nganhUser
-						? nganhNavWithBadge
-						: bghOnly
-							? bghNavWithBadge
-							: [
-									firstNavItem,
-									{
-										title: 'Đơn vị',
-										url: '#',
-										items: unitsNavbar
-									},
-									...navWithBadge
-								]
+	const allNavItems = leaveOperator
+		? leaveRoleNav
+		: roomTeacher
+			? roomTeacherNav
+			: pureExamLecturer
+				? examLecturerNav
+				: donViUser
+					? donViUserNav
+					: examOfficeUser
+						? examOfficeNavWithBadge
+						: nganhUser
+							? nganhNavWithBadge
+							: bghOnly
+								? bghNavWithBadge
+								: [
+										firstNavItem,
+										{
+											title: 'Đơn vị',
+											url: '#',
+											items: unitsNavbar
+										},
+										...navWithBadge
+									]
 	const newData = {
 		version: data.versions,
 		navMain: withExamFilter(

--- a/apps/web/src/components/date-input.tsx
+++ b/apps/web/src/components/date-input.tsx
@@ -1,0 +1,334 @@
+/**
+ * Controlled date input (YYYY-MM-DD) with custom calendar:
+ * - Header: Tháng | Năm (clickable)
+ * - Click month → 12 square month cells
+ * - Click year  → 12 square year cells (paged)
+ */
+import * as React from 'react'
+import { CalendarIcon, ChevronLeft, ChevronRight } from 'lucide-react'
+import dayjs from 'dayjs'
+import { Calendar } from '@/components/ui/calendar'
+import { Button } from '@/components/ui/button'
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger
+} from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
+
+const MONTH_LABELS = [
+	'Th1',
+	'Th2',
+	'Th3',
+	'Th4',
+	'Th5',
+	'Th6',
+	'Th7',
+	'Th8',
+	'Th9',
+	'Th10',
+	'Th11',
+	'Th12'
+] as const
+
+const MONTH_FULL = [
+	'Tháng 1',
+	'Tháng 2',
+	'Tháng 3',
+	'Tháng 4',
+	'Tháng 5',
+	'Tháng 6',
+	'Tháng 7',
+	'Tháng 8',
+	'Tháng 9',
+	'Tháng 10',
+	'Tháng 11',
+	'Tháng 12'
+] as const
+
+const START_YEAR = 1950
+const END_YEAR = dayjs().year() + 20
+const YEARS_PER_PAGE = 12
+
+type PickerView = 'days' | 'months' | 'years'
+
+function parseIso(value?: string | null): Date | undefined {
+	if (!value) return undefined
+	const d = dayjs(value)
+	return d.isValid() ? d.toDate() : undefined
+}
+
+function toIso(date: Date): string {
+	return dayjs(date).format('YYYY-MM-DD')
+}
+
+function displayText(value?: string | null): string {
+	const d = parseIso(value)
+	return d ? dayjs(d).format('DD/MM/YYYY') : ''
+}
+
+function GridCell({
+	selected,
+	onClick,
+	children
+}: {
+	selected?: boolean
+	onClick: () => void
+	children: React.ReactNode
+}) {
+	return (
+		<button
+			type='button'
+			onClick={onClick}
+			className={cn(
+				'flex aspect-square items-center justify-center rounded-md text-sm font-medium transition-colors',
+				'hover:bg-accent hover:text-accent-foreground',
+				'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none',
+				selected &&
+					'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground'
+			)}
+		>
+			{children}
+		</button>
+	)
+}
+
+function MonthYearHeader({
+	month,
+	view,
+	onOpenMonths,
+	onOpenYears,
+	onPrev,
+	onNext
+}: {
+	month: Date
+	view: PickerView
+	onOpenMonths: () => void
+	onOpenYears: () => void
+	onPrev: () => void
+	onNext: () => void
+}) {
+	const y = month.getFullYear()
+	const m = month.getMonth()
+	const decadeStart = Math.floor(y / YEARS_PER_PAGE) * YEARS_PER_PAGE
+
+	return (
+		<div className='flex items-center justify-between gap-1 px-1 pb-2'>
+			<Button
+				type='button'
+				variant='ghost'
+				size='icon'
+				className='size-8 shrink-0'
+				onClick={onPrev}
+				aria-label='Trước'
+			>
+				<ChevronLeft className='size-4' />
+			</Button>
+
+			<div className='flex min-w-0 flex-1 items-center justify-center gap-1'>
+				{view === 'years' ? (
+					<button
+						type='button'
+						className='rounded-md px-2 py-1 text-sm font-semibold hover:bg-accent'
+						onClick={onOpenYears}
+					>
+						{decadeStart} – {decadeStart + YEARS_PER_PAGE - 1}
+					</button>
+				) : (
+					<>
+						<button
+							type='button'
+							className={cn(
+								'rounded-md px-2 py-1 text-sm font-semibold hover:bg-accent',
+								view === 'months' && 'bg-accent'
+							)}
+							onClick={onOpenMonths}
+						>
+							{MONTH_FULL[m]}
+						</button>
+						<button
+							type='button'
+							className={cn(
+								'rounded-md px-2 py-1 text-sm font-semibold hover:bg-accent'
+							)}
+							onClick={onOpenYears}
+						>
+							{y}
+						</button>
+					</>
+				)}
+			</div>
+
+			<Button
+				type='button'
+				variant='ghost'
+				size='icon'
+				className='size-8 shrink-0'
+				onClick={onNext}
+				aria-label='Sau'
+			>
+				<ChevronRight className='size-4' />
+			</Button>
+		</div>
+	)
+}
+
+export interface DateInputProps {
+	value?: string | null
+	onChange: (isoDate: string) => void
+	placeholder?: string
+	disabled?: boolean
+	className?: string
+	/** id for accessibility */
+	id?: string
+}
+
+export default function DateInput({
+	value,
+	onChange,
+	placeholder = 'Chọn ngày',
+	disabled,
+	className,
+	id
+}: DateInputProps) {
+	const [open, setOpen] = React.useState(false)
+	const [view, setView] = React.useState<PickerView>('days')
+	const selected = parseIso(value)
+	const [month, setMonth] = React.useState<Date>(selected || new Date())
+
+	React.useEffect(() => {
+		if (selected) setMonth(selected)
+	}, [value])
+
+	React.useEffect(() => {
+		if (!open) setView('days')
+	}, [open])
+
+	const handleNav = (dir: -1 | 1) => {
+		if (view === 'days') {
+			setMonth((m) => new Date(m.getFullYear(), m.getMonth() + dir, 1))
+		} else if (view === 'months') {
+			setMonth((m) => new Date(m.getFullYear() + dir, m.getMonth(), 1))
+		} else {
+			setMonth(
+				(m) =>
+					new Date(
+						m.getFullYear() + dir * YEARS_PER_PAGE,
+						m.getMonth(),
+						1
+					)
+			)
+		}
+	}
+
+	const text = displayText(value)
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<Button
+					id={id}
+					type='button'
+					variant='outline'
+					disabled={disabled}
+					className={cn(
+						'w-full justify-start text-left font-normal',
+						!text && 'text-muted-foreground',
+						className
+					)}
+				>
+					<CalendarIcon className='mr-2 h-4 w-4 shrink-0 opacity-70' />
+					<span className='truncate'>{text || placeholder}</span>
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent
+				className='w-auto overflow-hidden p-3'
+				align='start'
+				onWheel={(e) => e.stopPropagation()}
+			>
+				{/* Tháng + Năm luôn trên đầu */}
+				<MonthYearHeader
+					month={month}
+					view={view}
+					onOpenMonths={() =>
+						setView((v) => (v === 'months' ? 'days' : 'months'))
+					}
+					onOpenYears={() =>
+						setView((v) => (v === 'years' ? 'days' : 'years'))
+					}
+					onPrev={() => handleNav(-1)}
+					onNext={() => handleNav(1)}
+				/>
+
+				{view === 'months' && (
+					<div className='grid grid-cols-4 gap-1 p-1'>
+						{MONTH_LABELS.map((label, i) => (
+							<GridCell
+								key={label}
+								selected={i === month.getMonth()}
+								onClick={() => {
+									setMonth(
+										(m) => new Date(m.getFullYear(), i, 1)
+									)
+									setView('days')
+								}}
+							>
+								{label}
+							</GridCell>
+						))}
+					</div>
+				)}
+
+				{view === 'years' && (
+					<div className='grid grid-cols-4 gap-1 p-1'>
+						{Array.from({ length: YEARS_PER_PAGE }, (_, i) => {
+							const pageStart =
+								Math.floor(
+									month.getFullYear() / YEARS_PER_PAGE
+								) * YEARS_PER_PAGE
+							return pageStart + i
+						})
+							.filter((y) => y >= START_YEAR && y <= END_YEAR)
+							.map((y) => (
+								<GridCell
+									key={y}
+									selected={y === month.getFullYear()}
+									onClick={() => {
+										setMonth(
+											(m) => new Date(y, m.getMonth(), 1)
+										)
+										setView('months')
+									}}
+								>
+									{y}
+								</GridCell>
+							))}
+					</div>
+				)}
+
+				{view === 'days' && (
+					<Calendar
+						mode='single'
+						selected={selected}
+						month={month}
+						onMonthChange={setMonth}
+						onSelect={(date) => {
+							if (date) {
+								onChange(toIso(date))
+								setMonth(date)
+								setOpen(false)
+							}
+						}}
+						startMonth={new Date(START_YEAR, 0)}
+						endMonth={new Date(END_YEAR, 11)}
+						classNames={{
+							nav: 'hidden',
+							month_caption: 'hidden',
+							caption_label: 'hidden'
+						}}
+					/>
+				)}
+			</PopoverContent>
+		</Popover>
+	)
+}

--- a/apps/web/src/components/leave-management/ApproveLeavePage.tsx
+++ b/apps/web/src/components/leave-management/ApproveLeavePage.tsx
@@ -1,0 +1,1226 @@
+/**
+ * Duyệt đề xuất nghỉ phép — hộp thư chỉ huy CQ / CQQL
+ * Bảng đơn chờ · bấm tên xem hồ sơ QN · bấm xem để duyệt
+ */
+import { useMemo, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+	Check,
+	Eye,
+	Loader2,
+	Printer,
+	RotateCcw,
+	UserRound
+} from 'lucide-react'
+import { toast } from 'sonner'
+import dayjs from 'dayjs'
+import {
+	DecideLeaveRequest,
+	GetLeaveMyAccess,
+	GetLeaveMailStatus,
+	ListLeaveAlerts,
+	ListLeaveMailLog,
+	ListLeaveRequests,
+	MarkLeaveAlertsRead,
+	TestLeaveMail,
+	type LeaveRequest
+} from '@/api/leave'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { isSuperAdmin } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow
+} from '@/components/ui/table'
+import PersonnelPreviewDialog from './PersonnelPreviewDialog'
+import { printLeaveCertificate } from './printLeaveCertificate'
+import { printClassLeaveList } from './printClassLeaveList'
+
+function readUserId(): number | null {
+	try {
+		const token = localStorage.getItem('qlhvAccessToken')
+		if (!token) return null
+		const payload = JSON.parse(atob(token.split('.')[1]!))
+		return Number(payload.userId) || null
+	} catch {
+		return null
+	}
+}
+
+const STATUS_LABEL: Record<string, string> = {
+	PENDING: 'Chờ chỉ huy CQ',
+	PENDING_COMMANDER: 'Chờ chỉ huy CQ',
+	PENDING_AGENCY: 'Chờ CQQL (ký)',
+	APPROVED: 'Đã duyệt',
+	RETURNED: 'Trả lại',
+	CANCELLED: 'Đã hủy'
+}
+
+type PendingGroup = {
+	key: string
+	rows: LeaveRequest[]
+	first: LeaveRequest
+	isClass: boolean
+}
+
+function pendingGroupKey(r: LeaveRequest): string {
+	if (r.requestScope !== 'CLASS' || r.classId == null)
+		return `request:${r.id}`
+	// Các đơn của một lần đề xuất lớp được tạo gần như đồng thời. Ghép thêm
+	// thông tin nghiệp vụ để không nhập nhầm hai lần đề xuất khác nhau.
+	return [
+		'class',
+		r.classId,
+		r.proposedByUserId ?? '',
+		r.status,
+		r.leaveType,
+		r.startDate ?? '',
+		r.endDate ?? '',
+		r.totalDays,
+		r.note ?? '',
+		String(r.createdAt).slice(0, 16)
+	].join(':')
+}
+
+export default function ApproveLeavePage() {
+	const qc = useQueryClient()
+	const admin = isSuperAdmin()
+	const userId = useMemo(() => readUserId(), [])
+	const [personnelId, setPersonnelId] = useState<number | null>(null)
+	const [personnelName, setPersonnelName] = useState<string | null>(null)
+	const [detail, setDetail] = useState<LeaveRequest | null>(null)
+	const [detailGroup, setDetailGroup] = useState<PendingGroup | null>(null)
+	const [testTo, setTestTo] = useState('maiphuongnam7554@gmail.com')
+	const { data: access } = useQuery({
+		queryKey: ['leave-my-access'],
+		queryFn: GetLeaveMyAccess
+	})
+	const agency = Boolean(access?.isAgency)
+
+	const { data: mailStatus, refetch: refetchMail } = useQuery({
+		queryKey: ['leave-mail-status'],
+		queryFn: GetLeaveMailStatus,
+		enabled: admin
+	})
+
+	const testMailMut = useMutation({
+		mutationFn: () => TestLeaveMail(testTo.trim()),
+		onSuccess: (r) => {
+			if (r.ok) {
+				if (r.isTestInbox || r.mode === 'ethereal-dev') {
+					toast.message(
+						`Mode TEST — thư KHÔNG vào Gmail. Mở link Ethereal để xem.`,
+						{ duration: 12000 }
+					)
+				} else {
+					toast.success(`Đã gửi mail thật → ${r.to} (${r.mode})`)
+				}
+				if (r.previewUrl) window.open(r.previewUrl, '_blank')
+				refetchMail()
+				qc.invalidateQueries({ queryKey: ['leave-mail-log'] })
+			} else {
+				toast.error(r.error || `Gửi thất bại (${r.mode})`)
+			}
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	const { data: alerts = [] } = useQuery({
+		queryKey: ['leave-alerts', 'unread'],
+		queryFn: () => ListLeaveAlerts({ unreadOnly: true, limit: 20 }),
+		refetchInterval: 30_000
+	})
+
+	// Đơn chờ chỉ huy (tôi)
+	const { data: commanderPending = [], isLoading: loadCmd } = useQuery({
+		queryKey: ['leave-approve', 'commander', userId],
+		queryFn: () =>
+			ListLeaveRequests({
+				inbox: 'commander',
+				status: 'PENDING_COMMANDER'
+			}),
+		enabled: userId != null
+	})
+	// legacy PENDING
+	const { data: commanderPendingLegacy = [] } = useQuery({
+		queryKey: ['leave-approve', 'commander-legacy', userId],
+		queryFn: () =>
+			ListLeaveRequests({
+				inbox: 'commander',
+				status: 'PENDING'
+			}),
+		enabled: userId != null
+	})
+
+	const { data: agencyPending = [], isLoading: loadAgency } = useQuery({
+		queryKey: ['leave-approve', 'agency'],
+		queryFn: () =>
+			ListLeaveRequests({
+				inbox: 'agency',
+				status: 'PENDING_AGENCY'
+			}),
+		enabled: admin || agency
+	})
+
+	const pendingRows = useMemo(() => {
+		const map = new Map<number, LeaveRequest>()
+		for (const r of [
+			...commanderPending,
+			...commanderPendingLegacy,
+			...(admin || agency ? agencyPending : [])
+		]) {
+			map.set(r.id, r)
+		}
+		return [...map.values()].sort((a, b) => b.id - a.id)
+	}, [commanderPending, commanderPendingLegacy, agencyPending, admin, agency])
+
+	const pendingGroups = useMemo<PendingGroup[]>(() => {
+		const groups = new Map<string, LeaveRequest[]>()
+		for (const row of pendingRows) {
+			const key = pendingGroupKey(row)
+			const rows = groups.get(key) || []
+			rows.push(row)
+			groups.set(key, rows)
+		}
+		return [...groups.entries()].map(([key, rows]) => ({
+			key,
+			rows,
+			first: rows[0]!,
+			isClass: rows[0]!.requestScope === 'CLASS'
+		}))
+	}, [pendingRows])
+
+	// Alert chưa đọc có thể còn tồn tại sau khi đơn đã được xử lý ở tab/phiên
+	// khác. Banner chỉ phản ánh những đơn thực sự còn trong hàng chờ hiện tại.
+	const actionableAlerts = useMemo(() => {
+		const pendingIds = new Set(pendingRows.map((r) => r.id))
+		return alerts.filter(
+			(a) => a.requestId != null && pendingIds.has(a.requestId)
+		)
+	}, [alerts, pendingRows])
+
+	const actionableAlertGroups = useMemo(() => {
+		const byRequest = new Map<number, PendingGroup>()
+		for (const group of pendingGroups) {
+			for (const row of group.rows) byRequest.set(row.id, group)
+		}
+		const seen = new Set<string>()
+		return actionableAlerts.flatMap((alert) => {
+			const group = byRequest.get(alert.requestId)
+			if (!group || seen.has(group.key)) return []
+			seen.add(group.key)
+			return [{ alert, group }]
+		})
+	}, [actionableAlerts, pendingGroups])
+
+	const decideMut = useMutation({
+		mutationFn: (vars: {
+			id: number
+			decision: 'APPROVED' | 'RETURNED'
+			adminNote?: string
+		}) =>
+			DecideLeaveRequest(vars.id, {
+				decision: vars.decision,
+				adminNote: vars.adminNote
+			}),
+		onSuccess: async (resp, vars) => {
+			toast.success(
+				vars.decision === 'APPROVED' ? 'Đã duyệt' : 'Đã trả lại'
+			)
+			const mail = resp.mail
+			if (mail) {
+				if (mail.ok && mail.previewUrl) {
+					toast.message(mail.message, {
+						duration: 15000,
+						action: {
+							label: 'Xem thư',
+							onClick: () =>
+								window.open(mail.previewUrl!, '_blank')
+						}
+					})
+					window.open(mail.previewUrl, '_blank')
+				} else if (mail.ok) {
+					toast.success(mail.message)
+				} else {
+					toast.error(mail.message || mail.error || 'Gửi mail lỗi')
+				}
+			}
+			await MarkLeaveAlertsRead({ requestId: vars.id }).catch(() => {})
+			qc.invalidateQueries({ queryKey: ['leave-approve'] })
+			qc.invalidateQueries({ queryKey: ['leave-requests'] })
+			qc.invalidateQueries({ queryKey: ['leave-alerts'] })
+			qc.invalidateQueries({ queryKey: ['leave-alert-count'] })
+			qc.invalidateQueries({ queryKey: ['leave-records'] })
+			qc.invalidateQueries({ queryKey: ['leave-mail-log'] })
+			setDetail(null)
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	const decideGroupMut = useMutation({
+		mutationFn: async (vars: {
+			rows: LeaveRequest[]
+			decision: 'APPROVED' | 'RETURNED'
+		}) => {
+			// Chạy tuần tự để SQLite và luồng gửi mail không bị tranh chấp khi lớp đông.
+			for (const row of vars.rows) {
+				await DecideLeaveRequest(row.id, { decision: vars.decision })
+			}
+		},
+		onSuccess: async (_, vars) => {
+			toast.success(
+				vars.decision === 'APPROVED'
+					? `Đã duyệt ${vars.rows.length} học viên`
+					: `Đã trả lại ${vars.rows.length} học viên`
+			)
+			await Promise.all(
+				vars.rows.map((row) =>
+					MarkLeaveAlertsRead({ requestId: row.id }).catch(() => {})
+				)
+			)
+			for (const key of [
+				['leave-approve'],
+				['leave-requests'],
+				['leave-alerts'],
+				['leave-alert-count'],
+				['leave-records'],
+				['leave-mail-log']
+			])
+				qc.invalidateQueries({ queryKey: key })
+		},
+		onError: (e: Error) =>
+			toast.error(`Duyệt theo lớp chưa hoàn tất: ${e.message}`)
+	})
+
+	const isLoading = loadCmd || ((admin || agency) && loadAgency)
+
+	function openPersonnel(r: LeaveRequest) {
+		if (r.personnelId) {
+			setPersonnelId(r.personnelId)
+			setPersonnelName(r.personnelName)
+		} else {
+			toast.message('Đơn không liên kết hồ sơ quân nhân')
+		}
+	}
+
+	return (
+		<div className='space-y-6'>
+			<div>
+				<h2 className='text-2xl font-bold tracking-tight'>
+					Duyệt đề xuất nghỉ phép
+				</h2>
+				<p className='text-sm text-muted-foreground'>
+					Đơn đẩy lên chỉ huy CQ / CQQL hiện tại bảng dưới. Bấm{' '}
+					<strong>họ tên</strong> để xem hồ sơ quân nhân · bấm{' '}
+					<strong>Xem</strong> để duyệt / trả lại.
+				</p>
+			</div>
+
+			{/* Banner thông báo chưa đọc */}
+			{actionableAlertGroups.length > 0 && (
+				<Card className='border-amber-500/40 bg-amber-500/10'>
+					<CardHeader className='pb-2'>
+						<CardTitle className='text-base'>
+							Thông báo chờ xử lý ({actionableAlertGroups.length})
+						</CardTitle>
+					</CardHeader>
+					<CardContent className='space-y-2'>
+						{actionableAlertGroups
+							.slice(0, 5)
+							.map(({ alert: a, group }) => (
+								<div
+									key={a.id}
+									className='flex flex-wrap items-start justify-between gap-2 rounded-md border bg-background/60 px-3 py-2 text-sm'
+								>
+									<div>
+										<p className='font-medium'>
+											{group.isClass
+												? `[Đề xuất phép theo lớp] ${group.first.className || 'Lớp'} — ${group.rows.length} học viên`
+												: a.title}
+										</p>
+										<p className='text-muted-foreground'>
+											{group.isClass
+												? `${group.first.totalDays} ngày (${group.first.startDate || '—'} → ${group.first.endDate || '—'}). Vào duyệt một lần cho cả lớp.`
+												: a.message}
+										</p>
+										<p className='mt-1 text-xs text-muted-foreground'>
+											{dayjs(a.createdAt).format(
+												'DD/MM/YYYY HH:mm'
+											)}
+										</p>
+									</div>
+									<Button
+										size='sm'
+										variant='outline'
+										onClick={async () => {
+											await MarkLeaveAlertsRead({
+												ids: [a.id]
+											})
+											const found = group.first
+											if (group.isClass)
+												setDetailGroup(group)
+											else if (found) setDetail(found)
+											else {
+												// load single via list
+												const all =
+													await ListLeaveRequests({
+														inbox: admin
+															? 'all'
+															: 'related'
+													})
+												const r = all.find(
+													(x) => x.id === a.requestId
+												)
+												if (r) setDetail(r)
+											}
+											qc.invalidateQueries({
+												queryKey: ['leave-alerts']
+											})
+											qc.invalidateQueries({
+												queryKey: ['leave-alert-count']
+											})
+										}}
+									>
+										{group.isClass ? 'Mở lớp' : 'Mở đơn'}
+									</Button>
+								</div>
+							))}
+					</CardContent>
+				</Card>
+			)}
+
+			<div className='rounded-md border'>
+				<div className='flex items-center justify-between border-b px-4 py-3'>
+					<p className='font-medium'>
+						Đơn chờ tôi duyệt
+						{pendingGroups.length > 0 && (
+							<Badge className='ml-2' variant='destructive'>
+								{pendingGroups.length}
+							</Badge>
+						)}
+					</p>
+				</div>
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>Mã QN</TableHead>
+							<TableHead>Họ tên / Lớp</TableHead>
+							<TableHead>Đối tượng</TableHead>
+							<TableHead>Đơn vị</TableHead>
+							<TableHead>Loại</TableHead>
+							<TableHead>Tổng ngày</TableHead>
+							<TableHead>Từ ngày</TableHead>
+							<TableHead>Đến ngày</TableHead>
+							<TableHead>Trạng thái</TableHead>
+							<TableHead className='w-36' />
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{isLoading && (
+							<TableRow>
+								<TableCell colSpan={10} className='text-center'>
+									<Loader2 className='mx-auto h-5 w-5 animate-spin' />
+								</TableCell>
+							</TableRow>
+						)}
+						{!isLoading && pendingRows.length === 0 && (
+							<TableRow>
+								<TableCell
+									colSpan={10}
+									className='text-center text-muted-foreground'
+								>
+									Không có đơn chờ bạn duyệt
+								</TableCell>
+							</TableRow>
+						)}
+						{pendingGroups.map((group) => {
+							const r = group.first
+							return (
+								<TableRow key={group.key}>
+									<TableCell className='font-mono text-sm'>
+										{group.isClass
+											? 'THEO LỚP'
+											: r.personnelCode || '—'}
+									</TableCell>
+									<TableCell>
+										<button
+											type='button'
+											className='inline-flex items-center gap-1 font-medium text-primary underline-offset-4 hover:underline'
+											onClick={() =>
+												group.isClass
+													? setDetailGroup(group)
+													: openPersonnel(r)
+											}
+											title={
+												group.isClass
+													? 'Xem đề xuất cả lớp'
+													: 'Xem hồ sơ quân nhân'
+											}
+										>
+											<UserRound className='h-3.5 w-3.5' />
+											{group.isClass
+												? `${r.className || 'Lớp'} (${group.rows.length} học viên)`
+												: r.personnelName || '—'}
+										</button>
+									</TableCell>
+									<TableCell>
+										<Badge variant='secondary'>
+											{group.isClass
+												? 'Học viên'
+												: r.objectTypeLabel}
+										</Badge>
+									</TableCell>
+									<TableCell>{r.unitName || '—'}</TableCell>
+									<TableCell>
+										{r.leaveType === 'SPECIAL'
+											? 'Đặc biệt'
+											: 'Hằng năm'}
+									</TableCell>
+									<TableCell className='font-semibold'>
+										{r.totalDays}
+									</TableCell>
+									<TableCell className='whitespace-nowrap text-sm'>
+										{r.startDate
+											? dayjs(r.startDate).format(
+													'DD/MM/YYYY'
+												)
+											: '—'}
+									</TableCell>
+									<TableCell className='whitespace-nowrap text-sm'>
+										{r.endDate
+											? dayjs(r.endDate).format(
+													'DD/MM/YYYY'
+												)
+											: '—'}
+									</TableCell>
+									<TableCell>
+										<Badge variant='secondary'>
+											{STATUS_LABEL[r.status] || r.status}
+										</Badge>
+									</TableCell>
+									<TableCell>
+										<div className='flex gap-1'>
+											{group.isClass && (
+												<Button
+													size='sm'
+													disabled={
+														decideGroupMut.isPending ||
+														decideMut.isPending
+													}
+													onClick={() => {
+														if (
+															window.confirm(
+																`Duyệt ${group.rows.length} học viên của ${r.className || 'lớp này'}?`
+															)
+														) {
+															decideGroupMut.mutate(
+																{
+																	rows: group.rows,
+																	decision:
+																		'APPROVED'
+																}
+															)
+														}
+													}}
+												>
+													<Check className='mr-1 h-3.5 w-3.5' />
+													Duyệt cả lớp
+												</Button>
+											)}
+											{!group.isClass && (
+												<Button
+													size='sm'
+													variant='outline'
+													title='In trước khi duyệt'
+													onClick={() => {
+														if (
+															!printLeaveCertificate(
+																r
+															)
+														) {
+															toast.error(
+																'Trình duyệt chặn popup in'
+															)
+														}
+													}}
+												>
+													<Printer className='h-3.5 w-3.5' />
+												</Button>
+											)}
+											{!group.isClass && (
+												<Button
+													size='sm'
+													variant='outline'
+													onClick={() => setDetail(r)}
+												>
+													<Eye className='mr-1 h-3.5 w-3.5' />
+													Xem
+												</Button>
+											)}
+											{group.isClass && (
+												<Button
+													size='sm'
+													variant='destructive'
+													disabled={
+														decideGroupMut.isPending ||
+														decideMut.isPending
+													}
+													onClick={() => {
+														if (
+															window.confirm(
+																`Trả lại đề xuất của ${group.rows.length} học viên?`
+															)
+														) {
+															decideGroupMut.mutate(
+																{
+																	rows: group.rows,
+																	decision:
+																		'RETURNED'
+																}
+															)
+														}
+													}}
+												>
+													<RotateCcw className='h-3.5 w-3.5' />
+												</Button>
+											)}
+											{!group.isClass && (
+												<Button
+													size='sm'
+													disabled={
+														decideMut.isPending
+													}
+													onClick={() =>
+														decideMut.mutate({
+															id: r.id,
+															decision: 'APPROVED'
+														})
+													}
+												>
+													<Check className='mr-1 h-3.5 w-3.5' />
+													Duyệt
+												</Button>
+											)}
+											{!group.isClass && (
+												<Button
+													size='sm'
+													variant='destructive'
+													disabled={
+														decideMut.isPending
+													}
+													onClick={() =>
+														decideMut.mutate({
+															id: r.id,
+															decision: 'RETURNED'
+														})
+													}
+												>
+													<RotateCcw className='h-3.5 w-3.5' />
+												</Button>
+											)}
+										</div>
+									</TableCell>
+								</TableRow>
+							)
+						})}
+					</TableBody>
+				</Table>
+			</div>
+
+			{/* Chi tiết duyệt — tái dùng dialog từ LeaveListPage qua state local đơn giản */}
+			{detail && (
+				<ApproveDetailDialog
+					r={detail}
+					busy={decideMut.isPending}
+					onClose={() => setDetail(null)}
+					onApprove={() =>
+						decideMut.mutate({
+							id: detail.id,
+							decision: 'APPROVED'
+						})
+					}
+					onReturn={() =>
+						decideMut.mutate({
+							id: detail.id,
+							decision: 'RETURNED'
+						})
+					}
+					onOpenPersonnel={() => openPersonnel(detail)}
+				/>
+			)}
+
+			{detailGroup && (
+				<ClassApproveDetailDialog
+					group={detailGroup}
+					busy={decideGroupMut.isPending}
+					onClose={() => setDetailGroup(null)}
+					onApprove={() =>
+						decideGroupMut.mutate(
+							{ rows: detailGroup.rows, decision: 'APPROVED' },
+							{ onSuccess: () => setDetailGroup(null) }
+						)
+					}
+					onReturn={() =>
+						decideGroupMut.mutate(
+							{ rows: detailGroup.rows, decision: 'RETURNED' },
+							{ onSuccess: () => setDetailGroup(null) }
+						)
+					}
+				/>
+			)}
+
+			{personnelId != null && (
+				<PersonnelPreviewDialog
+					personnelId={personnelId}
+					fallbackName={personnelName}
+					onClose={() => {
+						setPersonnelId(null)
+						setPersonnelName(null)
+					}}
+				/>
+			)}
+
+			{/* Admin: cấu hình / thử mail + nhật ký */}
+			{admin && (
+				<MailConfigAndLog
+					mailStatus={mailStatus}
+					testTo={testTo}
+					setTestTo={setTestTo}
+					testMailMut={testMailMut}
+				/>
+			)}
+		</div>
+	)
+}
+
+function MailConfigAndLog({
+	mailStatus,
+	testTo,
+	setTestTo,
+	testMailMut
+}: {
+	mailStatus:
+		| {
+				configured: boolean
+				mode: string
+				host: string | null
+				port: number | null
+				from: string | null
+				hint: string
+				lastPreviewUrl: string | null
+				devMode: boolean
+		  }
+		| undefined
+	testTo: string
+	setTestTo: (v: string) => void
+	testMailMut: {
+		isPending: boolean
+		mutate: () => void
+	}
+}) {
+	const { data: logs = [] } = useQuery({
+		queryKey: ['leave-mail-log'],
+		queryFn: () => ListLeaveMailLog(20),
+		refetchInterval: 15_000
+	})
+
+	return (
+		<>
+			{mailStatus && (
+				<Card
+					className={
+						mailStatus.mode === 'ethereal-dev' || mailStatus.devMode
+							? 'border-amber-500/50'
+							: ''
+					}
+				>
+					<CardHeader className='pb-2'>
+						<CardTitle className='text-base'>
+							Cấu hình email thông báo
+						</CardTitle>
+					</CardHeader>
+					<CardContent className='space-y-3 text-sm'>
+						{(mailStatus.mode === 'ethereal-dev' ||
+							mailStatus.devMode) && (
+							<div className='rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-amber-950 dark:text-amber-100'>
+								<strong>Đang bật LEAVE_MAIL_DEV</strong> — mail
+								chỉ vào hộp test Ethereal,{' '}
+								<strong>không vào Gmail thật</strong>. Muốn gửi
+								Gmail: điền SMTP_USER + SMTP_PASS (App
+								Password), đặt LEAVE_MAIL_DEV=false, restart
+								encore.
+							</div>
+						)}
+						<div className='grid gap-1 rounded-md border bg-muted/30 p-3'>
+							<p>
+								<strong>Trạng thái:</strong>{' '}
+								{mailStatus.configured ? (
+									<span className='text-green-600'>
+										Sẵn sàng ({mailStatus.mode})
+									</span>
+								) : (
+									<span className='text-destructive'>
+										Chưa cấu hình
+									</span>
+								)}
+							</p>
+							<p className='text-muted-foreground'>
+								{mailStatus.hint}
+							</p>
+							{mailStatus.host && (
+								<p className='text-xs text-muted-foreground'>
+									Host: {mailStatus.host}:{mailStatus.port} ·
+									From: {mailStatus.from}
+								</p>
+							)}
+							{mailStatus.lastPreviewUrl && (
+								<p className='text-xs'>
+									Preview gần nhất:{' '}
+									<a
+										className='text-primary underline'
+										href={mailStatus.lastPreviewUrl}
+										target='_blank'
+										rel='noreferrer'
+									>
+										mở thư test
+									</a>
+								</p>
+							)}
+						</div>
+						<div className='flex flex-wrap items-end gap-2'>
+							<div className='min-w-[220px] flex-1'>
+								<Label>Gửi thử tới</Label>
+								<Input
+									type='email'
+									value={testTo}
+									onChange={(e) => setTestTo(e.target.value)}
+									placeholder='email@example.com'
+								/>
+							</div>
+							<Button
+								disabled={
+									testMailMut.isPending || !testTo.trim()
+								}
+								onClick={() => testMailMut.mutate()}
+							>
+								{testMailMut.isPending && (
+									<Loader2 className='mr-1 h-4 w-4 animate-spin' />
+								)}
+								Gửi mail thử
+							</Button>
+						</div>
+					</CardContent>
+				</Card>
+			)}
+
+			<Card>
+				<CardHeader className='pb-2'>
+					<CardTitle className='text-base'>
+						Nhật ký mail đã gửi (tự động khi duyệt)
+					</CardTitle>
+				</CardHeader>
+				<CardContent>
+					{logs.length === 0 ? (
+						<p className='text-sm text-muted-foreground'>
+							Chưa có bản ghi. Sau khi duyệt đơn sẽ hiện ở đây.
+						</p>
+					) : (
+						<div className='space-y-2'>
+							{logs.map((l) => (
+								<div
+									key={l.id}
+									className='rounded-md border px-3 py-2 text-sm'
+								>
+									<div className='flex flex-wrap items-center justify-between gap-2'>
+										<span className='font-medium'>
+											{l.ok ? '✓' : '✗'} {l.toEmail}
+										</span>
+										<span className='text-xs text-muted-foreground'>
+											{dayjs(l.createdAt).format(
+												'DD/MM/YYYY HH:mm'
+											)}{' '}
+											· {l.mode}
+											{l.kind ? ` · ${l.kind}` : ''}
+										</span>
+									</div>
+									<p className='text-muted-foreground'>
+										{l.subject}
+									</p>
+									{l.error && (
+										<p className='text-xs text-destructive'>
+											{l.error}
+										</p>
+									)}
+									{l.previewUrl && (
+										<a
+											className='text-xs text-primary underline'
+											href={l.previewUrl}
+											target='_blank'
+											rel='noreferrer'
+										>
+											Xem nội dung thư (Ethereal)
+										</a>
+									)}
+								</div>
+							))}
+						</div>
+					)}
+				</CardContent>
+			</Card>
+		</>
+	)
+}
+
+function ClassApproveDetailDialog({
+	group,
+	busy,
+	onClose,
+	onApprove,
+	onReturn
+}: {
+	group: PendingGroup
+	busy: boolean
+	onClose: () => void
+	onApprove: () => void
+	onReturn: () => void
+}) {
+	const r = group.first
+	return (
+		<div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4'>
+			<div className='max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-lg border bg-background shadow-lg'>
+				<div className='flex items-center justify-between border-b px-5 py-4'>
+					<div>
+						<h3 className='font-semibold'>
+							Chi tiết đề xuất {r.className || 'theo lớp'}
+						</h3>
+						<p className='text-sm text-muted-foreground'>
+							{group.rows.length} học viên
+						</p>
+					</div>
+					<Button variant='ghost' size='sm' onClick={onClose}>
+						Đóng
+					</Button>
+				</div>
+				<div className='grid grid-cols-2 gap-3 px-5 py-4 text-sm sm:grid-cols-4'>
+					<div>
+						<p className='text-xs text-muted-foreground'>Lớp</p>
+						<p className='font-medium'>{r.className || '—'}</p>
+					</div>
+					<div>
+						<p className='text-xs text-muted-foreground'>
+							Đối tượng
+						</p>
+						<p className='font-medium'>Học viên</p>
+					</div>
+					<div>
+						<p className='text-xs text-muted-foreground'>Đơn vị</p>
+						<p className='font-medium'>{r.unitName || '—'}</p>
+					</div>
+					<div>
+						<p className='text-xs text-muted-foreground'>
+							Trạng thái
+						</p>
+						<p className='font-medium'>
+							{STATUS_LABEL[r.status] || r.status}
+						</p>
+					</div>
+					<div>
+						<p className='text-xs text-muted-foreground'>
+							Loại phép
+						</p>
+						<p className='font-medium'>
+							{r.leaveType === 'SPECIAL'
+								? 'Phép đặc biệt'
+								: 'Phép hằng năm'}
+						</p>
+					</div>
+					<div>
+						<p className='text-xs text-muted-foreground'>
+							Tổng ngày
+						</p>
+						<p className='font-semibold'>{r.totalDays} ngày</p>
+					</div>
+					<div>
+						<p className='text-xs text-muted-foreground'>Từ ngày</p>
+						<p className='font-medium'>
+							{r.startDate
+								? dayjs(r.startDate).format('DD/MM/YYYY')
+								: '—'}
+						</p>
+					</div>
+					<div>
+						<p className='text-xs text-muted-foreground'>
+							Đến ngày
+						</p>
+						<p className='font-medium'>
+							{r.endDate
+								? dayjs(r.endDate).format('DD/MM/YYYY')
+								: '—'}
+						</p>
+					</div>
+					<div className='col-span-2 sm:col-span-4'>
+						<p className='text-xs text-muted-foreground'>Ghi chú</p>
+						<p className='font-medium'>{r.note || '—'}</p>
+					</div>
+				</div>
+				<div className='border-t px-5 py-4'>
+					<p className='mb-2 font-medium'>
+						Danh sách học viên ({group.rows.length})
+					</p>
+					<div className='max-h-52 overflow-y-auto rounded-md border'>
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Mã QN</TableHead>
+									<TableHead>Họ tên</TableHead>
+									<TableHead>Cấp bậc</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{group.rows.map((row) => (
+									<TableRow key={row.id}>
+										<TableCell className='font-mono'>
+											{row.personnelCode || '—'}
+										</TableCell>
+										<TableCell>
+											{row.personnelName || '—'}
+										</TableCell>
+										<TableCell>{row.rank || '—'}</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					</div>
+				</div>
+				<div className='flex justify-end gap-2 border-t px-5 py-4'>
+					<Button
+						variant='outline'
+						disabled={busy}
+						onClick={() => {
+							if (!printClassLeaveList(group.rows))
+								toast.error('Trình duyệt chặn cửa sổ in')
+						}}
+					>
+						<Printer className='mr-1 h-4 w-4' />
+						In danh sách lớp
+					</Button>
+					<Button
+						variant='destructive'
+						disabled={busy}
+						onClick={onReturn}
+					>
+						<RotateCcw className='mr-1 h-4 w-4' />
+						Trả lại cả lớp
+					</Button>
+					<Button disabled={busy} onClick={onApprove}>
+						{busy ? (
+							<Loader2 className='mr-1 h-4 w-4 animate-spin' />
+						) : (
+							<Check className='mr-1 h-4 w-4' />
+						)}
+						Duyệt cả lớp
+					</Button>
+				</div>
+			</div>
+		</div>
+	)
+}
+
+function ApproveDetailDialog({
+	r,
+	busy,
+	onClose,
+	onApprove,
+	onReturn,
+	onOpenPersonnel
+}: {
+	r: LeaveRequest
+	busy: boolean
+	onClose: () => void
+	onApprove: () => void
+	onReturn: () => void
+	onOpenPersonnel: () => void
+}) {
+	return (
+		<div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4'>
+			<div className='max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-lg border bg-background shadow-lg'>
+				<div className='flex items-center justify-between border-b px-5 py-4'>
+					<h3 className='font-semibold'>Chi tiết đơn #{r.id}</h3>
+					<Button variant='ghost' size='sm' onClick={onClose}>
+						Đóng
+					</Button>
+				</div>
+				<div className='grid grid-cols-2 gap-3 px-5 py-4 text-sm'>
+					<div>
+						<p className='text-xs text-muted-foreground'>Họ tên</p>
+						<button
+							type='button'
+							className='font-medium text-primary underline-offset-4 hover:underline'
+							onClick={onOpenPersonnel}
+						>
+							{r.personnelName || '—'} ({r.personnelCode || '—'})
+						</button>
+					</div>
+					<div>
+						<p className='text-xs text-muted-foreground'>
+							Trạng thái
+						</p>
+						<p className='font-medium'>
+							{STATUS_LABEL[r.status] || r.status}
+						</p>
+					</div>
+					<div>
+						<p className='text-xs text-muted-foreground'>
+							Đối tượng
+						</p>
+						<p className='font-medium'>{r.objectTypeLabel}</p>
+					</div>
+					<div>
+						<p className='text-xs text-muted-foreground'>Cấp bậc</p>
+						<p className='font-medium'>{r.rank || '—'}</p>
+					</div>
+					<div>
+						<p className='text-xs text-muted-foreground'>Chức vụ</p>
+						<p className='font-medium'>{r.position || '—'}</p>
+					</div>
+					<div>
+						<p className='text-xs text-muted-foreground'>Đơn vị</p>
+						<p className='font-medium'>{r.unitName || '—'}</p>
+					</div>
+					<div>
+						<p className='text-xs text-muted-foreground'>
+							Loại phép
+						</p>
+						<p className='font-medium'>
+							{r.leaveType === 'SPECIAL'
+								? 'Phép đặc biệt'
+								: 'Phép hằng năm'}
+						</p>
+					</div>
+					<div>
+						<p className='text-xs text-muted-foreground'>
+							Nhập ngũ
+						</p>
+						<p className='font-medium'>
+							{r.enlistmentDate
+								? dayjs(r.enlistmentDate).format('DD/MM/YYYY')
+								: '—'}
+						</p>
+					</div>
+					<div>
+						<p className='text-xs text-muted-foreground'>
+							Thâm niên
+						</p>
+						<p className='font-medium'>{r.serviceYears} năm</p>
+					</div>
+					<div className='col-span-2 rounded-md border bg-muted/30 p-3'>
+						<p className='mb-2 font-medium'>
+							Căn cứ tính ngày phép
+						</p>
+						<div className='grid grid-cols-2 gap-x-4 gap-y-2 sm:grid-cols-4'>
+							<div>
+								<p className='text-xs text-muted-foreground'>
+									Ngày cơ bản
+								</p>
+								<p className='font-semibold'>
+									{r.baseDays} ngày
+								</p>
+							</div>
+							<div>
+								<p className='text-xs text-muted-foreground'>
+									Ngày đi đường
+								</p>
+								<p className='font-semibold'>
+									{r.travelDays} ngày
+								</p>
+							</div>
+							<div>
+								<p className='text-xs text-muted-foreground'>
+									Ngày nghỉ thêm
+								</p>
+								<p className='font-semibold'>
+									{r.extraDays} ngày
+								</p>
+							</div>
+							<div>
+								<p className='text-xs text-muted-foreground'>
+									Tổng cộng
+								</p>
+								<p className='font-semibold'>
+									{r.totalDays} ngày
+								</p>
+							</div>
+						</div>
+						{r.extraReasons.length > 0 && (
+							<p className='mt-2 text-xs text-muted-foreground'>
+								Lý do nghỉ thêm: {r.extraReasons.join(', ')}
+							</p>
+						)}
+					</div>
+					<div>
+						<p className='text-xs text-muted-foreground'>Bắt đầu</p>
+						<p className='font-medium'>
+							{r.startDate
+								? dayjs(r.startDate).format('DD/MM/YYYY')
+								: '—'}
+						</p>
+					</div>
+					<div>
+						<p className='text-xs text-muted-foreground'>
+							Kết thúc
+						</p>
+						<p className='font-medium'>
+							{r.endDate
+								? dayjs(r.endDate).format('DD/MM/YYYY')
+								: '—'}
+						</p>
+					</div>
+					<div className='col-span-2'>
+						<p className='text-xs text-muted-foreground'>
+							Nơi nghỉ
+						</p>
+						<p className='font-medium'>{r.localityPath || '—'}</p>
+					</div>
+					<div className='col-span-2'>
+						<p className='text-xs text-muted-foreground'>Ghi chú</p>
+						<p className='font-medium'>{r.note || '—'}</p>
+					</div>
+				</div>
+				<div className='flex flex-wrap gap-2 border-t px-5 py-4'>
+					<Button
+						variant='outline'
+						onClick={() => {
+							if (!printLeaveCertificate(r)) {
+								toast.error('Trình duyệt chặn popup in')
+							}
+						}}
+					>
+						Xuất giấy phép
+					</Button>
+					<Button
+						variant='destructive'
+						disabled={busy}
+						onClick={onReturn}
+					>
+						<RotateCcw className='mr-1 h-4 w-4' />
+						Trả lại
+					</Button>
+					<Button disabled={busy} onClick={onApprove}>
+						{busy && (
+							<Loader2 className='mr-1 h-4 w-4 animate-spin' />
+						)}
+						<Check className='mr-1 h-4 w-4' />
+						Duyệt
+					</Button>
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/apps/web/src/components/leave-management/ApproveLeavePage.tsx
+++ b/apps/web/src/components/leave-management/ApproveLeavePage.tsx
@@ -22,6 +22,7 @@ import {
 	ListLeaveMailLog,
 	ListLeaveRequests,
 	MarkLeaveAlertsRead,
+	SaveLeaveMailConfig,
 	TestLeaveMail,
 	type LeaveRequest
 } from '@/api/leave'
@@ -712,6 +713,7 @@ function MailConfigAndLog({
 				mode: string
 				host: string | null
 				port: number | null
+				user: string | null
 				from: string | null
 				hint: string
 				lastPreviewUrl: string | null
@@ -725,6 +727,25 @@ function MailConfigAndLog({
 		mutate: () => void
 	}
 }) {
+	const qc = useQueryClient()
+	const [smtpUser, setSmtpUser] = useState(mailStatus?.user || '')
+	const [smtpPass, setSmtpPass] = useState('')
+	const saveMailMut = useMutation({
+		mutationFn: () =>
+			SaveLeaveMailConfig({
+				user: smtpUser.trim(),
+				pass: smtpPass,
+				host: 'smtp.gmail.com',
+				port: 587,
+				from: `Quản lý phép <${smtpUser.trim()}>`
+			}),
+		onSuccess: (result) => {
+			toast.success(result.message)
+			setSmtpPass('')
+			qc.invalidateQueries({ queryKey: ['leave-mail-status'] })
+		},
+		onError: (error: Error) => toast.error(error.message)
+	})
 	const { data: logs = [] } = useQuery({
 		queryKey: ['leave-mail-log'],
 		queryFn: () => ListLeaveMailLog(20),
@@ -793,6 +814,51 @@ function MailConfigAndLog({
 									</a>
 								</p>
 							)}
+						</div>
+						<div className='grid gap-3 md:grid-cols-2'>
+							<div>
+								<Label>SMTP user</Label>
+								<Input
+									type='email'
+									autoComplete='username'
+									value={smtpUser}
+									onChange={(e) =>
+										setSmtpUser(e.target.value)
+									}
+									placeholder='your-account@gmail.com'
+								/>
+							</div>
+							<div>
+								<Label>SMTP password</Label>
+								<Input
+									type='password'
+									autoComplete='new-password'
+									value={smtpPass}
+									onChange={(e) =>
+										setSmtpPass(e.target.value)
+									}
+									placeholder='Gmail App Password'
+								/>
+								<p className='mt-1 text-xs text-muted-foreground'>
+									Mật khẩu ứng dụng Gmail; hệ thống không hiển
+									thị lại sau khi lưu.
+								</p>
+							</div>
+							<div className='md:col-span-2'>
+								<Button
+									disabled={
+										saveMailMut.isPending ||
+										!smtpUser.trim() ||
+										!smtpPass.trim()
+									}
+									onClick={() => saveMailMut.mutate()}
+								>
+									{saveMailMut.isPending && (
+										<Loader2 className='mr-1 h-4 w-4 animate-spin' />
+									)}
+									Lưu cấu hình SMTP
+								</Button>
+							</div>
 						</div>
 						<div className='flex flex-wrap items-end gap-2'>
 							<div className='min-w-[220px] flex-1'>

--- a/apps/web/src/components/leave-management/ImportLocalitiesDialog.tsx
+++ b/apps/web/src/components/leave-management/ImportLocalitiesDialog.tsx
@@ -1,0 +1,296 @@
+import { useRef, useState } from 'react'
+import ExcelJS from 'exceljs'
+import * as XLSX from 'xlsx'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Download, FileSpreadsheet, Loader2, Upload } from 'lucide-react'
+import { toast } from 'sonner'
+import { ImportLeaveLocalities } from '@/api/leave'
+import { Button } from '@/components/ui/button'
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle
+} from '@/components/ui/dialog'
+
+const HEADERS = [
+	'province',
+	'ward',
+	'village',
+	'provinceCode',
+	'wardCode',
+	'villageCode'
+] as const
+
+const VN_HEADERS = [
+	'Tỉnh *',
+	'Xã / Phường',
+	'Thôn',
+	'Mã tỉnh',
+	'Mã xã',
+	'Mã thôn'
+]
+
+interface LocalityImportRow {
+	province: string
+	ward?: string | null
+	village?: string | null
+	provinceCode?: string | null
+	wardCode?: string | null
+	villageCode?: string | null
+}
+
+function cellStr(v: unknown): string {
+	if (v == null) return ''
+	return String(v).replace(/\s+/g, ' ').trim()
+}
+
+function parseSheet(file: ArrayBuffer): LocalityImportRow[] {
+	const wb = XLSX.read(file, { type: 'array' })
+	const sheet = wb.Sheets[wb.SheetNames[0]!]
+	if (!sheet) return []
+	const rows = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet, {
+		defval: ''
+	})
+
+	const mapKey = (k: string) => {
+		const lower = k.trim().toLowerCase()
+		const aliases: Record<string, (typeof HEADERS)[number]> = {
+			province: 'province',
+			tỉnh: 'province',
+			'tỉnh *': 'province',
+			'tỉnh / thành phố': 'province',
+			'tỉnh/thành phố': 'province',
+			'tỉnh / thành phố ': 'province',
+			tinh: 'province',
+			ward: 'ward',
+			'xã / phường': 'ward',
+			'xã/phường': 'ward',
+			tên: 'ward',
+			xa: 'ward',
+			village: 'village',
+			thôn: 'village',
+			thon: 'village',
+			provincecode: 'provinceCode',
+			'mã tỉnh': 'provinceCode',
+			'mã tp': 'provinceCode',
+			wardcode: 'wardCode',
+			'mã xã': 'wardCode',
+			mã: 'wardCode',
+			villagecode: 'villageCode',
+			'mã thôn': 'villageCode'
+		}
+		return aliases[lower] || (HEADERS.includes(k as never) ? k : null)
+	}
+
+	const out: LocalityImportRow[] = []
+	for (const raw of rows) {
+		const mapped: Record<string, unknown> = {}
+		for (const [k, v] of Object.entries(raw)) {
+			const key = mapKey(k)
+			if (key) mapped[key] = v
+		}
+		if (
+			cellStr(mapped.province).toLowerCase() === 'province' ||
+			cellStr(mapped.province).toLowerCase() === 'tỉnh *'
+		) {
+			continue
+		}
+		const province = cellStr(mapped.province)
+		if (!province) continue
+		out.push({
+			province,
+			ward: cellStr(mapped.ward) || null,
+			village: cellStr(mapped.village) || null,
+			provinceCode: cellStr(mapped.provinceCode) || null,
+			wardCode: cellStr(mapped.wardCode) || null,
+			villageCode: cellStr(mapped.villageCode) || null
+		})
+	}
+	return out
+}
+
+interface Props {
+	open: boolean
+	onOpenChange: (open: boolean) => void
+}
+
+export default function ImportLocalitiesDialog({ open, onOpenChange }: Props) {
+	const qc = useQueryClient()
+	const inputRef = useRef<HTMLInputElement>(null)
+	const [rows, setRows] = useState<LocalityImportRow[]>([])
+	const [fileName, setFileName] = useState('')
+	const [parseError, setParseError] = useState('')
+
+	const mut = useMutation({
+		mutationFn: () => ImportLeaveLocalities(rows),
+		onSuccess: (res) => {
+			qc.invalidateQueries({ queryKey: ['leave-localities-tree'] })
+			if (res.errorCount === 0) {
+				toast.success(
+					`Import xong ${res.successCount} dòng (tạo mới: ${res.createdCount ?? 0}, đã có: ${res.skippedCount ?? 0})`
+				)
+				onOpenChange(false)
+				reset()
+			} else {
+				toast.warning(
+					`Thành công ${res.successCount}/${res.totalCount}. Lỗi: ${res.errorCount}`
+				)
+				if (res.errors[0]) {
+					toast.error(
+						`Dòng ${res.errors[0].row}: ${res.errors[0].message}`
+					)
+				}
+			}
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	function reset() {
+		setRows([])
+		setFileName('')
+		setParseError('')
+		if (inputRef.current) inputRef.current.value = ''
+	}
+
+	async function downloadTemplate() {
+		const wb = new ExcelJS.Workbook()
+		const sheet = wb.addWorksheet('Dia phuong')
+		const vn = sheet.addRow(VN_HEADERS)
+		const api = sheet.addRow([...HEADERS])
+		sheet.addRow(['Hà Nội', 'Ba Đình', 'Phúc Xá', '', '', ''])
+		sheet.addRow(['Hà Nội', 'Ba Đình', 'Vĩnh Phúc', '', '', ''])
+		sheet.addRow(['Hà Nội', 'Hoàn Kiếm', '', '', '', ''])
+		vn.eachCell((c) => {
+			c.font = { bold: true, color: { argb: 'FFFFFFFF' } }
+			c.fill = {
+				type: 'pattern',
+				pattern: 'solid',
+				fgColor: { argb: '4472C4' }
+			}
+		})
+		api.eachCell((c) => {
+			c.font = { bold: true }
+			c.fill = {
+				type: 'pattern',
+				pattern: 'solid',
+				fgColor: { argb: 'D9E1F2' }
+			}
+		})
+		HEADERS.forEach((_, i) => {
+			sheet.getColumn(i + 1).width = 16
+		})
+		const buf = await wb.xlsx.writeBuffer()
+		const blob = new Blob([buf], {
+			type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+		})
+		const url = URL.createObjectURL(blob)
+		const a = document.createElement('a')
+		a.href = url
+		a.download = 'mau-import-dia-phuong.xlsx'
+		a.click()
+		URL.revokeObjectURL(url)
+	}
+
+	async function onFile(file: File) {
+		setParseError('')
+		setFileName(file.name)
+		try {
+			const buf = await file.arrayBuffer()
+			const parsed = parseSheet(buf)
+			if (!parsed.length) {
+				setParseError('Không đọc được dòng dữ liệu hợp lệ')
+				setRows([])
+				return
+			}
+			setRows(parsed)
+		} catch (e) {
+			setParseError(String((e as Error).message || e))
+			setRows([])
+		}
+	}
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={(v) => {
+				onOpenChange(v)
+				if (!v) reset()
+			}}
+		>
+			<DialogContent className='max-w-lg'>
+				<DialogHeader>
+					<DialogTitle>Import danh sách địa phương</DialogTitle>
+				</DialogHeader>
+				<div className='space-y-3 py-2 text-sm'>
+					<p className='text-muted-foreground'>
+						Mỗi dòng: <strong>Tỉnh</strong> + (tuỳ chọn){' '}
+						<strong>Xã/Phường</strong> + (tuỳ chọn){' '}
+						<strong>Thôn</strong>. Hệ thống tự tạo cấp cha nếu chưa
+						có.
+					</p>
+					<Button
+						type='button'
+						variant='outline'
+						className='w-full'
+						onClick={() => downloadTemplate()}
+					>
+						<Download className='mr-2 h-4 w-4' />
+						Tải file mẫu
+					</Button>
+					<div
+						className='flex cursor-pointer flex-col items-center justify-center gap-2 rounded-md border border-dashed p-6 hover:bg-muted/40'
+						onClick={() => inputRef.current?.click()}
+						onKeyDown={() => {}}
+					>
+						{fileName ? (
+							<>
+								<FileSpreadsheet className='h-8 w-8 text-primary' />
+								<span className='font-medium'>{fileName}</span>
+								<span className='text-muted-foreground'>
+									{rows.length} dòng sẵn sàng
+								</span>
+							</>
+						) : (
+							<>
+								<Upload className='h-8 w-8 text-muted-foreground' />
+								<span>Chọn file .xlsx / .xls / .csv</span>
+							</>
+						)}
+						<input
+							ref={inputRef}
+							type='file'
+							accept='.xlsx,.xls,.csv'
+							className='hidden'
+							onChange={(e) => {
+								const f = e.target.files?.[0]
+								if (f) void onFile(f)
+							}}
+						/>
+					</div>
+					{parseError && (
+						<p className='text-sm text-destructive'>{parseError}</p>
+					)}
+				</div>
+				<DialogFooter>
+					<Button
+						variant='outline'
+						onClick={() => onOpenChange(false)}
+					>
+						Hủy
+					</Button>
+					<Button
+						disabled={!rows.length || mut.isPending}
+						onClick={() => mut.mutate()}
+					>
+						{mut.isPending && (
+							<Loader2 className='mr-1 h-4 w-4 animate-spin' />
+						)}
+						Import {rows.length ? `(${rows.length})` : ''}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/apps/web/src/components/leave-management/ImportPersonnelDialog.tsx
+++ b/apps/web/src/components/leave-management/ImportPersonnelDialog.tsx
@@ -1,0 +1,346 @@
+import { useRef, useState } from 'react'
+import ExcelJS from 'exceljs'
+import * as XLSX from 'xlsx'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Download, FileSpreadsheet, Loader2, Upload } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+	ImportLeavePersonnel,
+	type LeaveObjectType,
+	type LeavePersonnel
+} from '@/api/leave'
+import { Button } from '@/components/ui/button'
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle
+} from '@/components/ui/dialog'
+
+const HEADERS = [
+	'fullName',
+	'enlistmentDate',
+	'recruitment',
+	'objectType',
+	'rank',
+	'position',
+	'unitName',
+	'hometown',
+	'permanentResidence'
+] as const
+
+const VN_HEADERS = [
+	'Họ và tên *',
+	'Ngày nhập ngũ (YYYY-MM-DD)',
+	'Tuyển dụng',
+	'Đối tượng * (QN|CN|VCQP|HSQ|BS)',
+	'Cấp bậc',
+	'Chức vụ',
+	'Đơn vị',
+	'Quê quán (Xã, Tỉnh)',
+	'Thường trú (Xã, Tỉnh)'
+]
+
+type PersonnelImportRow = Partial<
+	Omit<LeavePersonnel, 'id' | 'createdAt' | 'updatedAt'>
+> & {
+	fullName: string
+	objectType: LeaveObjectType
+}
+
+function cellStr(v: unknown): string {
+	if (v == null) return ''
+	if (v instanceof Date) {
+		const y = v.getFullYear()
+		const m = String(v.getMonth() + 1).padStart(2, '0')
+		const d = String(v.getDate()).padStart(2, '0')
+		return `${y}-${m}-${d}`
+	}
+	return String(v).trim()
+}
+
+function excelSerialToDate(n: number): string {
+	const utc = Math.round((n - 25569) * 86400 * 1000)
+	const d = new Date(utc)
+	if (Number.isNaN(d.getTime())) return ''
+	const y = d.getUTCFullYear()
+	const m = String(d.getUTCMonth() + 1).padStart(2, '0')
+	const day = String(d.getUTCDate()).padStart(2, '0')
+	return `${y}-${m}-${day}`
+}
+
+function normalizeDate(v: unknown): string | null {
+	if (v == null || v === '') return null
+	if (typeof v === 'number') return excelSerialToDate(v) || null
+	const s = cellStr(v)
+	if (!s) return null
+	const m = s.match(/^(\d{1,2})[-/](\d{1,2})[-/](\d{4})$/)
+	if (m) {
+		return `${m[3]}-${m[2]!.padStart(2, '0')}-${m[1]!.padStart(2, '0')}`
+	}
+	if (/^\d{4}-\d{2}-\d{2}/.test(s)) return s.slice(0, 10)
+	return s
+}
+
+function parseSheet(file: ArrayBuffer): PersonnelImportRow[] {
+	const wb = XLSX.read(file, { type: 'array', cellDates: true })
+	const sheet = wb.Sheets[wb.SheetNames[0]!]
+	if (!sheet) return []
+	const rows = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet, {
+		defval: '',
+		raw: true
+	})
+
+	const mapKey = (k: string) => {
+		const lower = k.trim().toLowerCase()
+		const aliases: Record<string, string> = {
+			code: 'code',
+			mã: 'code',
+			fullname: 'fullName',
+			'họ và tên': 'fullName',
+			'họ và tên *': 'fullName',
+			hoten: 'fullName',
+			enlistmentdate: 'enlistmentDate',
+			'ngày nhập ngũ (yyyy-mm-dd)': 'enlistmentDate',
+			recruitment: 'recruitment',
+			'tuyển dụng': 'recruitment',
+			objecttype: 'objectType',
+			'đối tượng * (qn|cn|vcqp|hsq|bs)': 'objectType',
+			rank: 'rank',
+			'cấp bậc': 'rank',
+			position: 'position',
+			'chức vụ': 'position',
+			unitname: 'unitName',
+			'đơn vị': 'unitName',
+			hometown: 'hometown',
+			'quê quán': 'hometown',
+			'quê quán (xã, tỉnh)': 'hometown',
+			permanentresidence: 'permanentResidence',
+			'thường trú': 'permanentResidence',
+			'thường trú (xã, tỉnh)': 'permanentResidence'
+		}
+		return aliases[lower] || (HEADERS.includes(k as never) ? k : null)
+	}
+
+	const out: PersonnelImportRow[] = []
+	for (const raw of rows) {
+		const mapped: Record<string, unknown> = {}
+		for (const [k, v] of Object.entries(raw)) {
+			const key = mapKey(k)
+			if (key) mapped[key] = v
+		}
+		if (cellStr(mapped.fullName).toLowerCase() === 'fullname') continue
+		const fullName = cellStr(mapped.fullName)
+		if (!fullName) continue
+
+		const objectType = (
+			cellStr(mapped.objectType) || 'QN'
+		).toUpperCase() as LeaveObjectType
+
+		out.push({
+			code: cellStr(mapped.code) || null,
+			fullName,
+			enlistmentDate: normalizeDate(mapped.enlistmentDate),
+			recruitment: cellStr(mapped.recruitment) || null,
+			objectType,
+			rank: cellStr(mapped.rank) || null,
+			position: cellStr(mapped.position) || null,
+			unitId: null,
+			unitName: cellStr(mapped.unitName) || null,
+			hometown: cellStr(mapped.hometown) || null,
+			permanentResidence: cellStr(mapped.permanentResidence) || null,
+			userId: null
+		})
+	}
+	return out
+}
+
+interface Props {
+	open: boolean
+	onOpenChange: (open: boolean) => void
+}
+
+export default function ImportPersonnelDialog({ open, onOpenChange }: Props) {
+	const qc = useQueryClient()
+	const inputRef = useRef<HTMLInputElement>(null)
+	const [rows, setRows] = useState<PersonnelImportRow[]>([])
+	const [fileName, setFileName] = useState('')
+	const [parseError, setParseError] = useState('')
+
+	const mut = useMutation({
+		mutationFn: () => ImportLeavePersonnel(rows),
+		onSuccess: (res) => {
+			qc.invalidateQueries({ queryKey: ['leave-personnel'] })
+			if (res.errorCount === 0) {
+				toast.success(`Import thành công ${res.successCount} quân nhân`)
+				onOpenChange(false)
+				reset()
+			} else {
+				toast.warning(
+					`Thành công ${res.successCount}/${res.totalCount}. Lỗi: ${res.errorCount}`
+				)
+				if (res.errors[0]) {
+					toast.error(
+						`Dòng ${res.errors[0].row}: ${res.errors[0].message}`
+					)
+				}
+			}
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	function reset() {
+		setRows([])
+		setFileName('')
+		setParseError('')
+		if (inputRef.current) inputRef.current.value = ''
+	}
+
+	async function downloadTemplate() {
+		const wb = new ExcelJS.Workbook()
+		const sheet = wb.addWorksheet('Quan nhan')
+		const vn = sheet.addRow(VN_HEADERS)
+		const api = sheet.addRow([...HEADERS])
+		sheet.addRow([
+			'Nguyễn Văn A',
+			'2015-03-01',
+			'Đợt 1/2015',
+			'QN',
+			'Thượng úy',
+			'Trợ lý',
+			'Đại đội 1',
+			'Phường Ba Đình, Thành phố Hà Nội',
+			'Phường Ba Đình, Thành phố Hà Nội'
+		])
+		vn.eachCell((c) => {
+			c.font = { bold: true, color: { argb: 'FFFFFFFF' } }
+			c.fill = {
+				type: 'pattern',
+				pattern: 'solid',
+				fgColor: { argb: '4472C4' }
+			}
+		})
+		api.eachCell((c) => {
+			c.font = { bold: true }
+			c.fill = {
+				type: 'pattern',
+				pattern: 'solid',
+				fgColor: { argb: 'D9E1F2' }
+			}
+		})
+		HEADERS.forEach((_, i) => {
+			sheet.getColumn(i + 1).width = 18
+		})
+		const buf = await wb.xlsx.writeBuffer()
+		const blob = new Blob([buf], {
+			type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+		})
+		const url = URL.createObjectURL(blob)
+		const a = document.createElement('a')
+		a.href = url
+		a.download = 'mau-import-quan-nhan.xlsx'
+		a.click()
+		URL.revokeObjectURL(url)
+	}
+
+	async function onFile(file: File) {
+		setParseError('')
+		setFileName(file.name)
+		try {
+			const buf = await file.arrayBuffer()
+			const parsed = parseSheet(buf)
+			if (!parsed.length) {
+				setParseError('Không đọc được dòng dữ liệu hợp lệ')
+				setRows([])
+				return
+			}
+			setRows(parsed)
+		} catch (e) {
+			setParseError(String((e as Error).message || e))
+			setRows([])
+		}
+	}
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={(v) => {
+				onOpenChange(v)
+				if (!v) reset()
+			}}
+		>
+			<DialogContent className='max-w-lg'>
+				<DialogHeader>
+					<DialogTitle>Import danh sách quân nhân</DialogTitle>
+				</DialogHeader>
+				<div className='space-y-3 py-2 text-sm'>
+					<p className='text-muted-foreground'>
+						Tải mẫu Excel, điền dữ liệu rồi tải lên. Mã sẽ được hệ
+						thống tự sinh. Quê quán / thường trú nên dạng{' '}
+						<em>Xã/Phường, Tỉnh/TP</em>.
+					</p>
+					<Button
+						type='button'
+						variant='outline'
+						className='w-full'
+						onClick={() => downloadTemplate()}
+					>
+						<Download className='mr-2 h-4 w-4' />
+						Tải file mẫu
+					</Button>
+					<div
+						className='flex cursor-pointer flex-col items-center justify-center gap-2 rounded-md border border-dashed p-6 hover:bg-muted/40'
+						onClick={() => inputRef.current?.click()}
+						onKeyDown={() => {}}
+					>
+						{fileName ? (
+							<>
+								<FileSpreadsheet className='h-8 w-8 text-primary' />
+								<span className='font-medium'>{fileName}</span>
+								<span className='text-muted-foreground'>
+									{rows.length} dòng sẵn sàng
+								</span>
+							</>
+						) : (
+							<>
+								<Upload className='h-8 w-8 text-muted-foreground' />
+								<span>Chọn file .xlsx / .xls / .csv</span>
+							</>
+						)}
+						<input
+							ref={inputRef}
+							type='file'
+							accept='.xlsx,.xls,.csv'
+							className='hidden'
+							onChange={(e) => {
+								const f = e.target.files?.[0]
+								if (f) void onFile(f)
+							}}
+						/>
+					</div>
+					{parseError && (
+						<p className='text-sm text-destructive'>{parseError}</p>
+					)}
+				</div>
+				<DialogFooter>
+					<Button
+						variant='outline'
+						onClick={() => onOpenChange(false)}
+					>
+						Hủy
+					</Button>
+					<Button
+						disabled={!rows.length || mut.isPending}
+						onClick={() => mut.mutate()}
+					>
+						{mut.isPending && (
+							<Loader2 className='mr-1 h-4 w-4 animate-spin' />
+						)}
+						Import {rows.length ? `(${rows.length})` : ''}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/apps/web/src/components/leave-management/LeaveBatchesPage.tsx
+++ b/apps/web/src/components/leave-management/LeaveBatchesPage.tsx
@@ -1,0 +1,472 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Loader2, Plus, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+	CreateLeaveBatch,
+	DeleteLeaveBatch,
+	ListLeaveBatches,
+	ListLeaveAuditLogs,
+	UpdateLeaveBatch,
+	type LeaveBatch
+} from '@/api/leave'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow
+} from '@/components/ui/table'
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle
+} from '@/components/ui/dialog'
+import dayjs from 'dayjs'
+
+function getBatchProgress(batch: LeaveBatch) {
+	if (!batch.startDate || batch.totalDays <= 0) {
+		return { usedDays: 0, remainingDays: Math.max(0, batch.totalDays) }
+	}
+	const start = dayjs(batch.startDate).startOf('day')
+	const today = dayjs().startOf('day')
+	const elapsedDays = today.isBefore(start) ? 0 : today.diff(start, 'day') + 1
+	const usedDays = Math.min(batch.totalDays, Math.max(0, elapsedDays))
+	return {
+		usedDays,
+		remainingDays: Math.max(0, batch.totalDays - usedDays)
+	}
+}
+
+export default function LeaveBatchesPage() {
+	const qc = useQueryClient()
+	const [requestId, setRequestId] = useState<string>('')
+	const [showAddDialog, setShowAddDialog] = useState(false)
+	const [editingBatch, setEditingBatch] = useState<LeaveBatch | null>(null)
+	const [newBatchLabel, setNewBatchLabel] = useState('')
+	const [newStartDate, setNewStartDate] = useState('')
+	const [newEndDate, setNewEndDate] = useState('')
+	const [newTotalDays, setNewTotalDays] = useState(0)
+
+	const { data: fetchedBatches = [], isLoading } = useQuery({
+		queryKey: ['leave-batches', requestId],
+		queryFn: () =>
+			ListLeaveBatches(
+				requestId && Number(requestId) > 0
+					? Number(requestId)
+					: undefined
+			)
+	})
+	const batches = fetchedBatches
+	const { data: auditLogs = [] } = useQuery({
+		queryKey: ['leave-audit-logs', 'LEAVE_BATCH'],
+		queryFn: () => ListLeaveAuditLogs('LEAVE_BATCH')
+	})
+
+	const createMut = useMutation({
+		mutationFn: () =>
+			CreateLeaveBatch({
+				requestId: Number(requestId),
+				batchLabel: newBatchLabel,
+				startDate: newStartDate,
+				endDate: newEndDate,
+				totalDays: newTotalDays
+			}),
+		onSuccess: () => {
+			toast.success('Đã thêm đợt')
+			setShowAddDialog(false)
+			setNewBatchLabel('')
+			setNewStartDate('')
+			setNewEndDate('')
+			setNewTotalDays(0)
+			qc.invalidateQueries({ queryKey: ['leave-batches', requestId] })
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	const updateMut = useMutation({
+		mutationFn: (vars: {
+			id: number
+			body: Partial<
+				Pick<
+					LeaveBatch,
+					'batchLabel' | 'startDate' | 'endDate' | 'totalDays'
+				>
+			>
+		}) => UpdateLeaveBatch(vars.id, vars.body),
+		onSuccess: () => {
+			toast.success('Đã cập nhật đợt')
+			setEditingBatch(null)
+			qc.invalidateQueries({ queryKey: ['leave-batches', requestId] })
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	const deleteMut = useMutation({
+		mutationFn: (id: number) => DeleteLeaveBatch(id),
+		onSuccess: () => {
+			toast.success('Đã xóa đợt')
+			qc.invalidateQueries({ queryKey: ['leave-batches', requestId] })
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	function handleAdd() {
+		if (
+			!newBatchLabel ||
+			!newStartDate ||
+			!newEndDate ||
+			newTotalDays < 1
+		) {
+			toast.error('Vui lòng điền đầy đủ thông tin')
+			return
+		}
+		createMut.mutate()
+	}
+
+	function handleUpdate(batch: LeaveBatch) {
+		updateMut.mutate({ id: batch.id, body: batch })
+	}
+
+	return (
+		<div className='space-y-4'>
+			<div>
+				<h2 className='text-2xl font-bold tracking-tight'>
+					Quản lý đợt nghỉ phép
+				</h2>
+			</div>
+
+			<div className='flex items-center gap-2'>
+				<div className='min-w-[200px] flex-1'>
+					<Label>Mã đơn phép</Label>
+					<Input
+						placeholder='Để trống để xem tất cả đợt nghỉ...'
+						value={requestId}
+						onChange={(e) => setRequestId(e.target.value)}
+					/>
+				</div>
+			</div>
+
+			<div className='space-y-4'>
+				<div className='flex items-center justify-between'>
+					<h3 className='text-lg font-semibold'>Các đợt nghỉ phép</h3>
+					<Button
+						size='sm'
+						disabled={!requestId || Number(requestId) < 1}
+						onClick={() => setShowAddDialog(true)}
+					>
+						<Plus className='mr-1 h-4 w-4' />
+						Thêm đợt
+					</Button>
+				</div>
+
+				<div className='rounded-md border'>
+					<div className='border-b px-4 py-3 font-semibold'>
+						Nhật ký quản lý đợt nghỉ
+					</div>
+					<div className='max-h-72 overflow-auto'>
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Thời gian</TableHead>
+									<TableHead>Thao tác</TableHead>
+									<TableHead>Mã đợt</TableHead>
+									<TableHead>Chi tiết</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{auditLogs.map((log) => (
+									<TableRow key={log.id}>
+										<TableCell>
+											{dayjs(log.createdAt).format(
+												'DD/MM/YYYY HH:mm'
+											)}
+										</TableCell>
+										<TableCell>{log.action}</TableCell>
+										<TableCell>
+											#{log.entityId || '—'}
+										</TableCell>
+										<TableCell className='text-xs'>
+											{log.details || '—'}
+										</TableCell>
+									</TableRow>
+								))}
+								{auditLogs.length === 0 && (
+									<TableRow>
+										<TableCell
+											colSpan={4}
+											className='text-center text-muted-foreground'
+										>
+											Chưa có nhật ký
+										</TableCell>
+									</TableRow>
+								)}
+							</TableBody>
+						</Table>
+					</div>
+				</div>
+
+				{isLoading ? (
+					<div className='flex justify-center p-8'>
+						<Loader2 className='h-6 w-6 animate-spin' />
+					</div>
+				) : batches.length === 0 ? (
+					<p className='text-sm text-muted-foreground'>
+						Chưa có đợt nghỉ phép nào
+					</p>
+				) : (
+					<div className='rounded-md border'>
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Mã đơn</TableHead>
+									<TableHead>Quân nhân</TableHead>
+									<TableHead>Đợt</TableHead>
+									<TableHead>Ngày bắt đầu</TableHead>
+									<TableHead>Ngày kết thúc</TableHead>
+									<TableHead>Tổng ngày</TableHead>
+									<TableHead>Đã đi</TableHead>
+									<TableHead>Còn lại</TableHead>
+									<TableHead className='w-20' />
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{batches.map((batch) => {
+									const progress = getBatchProgress(batch)
+									return (
+										<TableRow key={batch.id}>
+											<TableCell>
+												#{batch.requestId}
+											</TableCell>
+											<TableCell>
+												{batch.personnelName || '—'}
+												{batch.personnelCode
+													? ` (${batch.personnelCode})`
+													: ''}
+											</TableCell>
+											<TableCell className='font-medium'>
+												{batch.batchLabel}
+											</TableCell>
+											<TableCell>
+												{batch.startDate
+													? dayjs(
+															batch.startDate
+														).format('DD/MM/YYYY')
+													: '—'}
+											</TableCell>
+											<TableCell>
+												{batch.endDate
+													? dayjs(
+															batch.endDate
+														).format('DD/MM/YYYY')
+													: '—'}
+											</TableCell>
+											<TableCell className='font-medium'>
+												{batch.totalDays}
+											</TableCell>
+											<TableCell>
+												{progress.usedDays}
+											</TableCell>
+											<TableCell className='font-semibold'>
+												{progress.remainingDays}
+											</TableCell>
+											<TableCell>
+												<div className='flex items-center gap-1'>
+													<Button
+														size='icon'
+														variant='ghost'
+														title='Chỉnh sửa'
+														onClick={() =>
+															setEditingBatch(
+																batch
+															)
+														}
+													>
+														<Plus className='h-4 w-4' />
+													</Button>
+													<Button
+														size='icon'
+														variant='ghost'
+														title='Xóa'
+														onClick={() =>
+															deleteMut.mutate(
+																batch.id
+															)
+														}
+													>
+														<Trash2 className='h-4 w-4' />
+													</Button>
+												</div>
+											</TableCell>
+										</TableRow>
+									)
+								})}
+							</TableBody>
+						</Table>
+					</div>
+				)}
+			</div>
+
+			<Dialog open={showAddDialog} onOpenChange={setShowAddDialog}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Thêm đợt nghỉ phép</DialogTitle>
+					</DialogHeader>
+					<div className='space-y-4 py-4'>
+						<div>
+							<Label>Nhãn đợt</Label>
+							<Input
+								value={newBatchLabel}
+								onChange={(e) =>
+									setNewBatchLabel(e.target.value)
+								}
+								placeholder='VD: Đợt 1'
+							/>
+						</div>
+						<div className='grid grid-cols-2 gap-4'>
+							<div>
+								<Label>Ngày bắt đầu</Label>
+								<Input
+									type='date'
+									value={newStartDate}
+									onChange={(e) =>
+										setNewStartDate(e.target.value)
+									}
+								/>
+							</div>
+							<div>
+								<Label>Ngày kết thúc</Label>
+								<Input
+									type='date'
+									value={newEndDate}
+									onChange={(e) =>
+										setNewEndDate(e.target.value)
+									}
+								/>
+							</div>
+						</div>
+						<div>
+							<Label>Tổng số ngày</Label>
+							<Input
+								type='number'
+								min={1}
+								value={newTotalDays}
+								onChange={(e) =>
+									setNewTotalDays(Number(e.target.value))
+								}
+							/>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button
+							variant='outline'
+							onClick={() => setShowAddDialog(false)}
+						>
+							Hủy
+						</Button>
+						<Button
+							onClick={handleAdd}
+							disabled={createMut.isPending}
+						>
+							{createMut.isPending && (
+								<Loader2 className='mr-2 h-4 w-4 animate-spin' />
+							)}
+							Thêm đợt
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog
+				open={!!editingBatch}
+				onOpenChange={(open) => !open && setEditingBatch(null)}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Chỉnh sửa đợt nghỉ phép</DialogTitle>
+					</DialogHeader>
+					{editingBatch && (
+						<div className='space-y-4 py-4'>
+							<div>
+								<Label>Nhãn đợt</Label>
+								<Input
+									value={editingBatch.batchLabel}
+									onChange={(e) =>
+										setEditingBatch({
+											...editingBatch,
+											batchLabel: e.target.value
+										})
+									}
+								/>
+							</div>
+							<div className='grid grid-cols-2 gap-4'>
+								<div>
+									<Label>Ngày bắt đầu</Label>
+									<Input
+										type='date'
+										value={editingBatch.startDate || ''}
+										onChange={(e) =>
+											setEditingBatch({
+												...editingBatch,
+												startDate: e.target.value
+											})
+										}
+									/>
+								</div>
+								<div>
+									<Label>Ngày kết thúc</Label>
+									<Input
+										type='date'
+										value={editingBatch.endDate || ''}
+										onChange={(e) =>
+											setEditingBatch({
+												...editingBatch,
+												endDate: e.target.value
+											})
+										}
+									/>
+								</div>
+							</div>
+							<div>
+								<Label>Tổng số ngày</Label>
+								<Input
+									type='number'
+									min={1}
+									value={editingBatch.totalDays}
+									onChange={(e) =>
+										setEditingBatch({
+											...editingBatch,
+											totalDays: Number(e.target.value)
+										})
+									}
+								/>
+							</div>
+						</div>
+					)}
+					<DialogFooter>
+						<Button
+							variant='outline'
+							onClick={() => setEditingBatch(null)}
+						>
+							Hủy
+						</Button>
+						<Button
+							disabled={!editingBatch || updateMut.isPending}
+							onClick={() =>
+								editingBatch && handleUpdate(editingBatch)
+							}
+						>
+							Lưu
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</div>
+	)
+}

--- a/apps/web/src/components/leave-management/LeaveListPage.tsx
+++ b/apps/web/src/components/leave-management/LeaveListPage.tsx
@@ -1,0 +1,1111 @@
+import { useMemo, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+	Check,
+	Eye,
+	Loader2,
+	Printer,
+	RotateCcw,
+	Save,
+	UserRound
+} from 'lucide-react'
+import { toast } from 'sonner'
+import dayjs from 'dayjs'
+import {
+	DecideLeaveRequest,
+	GetLeaveMeta,
+	ListLeaveRequests,
+	PatchLeaveRequest,
+	type LeaveRequest
+} from '@/api/leave'
+import { printLeaveCertificate } from '@/components/leave-management/printLeaveCertificate'
+import { printClassLeaveList } from '@/components/leave-management/printClassLeaveList'
+import PersonnelPreviewDialog from '@/components/leave-management/PersonnelPreviewDialog'
+import { isSuperAdmin } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow
+} from '@/components/ui/table'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue
+} from '@/components/ui/select'
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle
+} from '@/components/ui/dialog'
+
+const STATUS_LABEL: Record<string, string> = {
+	PENDING: 'Chờ chỉ huy CQ',
+	PENDING_COMMANDER: 'Chờ chỉ huy CQ',
+	PENDING_AGENCY: 'Chờ CQQL (ký)',
+	APPROVED: 'Đã duyệt',
+	RETURNED: 'Trả lại',
+	REJECTED: 'Trả lại',
+	CANCELLED: 'Đã hủy',
+	DRAFT: 'Nháp'
+}
+
+function statusVariant(
+	s: string
+): 'default' | 'secondary' | 'destructive' | 'outline' {
+	if (s === 'APPROVED') return 'default'
+	if (s === 'RETURNED' || s === 'REJECTED') return 'destructive'
+	if (s === 'PENDING_AGENCY') return 'outline'
+	return 'secondary'
+}
+
+function canAct(r: LeaveRequest, admin: boolean, userId: number | null) {
+	// Người đề xuất không tự duyệt đơn của mình
+	if (
+		userId != null &&
+		r.proposedByUserId != null &&
+		r.proposedByUserId === userId &&
+		!admin
+	) {
+		return false
+	}
+	const st = r.status
+	const isCommander =
+		userId != null &&
+		r.commanderUserId != null &&
+		r.commanderUserId === userId
+	if (st === 'PENDING_COMMANDER' || st === 'PENDING') {
+		return isCommander || admin
+	}
+	if (st === 'PENDING_AGENCY') {
+		return admin
+	}
+	return false
+}
+
+function isCommanderOf(r: LeaveRequest, userId: number | null, admin: boolean) {
+	const st = r.status
+	if (st !== 'PENDING_COMMANDER' && st !== 'PENDING') return false
+	if (admin) return true
+	return (
+		userId != null &&
+		r.commanderUserId != null &&
+		r.commanderUserId === userId
+	)
+}
+
+function readUserId(): number | null {
+	try {
+		const token = localStorage.getItem('qlhvAccessToken')
+		if (!token) return null
+		const payload = JSON.parse(atob(token.split('.')[1]!))
+		return Number(payload.userId) || null
+	} catch {
+		return null
+	}
+}
+
+function fmtDate(iso: string | null | undefined) {
+	if (!iso) return '—'
+	const d = dayjs(iso)
+	return d.isValid() ? d.format('DD/MM/YYYY') : iso
+}
+
+type LeaveListGroup = {
+	key: string
+	rows: LeaveRequest[]
+	first: LeaveRequest
+	isClass: boolean
+}
+
+function leaveListGroupKey(r: LeaveRequest) {
+	if (r.requestScope !== 'CLASS' || r.classId == null)
+		return `request:${r.id}`
+	return [
+		'class',
+		r.classId,
+		r.proposedByUserId ?? '',
+		r.status,
+		r.leaveType,
+		r.startDate ?? '',
+		r.endDate ?? '',
+		r.totalDays,
+		r.note ?? '',
+		String(r.createdAt).slice(0, 16)
+	].join(':')
+}
+
+export default function LeaveListPage() {
+	const qc = useQueryClient()
+	const admin = isSuperAdmin()
+	const userId = useMemo(() => readUserId(), [])
+	const [status, setStatus] = useState<string>('all')
+	// QN thường: chỉ xem đơn mình; admin/chỉ huy: hộp thư liên quan
+	const [inbox, setInbox] = useState<string>(admin ? 'all' : 'mine')
+	const [leaveType, setLeaveType] = useState<string>('all')
+	const [commanderId, setCommanderId] = useState<string>('all')
+	const [search, setSearch] = useState('')
+	const [searchApplied, setSearchApplied] = useState('')
+	const [detail, setDetail] = useState<LeaveRequest | null>(null)
+	const [detailGroup, setDetailGroup] = useState<LeaveListGroup | null>(null)
+	const [personnelPreview, setPersonnelPreview] = useState<{
+		id: number
+		name: string | null
+	} | null>(null)
+
+	/** Key theo ngày → Đã đi/Còn lại tự tính lại mỗi ngày khi mở lại trang */
+	const asOfDay = dayjs().format('YYYY-MM-DD')
+
+	const {
+		data = [],
+		isLoading,
+		dataUpdatedAt
+	} = useQuery({
+		queryKey: [
+			'leave-requests',
+			status,
+			inbox,
+			leaveType,
+			commanderId,
+			searchApplied,
+			admin,
+			asOfDay
+		],
+		queryFn: () =>
+			ListLeaveRequests({
+				status: status === 'all' ? undefined : status,
+				inbox,
+				leaveType: leaveType === 'all' ? undefined : leaveType,
+				commanderUserId:
+					commanderId === 'all' ? undefined : Number(commanderId),
+				search: searchApplied.trim() || undefined
+			}),
+		// Làm mới định kỳ trong ngày (5 phút) + khi focus lại tab
+		refetchInterval: 5 * 60 * 1000,
+		refetchOnWindowFocus: true
+	})
+
+	/** Danh sách chỉ huy để chọn lọc (từ dữ liệu đã load, không filter commander) */
+	const { data: allForCommanders = [] } = useQuery({
+		queryKey: ['leave-requests-commanders', inbox, admin, asOfDay],
+		queryFn: () =>
+			ListLeaveRequests({
+				inbox: admin ? 'all' : inbox,
+				status: undefined
+			}),
+		staleTime: 60_000
+	})
+
+	const commanderOptions = useMemo(() => {
+		const map = new Map<number, string>()
+		for (const r of allForCommanders) {
+			if (r.commanderUserId != null && r.commanderName) {
+				map.set(r.commanderUserId, r.commanderName)
+			} else if (r.commanderUserId != null) {
+				map.set(
+					r.commanderUserId,
+					map.get(r.commanderUserId) || `User #${r.commanderUserId}`
+				)
+			}
+		}
+		return [...map.entries()]
+			.map(([id, name]) => ({ id, name }))
+			.sort((a, b) => a.name.localeCompare(b.name, 'vi'))
+	}, [allForCommanders])
+
+	const displayGroups = useMemo<LeaveListGroup[]>(() => {
+		const grouped = new Map<string, LeaveRequest[]>()
+		for (const row of data) {
+			const key = leaveListGroupKey(row)
+			grouped.set(key, [...(grouped.get(key) || []), row])
+		}
+		return [...grouped.entries()].map(([key, rows]) => ({
+			key,
+			rows,
+			first: rows[0]!,
+			isClass: rows[0]!.requestScope === 'CLASS'
+		}))
+	}, [data])
+
+	const decideMut = useMutation({
+		mutationFn: (vars: {
+			id: number
+			decision: 'APPROVED' | 'RETURNED'
+			travelDays?: number
+			extraDays?: number
+			extraReasons?: string[]
+			adminNote?: string
+		}) =>
+			DecideLeaveRequest(vars.id, {
+				decision: vars.decision,
+				travelDays: vars.travelDays,
+				extraDays: vars.extraDays,
+				extraReasons: vars.extraReasons,
+				adminNote: vars.adminNote
+			}),
+		onSuccess: (resp, vars) => {
+			const mail = resp.mail
+			if (vars.decision === 'APPROVED' || vars.decision === 'RETURNED') {
+				toast.success(
+					vars.decision === 'APPROVED' ? 'Đã duyệt' : 'Đã trả lại'
+				)
+				if (mail) {
+					if (mail.ok && mail.previewUrl) {
+						toast.message(mail.message, {
+							duration: 12000,
+							action: {
+								label: 'Xem thư',
+								onClick: () =>
+									window.open(mail.previewUrl!, '_blank')
+							}
+						})
+						window.open(mail.previewUrl, '_blank')
+					} else if (mail.ok) {
+						toast.success(mail.message)
+					} else {
+						toast.error(mail.message || mail.error || 'Mail lỗi')
+					}
+				}
+			}
+			qc.invalidateQueries({ queryKey: ['leave-requests'] })
+			qc.invalidateQueries({ queryKey: ['leave-records'] })
+			qc.invalidateQueries({ queryKey: ['leave-mail-log'] })
+			setDetail(null)
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	function applySearch() {
+		setSearchApplied(search.trim())
+	}
+
+	return (
+		<div className='space-y-4'>
+			<div className='flex flex-wrap items-end justify-between gap-3'>
+				<div>
+					<h2 className='text-2xl font-bold tracking-tight'>
+						Danh sách phép
+					</h2>
+					<p className='text-sm text-muted-foreground'>
+						<strong>Đã đi</strong> / <strong>Còn lại</strong> cập
+						nhật theo lịch mỗi ngày
+						{dataUpdatedAt
+							? ` · Làm mới: ${dayjs(dataUpdatedAt).format('DD/MM/YYYY HH:mm')}`
+							: ''}
+					</p>
+				</div>
+			</div>
+
+			<div className='flex flex-wrap items-end gap-2'>
+				<div className='min-w-[200px] flex-1'>
+					<Label className='text-xs text-muted-foreground'>
+						Mã / họ tên
+					</Label>
+					<div className='flex gap-2'>
+						<Input
+							placeholder='Tìm mã QN hoặc tên…'
+							value={search}
+							onChange={(e) => setSearch(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === 'Enter') applySearch()
+							}}
+						/>
+						<Button
+							type='button'
+							variant='secondary'
+							onClick={applySearch}
+						>
+							Tìm
+						</Button>
+					</div>
+				</div>
+				<div className='w-40'>
+					<Label className='text-xs text-muted-foreground'>
+						Loại phép
+					</Label>
+					<Select value={leaveType} onValueChange={setLeaveType}>
+						<SelectTrigger>
+							<SelectValue placeholder='Loại phép' />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value='all'>Tất cả loại</SelectItem>
+							<SelectItem value='ANNUAL'>Hằng năm</SelectItem>
+							<SelectItem value='SPECIAL'>Đặc biệt</SelectItem>
+						</SelectContent>
+					</Select>
+				</div>
+				<div className='w-48'>
+					<Label className='text-xs text-muted-foreground'>
+						Chỉ huy CQ
+					</Label>
+					<Select value={commanderId} onValueChange={setCommanderId}>
+						<SelectTrigger>
+							<SelectValue placeholder='Chỉ huy' />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value='all'>Tất cả chỉ huy</SelectItem>
+							{commanderOptions.map((c) => (
+								<SelectItem key={c.id} value={String(c.id)}>
+									{c.name}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+				<div className='w-44'>
+					<Label className='text-xs text-muted-foreground'>
+						Trạng thái
+					</Label>
+					<Select value={status} onValueChange={setStatus}>
+						<SelectTrigger>
+							<SelectValue placeholder='Trạng thái' />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value='all'>Tất cả TT</SelectItem>
+							<SelectItem value='PENDING_COMMANDER'>
+								Chờ chỉ huy CQ
+							</SelectItem>
+							<SelectItem value='PENDING_AGENCY'>
+								Chờ CQQL
+							</SelectItem>
+							<SelectItem value='APPROVED'>Đã duyệt</SelectItem>
+							<SelectItem value='RETURNED'>Trả lại</SelectItem>
+							<SelectItem value='CANCELLED'>Đã hủy</SelectItem>
+						</SelectContent>
+					</Select>
+				</div>
+				{/* Chỉ admin / chỉ huy thấy bộ lọc hộp thư duyệt */}
+				{(admin || userId != null) && (
+					<div className='w-44'>
+						<Label className='text-xs text-muted-foreground'>
+							Hộp thư
+						</Label>
+						<Select value={inbox} onValueChange={setInbox}>
+							<SelectTrigger>
+								<SelectValue placeholder='Hộp thư' />
+							</SelectTrigger>
+							<SelectContent>
+								{admin && (
+									<SelectItem value='all'>
+										Tất cả đơn
+									</SelectItem>
+								)}
+								{admin && (
+									<SelectItem value='agency'>
+										Chờ CQQL (ký)
+									</SelectItem>
+								)}
+								{admin && (
+									<SelectItem value='commander'>
+										Chờ tôi (chỉ huy CQ)
+									</SelectItem>
+								)}
+								<SelectItem value='mine'>
+									Đơn tôi đề xuất
+								</SelectItem>
+								{!admin && (
+									<SelectItem value='related'>
+										Liên quan đến tôi
+									</SelectItem>
+								)}
+							</SelectContent>
+						</Select>
+					</div>
+				)}
+			</div>
+
+			<div className='rounded-md border'>
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>Mã QN</TableHead>
+							<TableHead>Họ tên</TableHead>
+							<TableHead>Loại</TableHead>
+							<TableHead>Tổng</TableHead>
+							<TableHead title='Số ngày đã trôi qua từ ngày bắt đầu (đơn đã duyệt)'>
+								Đã đi
+							</TableHead>
+							<TableHead title='Số ngày phép đã duyệt nhưng chưa tới lịch'>
+								Còn lại
+							</TableHead>
+							<TableHead>Nơi nghỉ</TableHead>
+							<TableHead>Chỉ huy CQ</TableHead>
+							<TableHead>Trạng thái</TableHead>
+							<TableHead className='w-28' />
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{isLoading && (
+							<TableRow>
+								<TableCell colSpan={10} className='text-center'>
+									<Loader2 className='mx-auto h-5 w-5 animate-spin' />
+								</TableCell>
+							</TableRow>
+						)}
+						{!isLoading && data.length === 0 && (
+							<TableRow>
+								<TableCell
+									colSpan={10}
+									className='text-center text-muted-foreground'
+								>
+									Chưa có đơn phép
+								</TableCell>
+							</TableRow>
+						)}
+						{displayGroups.map((group) => {
+							const r = group.first
+							return (
+								<TableRow
+									key={group.key}
+									className='cursor-pointer hover:bg-muted/40'
+									onClick={() =>
+										group.isClass
+											? setDetailGroup(group)
+											: setDetail(r)
+									}
+								>
+									<TableCell className='font-mono text-sm'>
+										{group.isClass
+											? '—'
+											: r.personnelCode || '—'}
+									</TableCell>
+									<TableCell
+										onClick={(e) => {
+											if (group.isClass) {
+												setDetailGroup(group)
+												return
+											}
+											e.stopPropagation()
+											if (r.personnelId) {
+												setPersonnelPreview({
+													id: r.personnelId,
+													name: r.personnelName
+												})
+											}
+										}}
+									>
+										{group.isClass ? (
+											<span className='font-medium'>
+												{r.className || 'Lớp'}{' '}
+												<span className='text-xs text-muted-foreground'>
+													({group.rows.length} học
+													viên)
+												</span>
+											</span>
+										) : r.personnelId ? (
+											<button
+												type='button'
+												className='inline-flex items-center gap-1 font-medium text-primary underline-offset-4 hover:underline'
+											>
+												<UserRound className='h-3.5 w-3.5' />
+												{r.personnelName || '—'}
+											</button>
+										) : (
+											r.personnelName || '—'
+										)}
+									</TableCell>
+									<TableCell>
+										{r.leaveType === 'ANNUAL'
+											? 'Hằng năm'
+											: 'Đặc biệt'}
+									</TableCell>
+									<TableCell className='font-semibold'>
+										{r.totalDays}
+									</TableCell>
+									<TableCell className='tabular-nums'>
+										{r.usedDays ?? 0}
+									</TableCell>
+									<TableCell className='tabular-nums font-medium'>
+										{r.remainingDays ?? 0}
+									</TableCell>
+									<TableCell className='max-w-[140px] truncate text-sm'>
+										{r.localityPath || '—'}
+									</TableCell>
+									<TableCell className='max-w-[120px] truncate text-sm'>
+										{r.commanderName || '—'}
+									</TableCell>
+									<TableCell>
+										<Badge
+											variant={statusVariant(r.status)}
+										>
+											{STATUS_LABEL[r.status] || r.status}
+										</Badge>
+									</TableCell>
+									<TableCell
+										onClick={(e) => e.stopPropagation()}
+									>
+										<Button
+											size='icon'
+											variant='ghost'
+											title='Xem chi tiết'
+											onClick={() =>
+												group.isClass
+													? setDetailGroup(group)
+													: setDetail(r)
+											}
+										>
+											<Eye className='h-4 w-4' />
+										</Button>
+									</TableCell>
+								</TableRow>
+							)
+						})}
+					</TableBody>
+				</Table>
+			</div>
+
+			{detail && (
+				<LeaveDetailDialog
+					key={detail.id}
+					r={detail}
+					admin={admin}
+					userId={userId}
+					busy={decideMut.isPending}
+					onClose={() => setDetail(null)}
+					onDecide={(vars) =>
+						decideMut.mutate({ id: detail.id, ...vars })
+					}
+					onPatched={(updated) => {
+						setDetail(updated)
+						qc.invalidateQueries({ queryKey: ['leave-requests'] })
+					}}
+					onOpenPersonnel={() => {
+						if (detail.personnelId) {
+							setPersonnelPreview({
+								id: detail.personnelId,
+								name: detail.personnelName
+							})
+						}
+					}}
+				/>
+			)}
+
+			{detailGroup && (
+				<ClassLeaveListDialog
+					group={detailGroup}
+					onClose={() => setDetailGroup(null)}
+				/>
+			)}
+
+			{personnelPreview && (
+				<PersonnelPreviewDialog
+					personnelId={personnelPreview.id}
+					fallbackName={personnelPreview.name}
+					onClose={() => setPersonnelPreview(null)}
+				/>
+			)}
+		</div>
+	)
+}
+
+function ClassLeaveListDialog({
+	group,
+	onClose
+}: {
+	group: LeaveListGroup
+	onClose: () => void
+}) {
+	const r = group.first
+	return (
+		<Dialog open onOpenChange={(open) => !open && onClose()}>
+			<DialogContent className='max-w-2xl'>
+				<DialogHeader>
+					<DialogTitle>
+						Chi tiết phép — {r.className || 'Lớp'}
+					</DialogTitle>
+				</DialogHeader>
+				<div className='grid grid-cols-2 gap-3 text-sm sm:grid-cols-4'>
+					<Info label='Đối tượng' value='Học viên' />
+					<Info label='Đơn vị' value={r.unitName || '—'} />
+					<Info
+						label='Loại phép'
+						value={
+							r.leaveType === 'ANNUAL' ? 'Hằng năm' : 'Đặc biệt'
+						}
+					/>
+					<Info label='Tổng ngày' value={`${r.totalDays} ngày`} />
+					<Info label='Từ ngày' value={fmtDate(r.startDate)} />
+					<Info label='Đến ngày' value={fmtDate(r.endDate)} />
+					<Info
+						label='Trạng thái'
+						value={STATUS_LABEL[r.status] || r.status}
+					/>
+					<Info
+						label='Số học viên'
+						value={String(group.rows.length)}
+					/>
+				</div>
+				<div className='max-h-64 overflow-y-auto rounded-md border'>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Mã QN</TableHead>
+								<TableHead>Họ tên</TableHead>
+								<TableHead>Cấp bậc</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{group.rows.map((row) => (
+								<TableRow key={row.id}>
+									<TableCell>
+										{row.personnelCode || '—'}
+									</TableCell>
+									<TableCell>
+										{row.personnelName || '—'}
+									</TableCell>
+									<TableCell>{row.rank || '—'}</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				</div>
+				<DialogFooter>
+					<Button
+						variant='outline'
+						onClick={() => {
+							if (!printClassLeaveList(group.rows))
+								toast.error('Trình duyệt chặn cửa sổ in')
+						}}
+					>
+						<Printer className='mr-1 h-4 w-4' />
+						In danh sách lớp
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	)
+}
+
+function LeaveDetailDialog({
+	r,
+	admin,
+	userId,
+	busy,
+	onClose,
+	onDecide,
+	onPatched,
+	onOpenPersonnel
+}: {
+	r: LeaveRequest
+	admin: boolean
+	userId: number | null
+	busy: boolean
+	onClose: () => void
+	onDecide: (v: {
+		decision: 'APPROVED' | 'RETURNED'
+		travelDays?: number
+		extraDays?: number
+		extraReasons?: string[]
+		adminNote?: string
+	}) => void
+	onPatched: (r: LeaveRequest) => void
+	onOpenPersonnel?: () => void
+}) {
+	const act = canAct(r, admin, userId)
+	const commanderEdit = isCommanderOf(r, userId, admin)
+	const agencyStep = r.status === 'PENDING_AGENCY'
+	const { data: meta } = useQuery({
+		queryKey: ['leave-meta'],
+		queryFn: GetLeaveMeta
+	})
+
+	const [travelDays, setTravelDays] = useState(r.travelDays)
+	const [extraDays, setExtraDays] = useState(r.extraDays)
+	const [wantExtra, setWantExtra] = useState(r.extraDays > 0)
+	const [reasons, setReasons] = useState<string[]>(r.extraReasons || [])
+	const [adminNote, setAdminNote] = useState(r.adminNote || '')
+
+	const previewTotal = r.baseDays + travelDays + (wantExtra ? extraDays : 0)
+
+	const patchMut = useMutation({
+		mutationFn: () =>
+			PatchLeaveRequest(r.id, {
+				travelDays,
+				extraDays: wantExtra ? extraDays : 0,
+				extraReasons: wantExtra ? reasons : [],
+				adminNote: adminNote || null
+			}),
+		onSuccess: (updated) => {
+			toast.success('Đã lưu chỉnh sửa ngày')
+			onPatched(updated)
+			setTravelDays(updated.travelDays)
+			setExtraDays(updated.extraDays)
+			setWantExtra(updated.extraDays > 0)
+			setReasons(updated.extraReasons || [])
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	const reasonOptions =
+		extraDays === 10
+			? meta?.extra10Reasons || []
+			: extraDays === 5
+				? meta?.extra5Reasons || []
+				: []
+
+	function printSlip() {
+		const ok = printLeaveCertificate(
+			{
+				...r,
+				extraReasons: wantExtra ? reasons : r.extraReasons
+			},
+			{
+				travelDays,
+				extraDays: wantExtra ? extraDays : 0,
+				totalDays: previewTotal
+			}
+		)
+		if (!ok) toast.error('Trình duyệt chặn popup in')
+	}
+
+	return (
+		<Dialog open onOpenChange={(o) => !o && onClose()}>
+			<DialogContent className='flex !h-auto max-h-[90vh] max-w-lg flex-col overflow-hidden p-0'>
+				<DialogHeader className='shrink-0 border-b px-6 py-4'>
+					<DialogTitle>
+						Chi tiết đơn #{r.id} — {r.personnelName}
+					</DialogTitle>
+				</DialogHeader>
+				<div className='space-y-4 overflow-y-auto px-6 py-4 text-sm'>
+					<div className='grid grid-cols-2 gap-3'>
+						<div className='col-span-2'>
+							<p className='text-xs text-muted-foreground'>
+								Họ tên
+							</p>
+							{onOpenPersonnel && r.personnelId ? (
+								<button
+									type='button'
+									className='text-sm font-medium text-primary underline-offset-4 hover:underline'
+									onClick={onOpenPersonnel}
+								>
+									{r.personnelName || '—'} (
+									{r.personnelCode || '—'})
+								</button>
+							) : (
+								<p className='text-sm font-medium'>
+									{r.personnelName || '—'} (
+									{r.personnelCode || '—'})
+								</p>
+							)}
+						</div>
+						<Field label='Mã' value={r.personnelCode || '—'} />
+						<Field
+							label='Trạng thái'
+							value={STATUS_LABEL[r.status] || r.status}
+						/>
+						<Field
+							label='Loại phép'
+							value={
+								r.leaveType === 'ANNUAL'
+									? 'Hằng năm'
+									: 'Đặc biệt'
+							}
+						/>
+						<Field label='Đối tượng' value={r.objectTypeLabel} />
+						<Field
+							label='Ngày nhập ngũ'
+							value={
+								r.enlistmentDate
+									? dayjs(r.enlistmentDate).format(
+											'DD/MM/YYYY'
+										)
+									: '—'
+							}
+						/>
+						<Field label='Cấp bậc' value={r.rank || '—'} />
+						<Field label='Chức vụ' value={r.position || '—'} />
+						<Field label='Đơn vị' value={r.unitName || '—'} />
+						<Field
+							label='Ngày bắt đầu'
+							value={fmtDate(r.startDate)}
+						/>
+						<Field
+							label='Ngày kết thúc'
+							value={fmtDate(r.endDate)}
+						/>
+						<Field
+							label='Phép cơ bản'
+							value={`${r.baseDays} ngày`}
+						/>
+						<Field
+							label='Thâm niên'
+							value={`${r.serviceYears} năm`}
+						/>
+						<Field
+							label='Đã đi (theo lịch)'
+							value={`${r.usedDays ?? 0} ngày`}
+						/>
+						<Field
+							label='Còn lại (chưa tới)'
+							value={`${r.remainingDays ?? 0} ngày${
+								r.quotaDays != null
+									? ` · hạn mức năm ${r.quotaDays}`
+									: ''
+							}`}
+						/>
+						<div className='col-span-2'>
+							<Field
+								label='Nơi nghỉ'
+								value={r.localityPath || '—'}
+							/>
+						</div>
+						<div className='col-span-2'>
+							<Field
+								label='Ghi chú đề xuất'
+								value={r.note || '—'}
+							/>
+						</div>
+						<Field
+							label='Người đề xuất'
+							value={
+								r.proposedByDisplayName ||
+								r.proposedByUsername ||
+								'—'
+							}
+						/>
+						<Field
+							label='Chỉ huy CQ'
+							value={r.commanderName || '—'}
+						/>
+						<Field
+							label='Xử lý cuối'
+							value={
+								r.decidedByUsername
+									? `${r.decidedByUsername} · ${r.decidedAt ? dayjs(r.decidedAt).format('DD/MM/YYYY HH:mm') : ''}`
+									: '—'
+							}
+						/>
+					</div>
+
+					{/* Commander edit travel / extra */}
+					{commanderEdit && r.leaveType === 'ANNUAL' && (
+						<div className='space-y-3 rounded-md border p-3'>
+							<p className='font-medium'>
+								Chỉ huy CQ — chỉnh ngày đi đường / nghỉ thêm
+							</p>
+							<div className='grid grid-cols-2 gap-3'>
+								<div>
+									<Label>Ngày đi đường</Label>
+									<Input
+										type='number'
+										min={0}
+										value={travelDays}
+										onChange={(e) =>
+											setTravelDays(
+												Math.max(
+													0,
+													Number(e.target.value) || 0
+												)
+											)
+										}
+									/>
+								</div>
+								<div>
+									<Label>Tổng dự kiến</Label>
+									<div className='flex h-10 items-center rounded-md border bg-muted/40 px-3 font-semibold'>
+										{previewTotal} ngày
+									</div>
+								</div>
+							</div>
+							<div className='flex items-center gap-2'>
+								<Checkbox
+									id='wantExtraCmd'
+									checked={wantExtra}
+									onCheckedChange={(c) => {
+										setWantExtra(!!c)
+										if (!c) {
+											setExtraDays(0)
+											setReasons([])
+										} else if (!extraDays) {
+											setExtraDays(10)
+										}
+									}}
+								/>
+								<Label htmlFor='wantExtraCmd'>Nghỉ thêm</Label>
+							</div>
+							{wantExtra && (
+								<>
+									<div className='flex gap-4 text-sm'>
+										<label className='flex items-center gap-2'>
+											<input
+												type='radio'
+												checked={extraDays === 10}
+												onChange={() => {
+													setExtraDays(10)
+													setReasons([])
+												}}
+											/>
+											10 ngày
+										</label>
+										<label className='flex items-center gap-2'>
+											<input
+												type='radio'
+												checked={extraDays === 5}
+												onChange={() => {
+													setExtraDays(5)
+													setReasons([])
+												}}
+											/>
+											5 ngày
+										</label>
+									</div>
+									<div className='space-y-2'>
+										{reasonOptions.map((opt) => (
+											<label
+												key={opt.code}
+												className='flex items-start gap-2 text-sm'
+											>
+												<Checkbox
+													checked={reasons.includes(
+														opt.code
+													)}
+													onCheckedChange={() =>
+														setReasons((prev) =>
+															prev.includes(
+																opt.code
+															)
+																? prev.filter(
+																		(c) =>
+																			c !==
+																			opt.code
+																	)
+																: [
+																		...prev,
+																		opt.code
+																	]
+														)
+													}
+												/>
+												<span>{opt.label}</span>
+											</label>
+										))}
+									</div>
+								</>
+							)}
+							<div>
+								<Label>Ghi chú chỉ huy</Label>
+								<Textarea
+									value={adminNote}
+									onChange={(e) =>
+										setAdminNote(e.target.value)
+									}
+									rows={2}
+								/>
+							</div>
+							<Button
+								variant='outline'
+								size='sm'
+								disabled={patchMut.isPending}
+								onClick={() => patchMut.mutate()}
+							>
+								{patchMut.isPending ? (
+									<Loader2 className='mr-1 h-4 w-4 animate-spin' />
+								) : (
+									<Save className='mr-1 h-4 w-4' />
+								)}
+								Lưu chỉnh sửa
+							</Button>
+						</div>
+					)}
+
+					{!commanderEdit && r.leaveType === 'ANNUAL' && (
+						<div className='grid grid-cols-3 gap-2 rounded-md bg-muted/40 p-3 text-sm'>
+							<span>Đi đường: {r.travelDays}</span>
+							<span>Nghỉ thêm: {r.extraDays}</span>
+							<span className='font-semibold'>
+								Tổng: {r.totalDays}
+							</span>
+						</div>
+					)}
+
+					{act && agencyStep && (
+						<div>
+							<Label>Ghi chú CQQL</Label>
+							<Textarea
+								value={adminNote}
+								onChange={(e) => setAdminNote(e.target.value)}
+								rows={2}
+								placeholder='VD: Đã ký BGH…'
+							/>
+						</div>
+					)}
+				</div>
+
+				<DialogFooter className='shrink-0 flex-wrap gap-2 border-t px-6 py-4'>
+					<Button variant='outline' onClick={onClose}>
+						Đóng
+					</Button>
+					<Button variant='outline' onClick={printSlip}>
+						<Printer className='mr-1 h-4 w-4' />
+						Xuất giấy phép
+					</Button>
+					{act && (
+						<>
+							<Button
+								variant='destructive'
+								disabled={busy}
+								onClick={() =>
+									onDecide({
+										decision: 'RETURNED',
+										travelDays,
+										extraDays: wantExtra ? extraDays : 0,
+										extraReasons: wantExtra ? reasons : [],
+										adminNote
+									})
+								}
+							>
+								<RotateCcw className='mr-1 h-4 w-4' />
+								Trả lại
+							</Button>
+							<Button
+								disabled={
+									busy ||
+									(wantExtra &&
+										commanderEdit &&
+										reasons.length === 0)
+								}
+								onClick={() =>
+									onDecide({
+										decision: 'APPROVED',
+										travelDays,
+										extraDays: wantExtra ? extraDays : 0,
+										extraReasons: wantExtra ? reasons : [],
+										adminNote
+									})
+								}
+							>
+								{busy ? (
+									<Loader2 className='mr-1 h-4 w-4 animate-spin' />
+								) : (
+									<Check className='mr-1 h-4 w-4' />
+								)}
+								{agencyStep ? 'Duyệt (đã ký)' : 'Duyệt → CQQL'}
+							</Button>
+						</>
+					)}
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	)
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+	return (
+		<div>
+			<p className='text-xs text-muted-foreground'>{label}</p>
+			<p className='font-medium break-words'>{value}</p>
+		</div>
+	)
+}

--- a/apps/web/src/components/leave-management/LeaveReportsPage.tsx
+++ b/apps/web/src/components/leave-management/LeaveReportsPage.tsx
@@ -1,0 +1,422 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Loader2, Printer } from 'lucide-react'
+import dayjs from 'dayjs'
+import { toast } from 'sonner'
+import {
+	GetLeaveCheckYearReport,
+	GetLeaveNotYetTakenReport,
+	GetLeaveTakenReport,
+	ListLeaveAuditLogs,
+	type LeaveCheckYearItem,
+	type LeaveNotYetTakenItem,
+	type LeaveTakenReportItem
+} from '@/api/leave'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow
+} from '@/components/ui/table'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue
+} from '@/components/ui/select'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Badge } from '@/components/ui/badge'
+
+const years = (() => {
+	const y = dayjs().year()
+	return Array.from({ length: y + 3 - 2022 + 1 }, (_, i) => 2022 + i)
+})()
+
+export default function LeaveReportsPage() {
+	const [activeTab, setActiveTab] = useState('taken-list')
+	const [year, setYear] = useState<string>(String(dayjs().year()))
+	const [search, setSearch] = useState('')
+	const { data: auditLogs = [] } = useQuery({
+		queryKey: ['leave-audit-logs', 'LEAVE_REPORT'],
+		queryFn: () => ListLeaveAuditLogs('LEAVE_REPORT')
+	})
+
+	const { data: takenData = [], isLoading: loadingTaken } = useQuery({
+		queryKey: ['leave-report-taken', year],
+		queryFn: () => GetLeaveTakenReport(Number(year)),
+		enabled: !!year
+	})
+
+	const { data: checkYearData = [], isLoading: loadingCheckYear } = useQuery({
+		queryKey: ['leave-report-check-year', year, search],
+		queryFn: () =>
+			GetLeaveCheckYearReport({
+				year: Number(year),
+				search: search || undefined
+			}),
+		enabled: !!year
+	})
+
+	const { data: notYetTakenData = [], isLoading: loadingNotYetTaken } =
+		useQuery({
+			queryKey: ['leave-report-not-yet-taken', year],
+			queryFn: () => GetLeaveNotYetTakenReport(Number(year)),
+			enabled: !!year
+		})
+
+	function handleExportExcel(data: unknown, filename: string) {
+		const rows = [Object.keys(data[0] || {})]
+		for (const item of data) {
+			rows.push(Object.values(item))
+		}
+		const csv = rows.map((r) => r.join(',')).join('\n')
+		const blob = new Blob([csv], { type: 'text/csv' })
+		const url = URL.createObjectURL(blob)
+		const a = document.createElement('a')
+		a.href = url
+		a.download = `${filename}.csv`
+		a.click()
+		URL.revokeObjectURL(url)
+		toast.success('Đã xuất file')
+	}
+
+	return (
+		<div className='space-y-4'>
+			<div className='rounded-md border p-4'>
+				<h3 className='mb-2 font-semibold'>Nhật ký báo cáo</h3>
+				<div className='max-h-40 overflow-auto text-sm'>
+					{auditLogs.length === 0
+						? 'Chưa có nhật ký'
+						: auditLogs.slice(0, 20).map((x) => (
+								<div key={x.id} className='border-b py-1'>
+									{dayjs(x.createdAt).format(
+										'DD/MM/YYYY HH:mm'
+									)}{' '}
+									· {x.details || x.action}
+								</div>
+							))}
+				</div>
+			</div>
+			<div>
+				<h2 className='text-2xl font-bold tracking-tight'>
+					Báo cáo nghỉ phép
+				</h2>
+			</div>
+
+			<div className='flex items-center gap-2'>
+				<div className='w-36'>
+					<Label>Năm</Label>
+					<Select value={year} onValueChange={setYear}>
+						<SelectTrigger>
+							<SelectValue placeholder='Chọn năm' />
+						</SelectTrigger>
+						<SelectContent>
+							{years.map((y) => (
+								<SelectItem key={y} value={String(y)}>
+									{y}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+			</div>
+
+			<Tabs value={activeTab} onValueChange={setActiveTab}>
+				<TabsList>
+					<TabsTrigger value='taken-list'>
+						Báo cáo danh sách đã nghỉ phép
+					</TabsTrigger>
+					<TabsTrigger value='check-year'>
+						Tra cứu nghỉ phép năm
+					</TabsTrigger>
+					<TabsTrigger value='not-yet-taken'>
+						Thống kê chưa nghỉ phép
+					</TabsTrigger>
+				</TabsList>
+
+				<TabsContent value='taken-list'>
+					<div className='flex items-center justify-between'>
+						<p className='text-sm text-muted-foreground'>
+							Danh sách quân nhân đã nghỉ phép năm {year}
+						</p>
+						<Button
+							variant='outline'
+							size='sm'
+							onClick={() =>
+								handleExportExcel(
+									takenData,
+									`da-nghi-phep-${year}`
+								)
+							}
+						>
+							Xuất CSV
+						</Button>
+					</div>
+					<div className='rounded-md border'>
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Mã QN</TableHead>
+									<TableHead>Họ tên</TableHead>
+									<TableHead>Đối tượng</TableHead>
+									<TableHead>Đơn vị</TableHead>
+									<TableHead>Loại</TableHead>
+									<TableHead>Tổng ngày</TableHead>
+									<TableHead>Từ ngày</TableHead>
+									<TableHead>Đến ngày</TableHead>
+									<TableHead>Trạng thái</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{loadingTaken && (
+									<TableRow>
+										<TableCell
+											colSpan={9}
+											className='text-center'
+										>
+											<Loader2 className='mx-auto h-5 w-5 animate-spin' />
+										</TableCell>
+									</TableRow>
+								)}
+								{!loadingTaken && takenData.length === 0 && (
+									<TableRow>
+										<TableCell
+											colSpan={9}
+											className='text-center text-muted-foreground'
+										>
+											Không có dữ liệu
+										</TableCell>
+									</TableRow>
+								)}
+								{(takenData as LeaveTakenReportItem[]).map(
+									(r) => (
+										<TableRow key={r.id}>
+											<TableCell className='font-mono text-sm'>
+												{r.personnelCode}
+											</TableCell>
+											<TableCell>
+												{r.personnelName}
+											</TableCell>
+											<TableCell>
+												<Badge variant='secondary'>
+													{r.objectTypeLabel}
+												</Badge>
+											</TableCell>
+											<TableCell>{r.unitName}</TableCell>
+											<TableCell>
+												{r.leaveType === 'SPECIAL'
+													? 'Đặc biệt'
+													: 'Phép năm'}
+											</TableCell>
+											<TableCell className='font-medium'>
+												{r.totalDays}
+											</TableCell>
+											<TableCell>
+												{r.startDate
+													? dayjs(r.startDate).format(
+															'DD/MM/YYYY'
+														)
+													: '—'}
+											</TableCell>
+											<TableCell>
+												{r.endDate
+													? dayjs(r.endDate).format(
+															'DD/MM/YYYY'
+														)
+													: '—'}
+											</TableCell>
+											<TableCell>
+												<Badge variant='secondary'>
+													{r.status}
+												</Badge>
+											</TableCell>
+										</TableRow>
+									)
+								)}
+							</TableBody>
+						</Table>
+					</div>
+				</TabsContent>
+
+				<TabsContent value='check-year'>
+					<div className='flex items-center gap-2'>
+						<div className='min-w-[200px] flex-1'>
+							<Label>Tìm kiếm quân nhân</Label>
+							<Input
+								placeholder='Tìm mã QN hoặc tên...'
+								value={search}
+								onChange={(e) => setSearch(e.target.value)}
+							/>
+						</div>
+						<Button
+							variant='outline'
+							size='sm'
+							onClick={() =>
+								handleExportExcel(
+									checkYearData,
+									`tra-cuu-nghi-phep-${year}`
+								)
+							}
+						>
+							Xuất CSV
+						</Button>
+					</div>
+					<div className='rounded-md border'>
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Mã QN</TableHead>
+									<TableHead>Họ tên</TableHead>
+									<TableHead>Đối tượng</TableHead>
+									<TableHead>Đơn vị</TableHead>
+									<TableHead>Tổng ngày</TableHead>
+									<TableHead>Còn lại</TableHead>
+									<TableHead>Hạn mức</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{loadingCheckYear && (
+									<TableRow>
+										<TableCell
+											colSpan={7}
+											className='text-center'
+										>
+											<Loader2 className='mx-auto h-5 w-5 animate-spin' />
+										</TableCell>
+									</TableRow>
+								)}
+								{!loadingCheckYear &&
+									checkYearData.length === 0 && (
+										<TableRow>
+											<TableCell
+												colSpan={7}
+												className='text-center text-muted-foreground'
+											>
+												Không có kết quả
+											</TableCell>
+										</TableRow>
+									)}
+								{(checkYearData as LeaveCheckYearItem[]).map(
+									(r) => (
+										<TableRow
+											key={`${r.personnelCode}-${r.personnelName}`}
+										>
+											<TableCell className='font-mono text-sm'>
+												{r.personnelCode}
+											</TableCell>
+											<TableCell>
+												{r.personnelName}
+											</TableCell>
+											<TableCell>
+												<Badge variant='secondary'>
+													{r.objectTypeLabel}
+												</Badge>
+											</TableCell>
+											<TableCell>{r.unitName}</TableCell>
+											<TableCell className='font-medium'>
+												{r.totalDays}
+											</TableCell>
+											<TableCell className='tabular-nums'>
+												{r.remainingDays ?? 0}
+											</TableCell>
+											<TableCell className='tabular-nums'>
+												{r.quotaDays ?? '—'}
+											</TableCell>
+										</TableRow>
+									)
+								)}
+							</TableBody>
+						</Table>
+					</div>
+				</TabsContent>
+
+				<TabsContent value='not-yet-taken'>
+					<div className='flex items-center justify-between'>
+						<p className='text-sm text-muted-foreground'>
+							Danh sách quân nhân chưa nghỉ phép năm {year}
+						</p>
+						<Button
+							variant='outline'
+							size='sm'
+							onClick={() =>
+								handleExportExcel(
+									notYetTakenData,
+									`chua-nghi-phep-${year}`
+								)
+							}
+						>
+							Xuất CSV
+						</Button>
+					</div>
+					<div className='rounded-md border'>
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Mã QN</TableHead>
+									<TableHead>Họ tên</TableHead>
+									<TableHead>Đối tượng</TableHead>
+									<TableHead>Đơn vị</TableHead>
+									<TableHead>Hạn mức</TableHead>
+									<TableHead>Còn lại</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{loadingNotYetTaken && (
+									<TableRow>
+										<TableCell
+											colSpan={6}
+											className='text-center'
+										>
+											<Loader2 className='mx-auto h-5 w-5 animate-spin' />
+										</TableCell>
+									</TableRow>
+								)}
+								{!loadingNotYetTaken &&
+									notYetTakenData.length === 0 && (
+										<TableRow>
+											<TableCell
+												colSpan={6}
+												className='text-center text-muted-foreground'
+											>
+												Không có dữ liệu
+											</TableCell>
+										</TableRow>
+									)}
+								{(
+									notYetTakenData as LeaveNotYetTakenItem[]
+								).map((r) => (
+									<TableRow
+										key={`${r.personnelCode}-${r.personnelName}`}
+									>
+										<TableCell className='font-mono text-sm'>
+											{r.personnelCode}
+										</TableCell>
+										<TableCell>{r.personnelName}</TableCell>
+										<TableCell>
+											<Badge variant='secondary'>
+												{r.objectTypeLabel}
+											</Badge>
+										</TableCell>
+										<TableCell>{r.unitName}</TableCell>
+										<TableCell className='tabular-nums'>
+											{r.quotaDays ?? '—'}
+										</TableCell>
+										<TableCell className='tabular-nums font-medium'>
+											{r.remainingDays ?? 0}
+										</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					</div>
+				</TabsContent>
+			</Tabs>
+		</div>
+	)
+}

--- a/apps/web/src/components/leave-management/LeaveRequestForm.tsx
+++ b/apps/web/src/components/leave-management/LeaveRequestForm.tsx
@@ -1,0 +1,1074 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Loader2, Send } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+	ComputeLeaveDays,
+	CreateLeaveRequest,
+	GetLeaveMyAccess,
+	GetLeaveMeta,
+	GetMyLeavePersonnel,
+	ListLeaveLocalities,
+	ListLeaveClasses,
+	ListLeavePersonnel,
+	ListLeaveRequests,
+	type LeaveLocality,
+	type LeavePersonnel
+} from '@/api/leave'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue
+} from '@/components/ui/select'
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow
+} from '@/components/ui/table'
+import DateInput from '@/components/date-input'
+import { isSuperAdmin } from '@/lib/utils'
+import dayjs from 'dayjs'
+
+const EXTRA_ELIGIBLE = new Set([
+	'SQ',
+	'QNCN',
+	'CNQP',
+	'VCQP',
+	// legacy
+	'QN',
+	'CN'
+])
+
+export default function LeaveRequestForm() {
+	const qc = useQueryClient()
+	const admin = isSuperAdmin()
+	const { data: access } = useQuery({
+		queryKey: ['leave-my-access'],
+		queryFn: GetLeaveMyAccess
+	})
+	const canProposeForUnit = admin || Boolean(access?.isCommander)
+
+	const { data: myPersonnel, isLoading: loadingP } = useQuery({
+		queryKey: ['leave-my-personnel'],
+		queryFn: GetMyLeavePersonnel
+	})
+	const { data: allPersonnel = [], isLoading: loadingAll } = useQuery({
+		queryKey: ['leave-personnel', 'for-propose'],
+		queryFn: () => ListLeavePersonnel(),
+		enabled: canProposeForUnit
+	})
+	const { data: classes = [] } = useQuery({
+		queryKey: ['leave-classes', 'for-propose'],
+		queryFn: () => ListLeaveClasses()
+	})
+	const { data: meta } = useQuery({
+		queryKey: ['leave-meta'],
+		queryFn: GetLeaveMeta
+	})
+	const { data: myRequests = [] } = useQuery({
+		queryKey: ['leave-requests', 'mine'],
+		queryFn: () => ListLeaveRequests({ mine: true })
+	})
+
+	const [selectedPersonnelId, setSelectedPersonnelId] = useState<string>('')
+	const [requestScope, setRequestScope] = useState<'INDIVIDUAL' | 'CLASS'>(
+		'INDIVIDUAL'
+	)
+	const [selectedClassId, setSelectedClassId] = useState('')
+	const [leaveType, setLeaveType] = useState<'ANNUAL' | 'SPECIAL'>('ANNUAL')
+	const [rank, setRank] = useState('')
+	const [unitName, setUnitName] = useState('')
+	const [travelDays, setTravelDays] = useState(0)
+	const [wantExtra, setWantExtra] = useState(false)
+	const [extraDays, setExtraDays] = useState<0 | 5 | 10>(0)
+	const [reasons, setReasons] = useState<string[]>([])
+	/** Lý do phép đặc biệt */
+	const [specialReasons, setSpecialReasons] = useState<string[]>([])
+	/** Số ngày phép đặc biệt (1–10) */
+	const [specialDays, setSpecialDays] = useState(10)
+	const [manualDays, setManualDays] = useState(1)
+	const [provinceId, setProvinceId] = useState('')
+	const [wardId, setWardId] = useState('')
+	const [addressDetail, setAddressDetail] = useState('')
+	const [note, setNote] = useState('')
+	const [otherReason, setOtherReason] = useState('')
+	const [startDate, setStartDate] = useState('')
+	const [endDate, setEndDate] = useState('')
+
+	/** Hồ sơ đang dùng: linked account hoặc admin chọn từ danh sách */
+	const personnel: LeavePersonnel | null = useMemo(() => {
+		if (myPersonnel && !canProposeForUnit) return myPersonnel
+		if (requestScope === 'CLASS' && selectedClassId) {
+			return (
+				allPersonnel.find(
+					(p) => p.classId === Number(selectedClassId)
+				) || null
+			)
+		}
+		if (canProposeForUnit && selectedPersonnelId) {
+			return (
+				allPersonnel.find(
+					(p) => p.id === Number(selectedPersonnelId)
+				) || null
+			)
+		}
+		return null
+	}, [
+		myPersonnel,
+		canProposeForUnit,
+		requestScope,
+		selectedClassId,
+		selectedPersonnelId,
+		allPersonnel
+	])
+
+	useEffect(() => {
+		if (personnel) {
+			setRank(personnel.rank || '')
+			setUnitName(personnel.unitName || '')
+		}
+	}, [personnel])
+
+	const { data: provinces = [] } = useQuery({
+		queryKey: ['leave-loc-province'],
+		queryFn: () => ListLeaveLocalities({ level: 'province' })
+	})
+	const { data: wards = [] } = useQuery({
+		queryKey: ['leave-loc-ward', provinceId],
+		queryFn: () =>
+			ListLeaveLocalities({
+				level: 'ward',
+				parentId: Number(provinceId)
+			}),
+		enabled: !!provinceId
+	})
+	const objectType = personnel?.objectType
+	const canExtra =
+		leaveType === 'ANNUAL' && objectType
+			? EXTRA_ELIGIBLE.has(objectType)
+			: false
+	const canSpecial = objectType
+		? (meta?.specialEligible || ['SQ', 'QNCN', 'CNQP', 'VCQP']).includes(
+				objectType
+			)
+		: false
+	const specialMax = meta?.specialMaxDays ?? 10
+	const effectiveExtra = wantExtra && leaveType === 'ANNUAL' ? extraDays : 0
+
+	// HSQ/BS không được phép đặc biệt → tự về ANNUAL
+	useEffect(() => {
+		if (leaveType === 'SPECIAL' && objectType && !canSpecial) {
+			setLeaveType('ANNUAL')
+			toast.message('Hạ sĩ quan / binh sĩ không được nghỉ phép đặc biệt')
+		}
+	}, [leaveType, objectType, canSpecial])
+
+	const { data: computed } = useQuery({
+		queryKey: [
+			'leave-compute',
+			objectType,
+			personnel?.enlistmentDate,
+			startDate,
+			leaveType,
+			travelDays,
+			effectiveExtra,
+			specialDays
+		],
+		queryFn: () =>
+			ComputeLeaveDays({
+				objectType: objectType!,
+				enlistmentDate: personnel?.enlistmentDate,
+				startDate: startDate || null,
+				leaveType,
+				travelDays: leaveType === 'SPECIAL' ? 0 : travelDays,
+				extraDays: leaveType === 'SPECIAL' ? 0 : effectiveExtra,
+				specialDays: leaveType === 'SPECIAL' ? specialDays : undefined
+			}),
+		enabled: !!objectType && !canProposeForUnit
+	})
+
+	/** Tổng ngày dùng để auto end date (ANNUAL lấy từ API compute) */
+	const totalLeaveDays = useMemo(() => {
+		if (canProposeForUnit) return Math.max(1, manualDays)
+		if (leaveType === 'SPECIAL') return Math.max(1, specialDays)
+		if (computed?.totalDays != null && computed.totalDays > 0) {
+			return Number(computed.totalDays)
+		}
+		return 0
+	}, [
+		canProposeForUnit,
+		manualDays,
+		leaveType,
+		specialDays,
+		computed?.totalDays
+	])
+
+	/**
+	 * end = start + (totalDays − 1)  // inclusive
+	 * VD: 22/07 + 25 ngày → kết thúc 15/08
+	 */
+	const autoEndDate = useMemo(() => {
+		if (!startDate || totalLeaveDays < 1) return ''
+		const d = dayjs(startDate)
+		if (!d.isValid()) return ''
+		return d.add(totalLeaveDays - 1, 'day').format('YYYY-MM-DD')
+	}, [startDate, totalLeaveDays])
+
+	// Luôn sync endDate khi start / tổng ngày đổi
+	useEffect(() => {
+		if (leaveType !== 'ANNUAL' && leaveType !== 'SPECIAL') return
+		if (autoEndDate) {
+			setEndDate(autoEndDate)
+		} else if (!startDate) {
+			setEndDate('')
+		}
+	}, [leaveType, autoEndDate, startDate])
+
+	function handleStartDateChange(v: string) {
+		setStartDate(v)
+		const days =
+			leaveType === 'SPECIAL'
+				? Math.max(1, specialDays)
+				: computed?.totalDays != null && computed.totalDays > 0
+					? Number(computed.totalDays)
+					: 0
+		if (v && days >= 1) {
+			const d = dayjs(v)
+			if (d.isValid()) {
+				setEndDate(d.add(days - 1, 'day').format('YYYY-MM-DD'))
+			}
+		} else if (!v) {
+			setEndDate('')
+		}
+	}
+
+	const reasonOptions = useMemo(() => {
+		if (!meta) return []
+		if (extraDays === 10) return meta.extra10Reasons
+		if (extraDays === 5) return meta.extra5Reasons
+		return []
+	}, [meta, extraDays])
+
+	function toggleReason(code: string) {
+		setReasons((prev) =>
+			prev.includes(code)
+				? prev.filter((c) => c !== code)
+				: [...prev, code]
+		)
+	}
+
+	function toggleSpecialReason(code: string) {
+		setSpecialReasons((prev) =>
+			prev.includes(code)
+				? prev.filter((c) => c !== code)
+				: [...prev, code]
+		)
+	}
+
+	const createMut = useMutation({
+		mutationFn: () => {
+			if (!personnel) {
+				throw new Error('Vui lòng chọn quân nhân')
+			}
+			if (leaveType === 'SPECIAL') {
+				if (!canSpecial) {
+					throw new Error(
+						'Chỉ sỹ quan, QNCN, CNQP, VCQP được nghỉ phép đặc biệt'
+					)
+				}
+				if (!specialReasons.length) {
+					throw new Error('Vui lòng chọn lý do phép đặc biệt')
+				}
+			}
+			const localityId = wardId
+				? Number(wardId)
+				: provinceId
+					? Number(provinceId)
+					: null
+			const selectedClass = classes.find(
+				(c) => c.id === Number(selectedClassId)
+			)
+			const targets =
+				requestScope === 'CLASS'
+					? allPersonnel.filter(
+							(p) => p.classId === Number(selectedClassId)
+						)
+					: [personnel]
+			if (!targets.length) {
+				throw new Error('Lớp chưa có quân nhân')
+			}
+			const common = {
+				leaveType,
+				manualDays: canProposeForUnit ? manualDays : undefined,
+				rank: rank || null,
+				unitName: unitName || null,
+				travelDays: leaveType === 'SPECIAL' ? 0 : travelDays,
+				extraDays: leaveType === 'SPECIAL' ? 0 : effectiveExtra,
+				extraReasons:
+					leaveType === 'SPECIAL'
+						? specialReasons
+						: effectiveExtra > 0
+							? reasons
+							: [],
+				specialDays: leaveType === 'SPECIAL' ? specialDays : undefined,
+				localityId: canProposeForUnit ? null : localityId,
+				localityDetail: canProposeForUnit
+					? null
+					: addressDetail.trim() || null,
+				startDate: startDate || null,
+				endDate: endDate || autoEndDate || null,
+				note: proposalReason || null
+			}
+			return Promise.all(
+				targets.map((target) =>
+					CreateLeaveRequest({
+						...common,
+						requestScope,
+						classId:
+							requestScope === 'CLASS'
+								? Number(selectedClassId)
+								: target.classId,
+						className:
+							requestScope === 'CLASS'
+								? selectedClass?.name || null
+								: target.className,
+						personnelId: target.id,
+						objectType: target.objectType,
+						rank: target.rank || null,
+						unitId: target.unitId,
+						unitName: target.unitName || null
+					})
+				)
+			)
+		},
+		onSuccess: () => {
+			toast.success(
+				'Đã gửi đề xuất — chỉ huy CQ / CQQL sẽ thấy trong «Duyệt đề xuất»'
+			)
+			qc.invalidateQueries({ queryKey: ['leave-requests'] })
+			setWantExtra(false)
+			setExtraDays(0)
+			setReasons([])
+			setSpecialReasons([])
+			setSpecialDays(specialMax)
+			setNote('')
+			setAddressDetail('')
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	if (loadingP || (canProposeForUnit && loadingAll)) {
+		return (
+			<div className='flex justify-center p-12'>
+				<Loader2 className='h-6 w-6 animate-spin' />
+			</div>
+		)
+	}
+
+	// Không phải admin và chưa liên kết hồ sơ
+	if (!personnel && !canProposeForUnit) {
+		return (
+			<div className='space-y-4'>
+				<h2 className='text-2xl font-bold tracking-tight'>
+					Đề xuất nghỉ phép
+				</h2>
+				<Card>
+					<CardContent className='p-6 text-muted-foreground'>
+						Tài khoản chưa được liên kết hồ sơ quân nhân. Quản trị
+						viên cần gán tài khoản cho quân nhân trong{' '}
+						<strong>Danh sách quân nhân</strong> (hoặc tạo user rồi
+						liên kết) để bạn có thể đề xuất phép.
+					</CardContent>
+				</Card>
+			</div>
+		)
+	}
+
+	const objectLabel = personnel
+		? meta?.objectTypes.find((o) => o.code === personnel.objectType)
+				?.label || personnel.objectType
+		: ''
+	const isClassProposal = canProposeForUnit && requestScope === 'CLASS'
+	const selectedClass = classes.find((c) => c.id === Number(selectedClassId))
+	const proposalReason = canProposeForUnit
+		? isClassProposal
+			? 'Nghỉ hè'
+			: otherReason.trim()
+		: note.trim()
+
+	return (
+		<div className='space-y-6'>
+			<div>
+				<h2 className='text-2xl font-bold tracking-tight'>
+					Đề xuất nghỉ phép
+				</h2>
+				{personnel && myPersonnel && (
+					<p className='text-sm text-muted-foreground'>
+						{personnel.fullName} ({personnel.code}) — đối tượng cố
+						định
+					</p>
+				)}
+				{canProposeForUnit && (
+					<p className='text-sm text-muted-foreground'>
+						Chọn đề xuất riêng cho một cá nhân hoặc cho cả lớp
+					</p>
+				)}
+			</div>
+
+			{/* Admin / chỉ huy chọn phạm vi và đối tượng được quản lý */}
+			{canProposeForUnit && (
+				<Card>
+					<CardHeader>
+						<CardTitle className='text-lg'>
+							Phạm vi đề xuất
+						</CardTitle>
+					</CardHeader>
+					<CardContent className='space-y-4'>
+						<div className='max-w-md'>
+							<Label>Đề xuất cho *</Label>
+							<Select
+								value={requestScope}
+								onValueChange={(v) => {
+									setRequestScope(v as 'INDIVIDUAL' | 'CLASS')
+									setSelectedPersonnelId('')
+									setSelectedClassId('')
+								}}
+							>
+								<SelectTrigger>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value='INDIVIDUAL'>
+										Một cá nhân
+									</SelectItem>
+									<SelectItem value='CLASS'>
+										Cả lớp
+									</SelectItem>
+								</SelectContent>
+							</Select>
+						</div>
+						{allPersonnel.length === 0 ? (
+							<p className='text-sm text-muted-foreground'>
+								Chưa có quân nhân trong danh sách — thêm ở menu
+								Danh sách quân nhân trước.
+							</p>
+						) : (
+							<div className='max-w-md'>
+								{requestScope === 'INDIVIDUAL' ? (
+									<>
+										<Label>Quân nhân *</Label>
+										<Select
+											value={selectedPersonnelId}
+											onValueChange={
+												setSelectedPersonnelId
+											}
+										>
+											<SelectTrigger>
+												<SelectValue placeholder='Chọn người đề xuất phép…' />
+											</SelectTrigger>
+											<SelectContent>
+												{allPersonnel.map((p) => (
+													<SelectItem
+														key={p.id}
+														value={String(p.id)}
+													>
+														{p.fullName} ({p.code})
+														{p.unitName
+															? ` — ${p.unitName}`
+															: ''}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+									</>
+								) : (
+									<>
+										<Label>Lớp *</Label>
+										<Select
+											value={selectedClassId}
+											onValueChange={setSelectedClassId}
+										>
+											<SelectTrigger>
+												<SelectValue placeholder='Chọn lớp nghỉ phép…' />
+											</SelectTrigger>
+											<SelectContent>
+												{classes
+													.filter((c) =>
+														allPersonnel.some(
+															(p) =>
+																p.classId ===
+																c.id
+														)
+													)
+													.map((c) => (
+														<SelectItem
+															key={c.id}
+															value={String(c.id)}
+														>
+															{c.name} —{' '}
+															{c.unitName}
+														</SelectItem>
+													))}
+											</SelectContent>
+										</Select>
+									</>
+								)}
+							</div>
+						)}
+					</CardContent>
+				</Card>
+			)}
+
+			{personnel && (
+				<Card>
+					<CardHeader>
+						<CardTitle className='text-lg'>
+							Thông tin đề xuất
+						</CardTitle>
+					</CardHeader>
+					<CardContent className='grid gap-4 md:grid-cols-2'>
+						<div>
+							<Label>Đối tượng</Label>
+							<Input
+								value={
+									isClassProposal
+										? `Lớp ${selectedClass?.name || '—'}`
+										: objectLabel
+								}
+								disabled
+							/>
+						</div>
+						<div className={canProposeForUnit ? 'hidden' : ''}>
+							<Label>Loại phép</Label>
+							<Select
+								value={leaveType}
+								onValueChange={(v) => {
+									const t = v as 'ANNUAL' | 'SPECIAL'
+									setLeaveType(t)
+									if (t === 'SPECIAL') {
+										setWantExtra(false)
+										setExtraDays(0)
+										setReasons([])
+										setTravelDays(0)
+									} else {
+										setSpecialReasons([])
+									}
+								}}
+							>
+								<SelectTrigger>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value='ANNUAL'>
+										Phép hằng năm
+									</SelectItem>
+									<SelectItem
+										value='SPECIAL'
+										disabled={!canSpecial}
+									>
+										Phép đặc biệt
+										{!canSpecial
+											? ' (không áp dụng HSQBS/HV)'
+											: ''}
+									</SelectItem>
+								</SelectContent>
+							</Select>
+						</div>
+						{canProposeForUnit && (
+							<div className='md:col-span-2'>
+								<Label>Lý do *</Label>
+								{isClassProposal ? (
+									<Input value='Nghỉ hè' disabled />
+								) : (
+									<Input
+										value={otherReason}
+										onChange={(e) =>
+											setOtherReason(e.target.value)
+										}
+										placeholder='Nhập lý do phép khác…'
+									/>
+								)}
+							</div>
+						)}
+						<div className={isClassProposal ? 'hidden' : ''}>
+							<Label>Họ tên</Label>
+							<Input
+								value={personnel.fullName}
+								disabled
+								readOnly
+								className='bg-muted/40'
+							/>
+						</div>
+						<div className={isClassProposal ? 'hidden' : ''}>
+							<Label>Ngày nhập ngũ / tuyển dụng</Label>
+							<Input
+								value={
+									personnel.enlistmentDate
+										? dayjs(
+												personnel.enlistmentDate
+											).format('DD/MM/YYYY')
+										: personnel.recruitment || '—'
+								}
+								disabled
+								readOnly
+								className='bg-muted/40'
+							/>
+						</div>
+						<div className={isClassProposal ? 'hidden' : ''}>
+							<Label>Cấp bậc</Label>
+							<Input
+								value={rank || '—'}
+								disabled
+								readOnly
+								className='bg-muted/40'
+							/>
+						</div>
+						<div>
+							<Label>Chức vụ</Label>
+							<Input
+								value={personnel.position || '—'}
+								disabled
+								readOnly
+								className='bg-muted/40'
+							/>
+						</div>
+						<div>
+							<Label>Đơn vị</Label>
+							<Input
+								value={unitName || '—'}
+								disabled
+								readOnly
+								className='bg-muted/40'
+							/>
+						</div>
+						{!isClassProposal &&
+							leaveType === 'ANNUAL' &&
+							computed && (
+								<div>
+									<Label>
+										Thâm niên (năm) / Ngày phép cơ bản
+									</Label>
+									<Input
+										value={`${computed.serviceYears} năm → ${computed.baseDays} ngày`}
+										disabled
+										readOnly
+										className='bg-muted/40'
+									/>
+									<p className='mt-1 text-xs text-muted-foreground'>
+										Tự tính theo đối tượng + thâm niên tại
+										ngày bắt đầu nghỉ (hoặc hôm nay nếu chưa
+										chọn ngày).
+									</p>
+								</div>
+							)}
+						{canProposeForUnit && (
+							<div>
+								<Label>Số ngày nghỉ *</Label>
+								<Input
+									type='number'
+									min={1}
+									max={365}
+									value={manualDays}
+									onChange={(e) =>
+										setManualDays(
+											Math.min(
+												365,
+												Math.max(
+													1,
+													Number(e.target.value) || 1
+												)
+											)
+										)
+									}
+								/>
+								<p className='mt-1 text-xs text-muted-foreground'>
+									Đại đội nhập trực tiếp, không tính theo thâm
+									niên.
+								</p>
+							</div>
+						)}
+						{leaveType === 'ANNUAL' && !canProposeForUnit && (
+							<div>
+								<Label>Ngày đi đường</Label>
+								<Input
+									type='number'
+									min={0}
+									value={travelDays}
+									onChange={(e) =>
+										setTravelDays(
+											Math.max(
+												0,
+												Number(e.target.value) || 0
+											)
+										)
+									}
+								/>
+							</div>
+						)}
+						{leaveType === 'SPECIAL' && !canProposeForUnit && (
+							<div>
+								<Label>
+									Số ngày phép đặc biệt (tối đa {specialMax})
+								</Label>
+								<Input
+									type='number'
+									min={1}
+									max={specialMax}
+									value={specialDays}
+									onChange={(e) => {
+										const n = Number(e.target.value) || 1
+										setSpecialDays(
+											Math.min(specialMax, Math.max(1, n))
+										)
+									}}
+								/>
+							</div>
+						)}
+						<div>
+							<Label>Ngày bắt đầu</Label>
+							<DateInput
+								value={startDate}
+								onChange={handleStartDateChange}
+								placeholder='Chọn ngày bắt đầu'
+							/>
+						</div>
+						<div>
+							<Label>Ngày kết thúc</Label>
+							{/* Chỉ hiển thị — không cho chọn / sửa */}
+							<div
+								className='flex h-10 w-full items-center rounded-md border border-input bg-muted/50 px-3 text-sm text-muted-foreground'
+								aria-readonly
+							>
+								{endDate || autoEndDate
+									? dayjs(endDate || autoEndDate).format(
+											'DD/MM/YYYY'
+										)
+									: startDate
+										? 'Đang tính…'
+										: 'Tự cập nhật khi chọn ngày bắt đầu'}
+							</div>
+							{startDate && totalLeaveDays > 0 && (
+								<p className='mt-1 text-xs text-muted-foreground'>
+									Tự động = bắt đầu + {totalLeaveDays} ngày
+									nghỉ
+									{leaveType === 'ANNUAL' && computed
+										? ` (cơ bản ${computed.baseDays}${computed.travelDays ? ` + đi đường ${computed.travelDays}` : ''}${computed.extraDays ? ` + thêm ${computed.extraDays}` : ''})`
+										: ''}
+									. Không chỉnh tay.
+								</p>
+							)}
+						</div>
+
+						{!canProposeForUnit && (
+							<div className='md:col-span-2 grid gap-3 md:grid-cols-2'>
+								<div>
+									<Label>Tỉnh / Thành phố</Label>
+									<Select
+										value={provinceId}
+										onValueChange={(v) => {
+											setProvinceId(v)
+											setWardId('')
+										}}
+									>
+										<SelectTrigger>
+											<SelectValue placeholder='Chọn tỉnh / thành phố' />
+										</SelectTrigger>
+										<SelectContent>
+											{provinces.map(
+												(p: LeaveLocality) => (
+													<SelectItem
+														key={p.id}
+														value={String(p.id)}
+													>
+														{p.name}
+													</SelectItem>
+												)
+											)}
+										</SelectContent>
+									</Select>
+								</div>
+								<div>
+									<Label>Xã / Phường</Label>
+									<Select
+										value={wardId}
+										onValueChange={setWardId}
+										disabled={!provinceId}
+									>
+										<SelectTrigger>
+											<SelectValue placeholder='Chọn xã / phường' />
+										</SelectTrigger>
+										<SelectContent>
+											{wards.map((p) => (
+												<SelectItem
+													key={p.id}
+													value={String(p.id)}
+												>
+													{p.name}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</div>
+								<div className='md:col-span-2'>
+									<Label>Địa chỉ cụ thể</Label>
+									<Input
+										value={addressDetail}
+										onChange={(e) =>
+											setAddressDetail(e.target.value)
+										}
+										placeholder='Số nhà, đường, tổ, thôn…'
+									/>
+								</div>
+							</div>
+						)}
+
+						{leaveType === 'SPECIAL' && canSpecial && (
+							<div className='md:col-span-2 space-y-3 rounded-md border border-amber-500/30 bg-amber-500/5 p-4'>
+								<p className='text-sm font-medium'>
+									Lý do phép đặc biệt (chọn ít nhất 1) *
+								</p>
+								<p className='text-xs text-muted-foreground'>
+									Mỗi lần không quá {specialMax} ngày. Chỉ áp
+									dụng quân nhân, công nhân, viên chức QP.
+								</p>
+								<div className='space-y-3'>
+									{(meta?.specialReasons || []).map((r) => (
+										<label
+											key={r.code}
+											className='flex items-start gap-2 text-sm'
+										>
+											<Checkbox
+												checked={specialReasons.includes(
+													r.code
+												)}
+												onCheckedChange={() =>
+													toggleSpecialReason(r.code)
+												}
+											/>
+											<span>{r.label}</span>
+										</label>
+									))}
+								</div>
+							</div>
+						)}
+
+						{canExtra &&
+							leaveType === 'ANNUAL' &&
+							!canProposeForUnit && (
+								<div className='md:col-span-2 space-y-3 rounded-md border p-4'>
+									<div className='flex items-center gap-2'>
+										<Checkbox
+											id='wantExtra'
+											checked={wantExtra}
+											onCheckedChange={(c) => {
+												setWantExtra(!!c)
+												if (!c) {
+													setExtraDays(0)
+													setReasons([])
+												} else {
+													setExtraDays(10)
+												}
+											}}
+										/>
+										<Label
+											htmlFor='wantExtra'
+											className='cursor-pointer'
+										>
+											Nghỉ thêm
+										</Label>
+									</div>
+									{wantExtra && (
+										<>
+											<div className='flex flex-wrap gap-4'>
+												<label className='flex items-center gap-2 text-sm'>
+													<input
+														type='radio'
+														name='extraDays'
+														checked={
+															extraDays === 10
+														}
+														onChange={() => {
+															setExtraDays(10)
+															setReasons([])
+														}}
+													/>
+													Nghỉ thêm 10 ngày
+												</label>
+												<label className='flex items-center gap-2 text-sm'>
+													<input
+														type='radio'
+														name='extraDays'
+														checked={
+															extraDays === 5
+														}
+														onChange={() => {
+															setExtraDays(5)
+															setReasons([])
+														}}
+													/>
+													Nghỉ thêm 5 ngày
+												</label>
+											</div>
+											<div className='space-y-2'>
+												<p className='text-sm font-medium'>
+													Lý do (chọn ít nhất 1):
+												</p>
+												{reasonOptions.map((r) => (
+													<label
+														key={r.code}
+														className='flex items-start gap-2 text-sm'
+													>
+														<Checkbox
+															checked={reasons.includes(
+																r.code
+															)}
+															onCheckedChange={() =>
+																toggleReason(
+																	r.code
+																)
+															}
+														/>
+														<span>{r.label}</span>
+													</label>
+												))}
+											</div>
+										</>
+									)}
+								</div>
+							)}
+
+						<div
+							className={
+								canProposeForUnit ? 'hidden' : 'md:col-span-2'
+							}
+						>
+							<Label>Ghi chú</Label>
+							<Textarea
+								value={note}
+								onChange={(e) => setNote(e.target.value)}
+								rows={2}
+							/>
+						</div>
+
+						{computed && (
+							<div className='md:col-span-2 flex flex-wrap gap-3 rounded-md bg-muted/50 p-4 text-sm'>
+								<span>
+									Thâm niên:{' '}
+									<strong>{computed.serviceYears} năm</strong>
+								</span>
+								<span>
+									Phép cơ bản:{' '}
+									<strong>{computed.baseDays} ngày</strong>
+								</span>
+								<span>
+									Đi đường:{' '}
+									<strong>{computed.travelDays} ngày</strong>
+								</span>
+								<span>
+									Nghỉ thêm:{' '}
+									<strong>{computed.extraDays} ngày</strong>
+								</span>
+								<span>
+									Tổng:{' '}
+									<strong className='text-base'>
+										{computed.totalDays} ngày
+									</strong>
+								</span>
+							</div>
+						)}
+
+						<div className='md:col-span-2'>
+							<Button
+								disabled={
+									createMut.isPending ||
+									!personnel ||
+									(canProposeForUnit && !proposalReason) ||
+									(leaveType === 'SPECIAL' &&
+										specialReasons.length === 0) ||
+									(leaveType === 'ANNUAL' &&
+										wantExtra &&
+										(extraDays === 0 ||
+											reasons.length === 0))
+								}
+								onClick={() => createMut.mutate()}
+							>
+								{createMut.isPending ? (
+									<Loader2 className='mr-1 h-4 w-4 animate-spin' />
+								) : (
+									<Send className='mr-1 h-4 w-4' />
+								)}
+								Gửi đề xuất
+							</Button>
+						</div>
+					</CardContent>
+				</Card>
+			)}
+
+			<div>
+				<h3 className='mb-2 text-lg font-semibold'>Đơn của tôi</h3>
+				<div className='rounded-md border'>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Quân nhân</TableHead>
+								<TableHead>Loại</TableHead>
+								<TableHead>Tổng ngày</TableHead>
+								<TableHead>Nơi nghỉ</TableHead>
+								<TableHead>Trạng thái</TableHead>
+								<TableHead>Ngày tạo</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{myRequests.length === 0 && (
+								<TableRow>
+									<TableCell
+										colSpan={6}
+										className='text-center text-muted-foreground'
+									>
+										Chưa có đơn
+									</TableCell>
+								</TableRow>
+							)}
+							{myRequests.map((r) => (
+								<TableRow key={r.id}>
+									<TableCell>
+										{r.personnelName || '—'}
+									</TableCell>
+									<TableCell>
+										{r.leaveType === 'ANNUAL'
+											? 'Hằng năm'
+											: 'Đặc biệt'}
+									</TableCell>
+									<TableCell>{r.totalDays}</TableCell>
+									<TableCell className='max-w-[200px] truncate'>
+										{r.localityPath || '—'}
+									</TableCell>
+									<TableCell>
+										<Badge variant='secondary'>
+											{r.status}
+										</Badge>
+									</TableCell>
+									<TableCell className='text-sm text-muted-foreground'>
+										{r.createdAt?.slice(0, 10)}
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/apps/web/src/components/leave-management/LeaveRequestForm.tsx
+++ b/apps/web/src/components/leave-management/LeaveRequestForm.tsx
@@ -73,6 +73,10 @@ export default function LeaveRequestForm() {
 		queryKey: ['leave-classes', 'for-propose'],
 		queryFn: () => ListLeaveClasses()
 	})
+	const managedStudents = useMemo(
+		() => allPersonnel.filter((p) => p.classId != null),
+		[allPersonnel]
+	)
 	const { data: meta } = useQuery({
 		queryKey: ['leave-meta'],
 		queryFn: GetLeaveMeta
@@ -83,10 +87,13 @@ export default function LeaveRequestForm() {
 	})
 
 	const [selectedPersonnelId, setSelectedPersonnelId] = useState<string>('')
-	const [requestScope, setRequestScope] = useState<'INDIVIDUAL' | 'CLASS'>(
-		'INDIVIDUAL'
-	)
+	type RequestScope = 'INDIVIDUAL' | 'CLASS' | 'SHORT_LEAVE'
+	const [requestScope, setRequestScope] = useState<RequestScope>('INDIVIDUAL')
 	const [selectedClassId, setSelectedClassId] = useState('')
+	const [selectedTargetIds, setSelectedTargetIds] = useState<number[]>([])
+	const [targetLocations, setTargetLocations] = useState<
+		Record<number, string>
+	>({})
 	const [leaveType, setLeaveType] = useState<'ANNUAL' | 'SPECIAL'>('ANNUAL')
 	const [rank, setRank] = useState('')
 	const [unitName, setUnitName] = useState('')
@@ -117,6 +124,13 @@ export default function LeaveRequestForm() {
 				) || null
 			)
 		}
+		if (requestScope === 'SHORT_LEAVE') {
+			return (
+				managedStudents.find((p) => selectedTargetIds.includes(p.id)) ||
+				managedStudents[0] ||
+				null
+			)
+		}
 		if (canProposeForUnit && selectedPersonnelId) {
 			return (
 				allPersonnel.find(
@@ -131,7 +145,9 @@ export default function LeaveRequestForm() {
 		requestScope,
 		selectedClassId,
 		selectedPersonnelId,
-		allPersonnel
+		selectedTargetIds,
+		allPersonnel,
+		managedStudents
 	])
 
 	useEffect(() => {
@@ -305,9 +321,20 @@ export default function LeaveRequestForm() {
 					? allPersonnel.filter(
 							(p) => p.classId === Number(selectedClassId)
 						)
-					: [personnel]
+					: requestScope === 'SHORT_LEAVE'
+						? managedStudents.filter((p) =>
+								selectedTargetIds.includes(p.id)
+							)
+						: [personnel]
 			if (!targets.length) {
-				throw new Error('Lớp chưa có quân nhân')
+				throw new Error(
+					requestScope === 'SHORT_LEAVE'
+						? 'Vui lòng tích chọn ít nhất một học viên'
+						: 'Lớp chưa có quân nhân'
+				)
+			}
+			if (canProposeForUnit && !proposalReason) {
+				throw new Error('Vui lòng nhập lý do')
 			}
 			const common = {
 				leaveType,
@@ -324,9 +351,6 @@ export default function LeaveRequestForm() {
 							: [],
 				specialDays: leaveType === 'SPECIAL' ? specialDays : undefined,
 				localityId: canProposeForUnit ? null : localityId,
-				localityDetail: canProposeForUnit
-					? null
-					: addressDetail.trim() || null,
 				startDate: startDate || null,
 				endDate: endDate || autoEndDate || null,
 				note: proposalReason || null
@@ -335,6 +359,14 @@ export default function LeaveRequestForm() {
 				targets.map((target) =>
 					CreateLeaveRequest({
 						...common,
+						localityDetail: canProposeForUnit
+							? requestScope === 'INDIVIDUAL'
+								? addressDetail.trim() || null
+								: targetLocations[target.id]?.trim() ||
+									target.permanentResidence ||
+									target.hometown ||
+									null
+							: addressDetail.trim() || null,
 						requestScope,
 						classId:
 							requestScope === 'CLASS'
@@ -364,7 +396,10 @@ export default function LeaveRequestForm() {
 			setSpecialReasons([])
 			setSpecialDays(specialMax)
 			setNote('')
+			setOtherReason('')
 			setAddressDetail('')
+			setSelectedTargetIds([])
+			setTargetLocations({})
 		},
 		onError: (e: Error) => toast.error(e.message)
 	})
@@ -401,6 +436,9 @@ export default function LeaveRequestForm() {
 				?.label || personnel.objectType
 		: ''
 	const isClassProposal = canProposeForUnit && requestScope === 'CLASS'
+	const isMultiProposal =
+		canProposeForUnit &&
+		(requestScope === 'CLASS' || requestScope === 'SHORT_LEAVE')
 	const selectedClass = classes.find((c) => c.id === Number(selectedClassId))
 	const proposalReason = canProposeForUnit
 		? isClassProposal
@@ -441,9 +479,10 @@ export default function LeaveRequestForm() {
 							<Select
 								value={requestScope}
 								onValueChange={(v) => {
-									setRequestScope(v as 'INDIVIDUAL' | 'CLASS')
+									setRequestScope(v as RequestScope)
 									setSelectedPersonnelId('')
 									setSelectedClassId('')
+									setSelectedTargetIds([])
 								}}
 							>
 								<SelectTrigger>
@@ -455,6 +494,9 @@ export default function LeaveRequestForm() {
 									</SelectItem>
 									<SelectItem value='CLASS'>
 										Cả lớp
+									</SelectItem>
+									<SelectItem value='SHORT_LEAVE'>
+										Tranh thủ
 									</SelectItem>
 								</SelectContent>
 							</Select>
@@ -493,7 +535,7 @@ export default function LeaveRequestForm() {
 											</SelectContent>
 										</Select>
 									</>
-								) : (
+								) : requestScope === 'CLASS' ? (
 									<>
 										<Label>Lớp *</Label>
 										<Select
@@ -524,6 +566,16 @@ export default function LeaveRequestForm() {
 											</SelectContent>
 										</Select>
 									</>
+								) : (
+									<div className='space-y-2'>
+										<Label>
+											Học viên được phép đi tranh thủ *
+										</Label>
+										<p className='text-xs text-muted-foreground'>
+											Tích chọn trong toàn bộ học viên
+											thuộc các lớp đại đội quản lý.
+										</p>
+									</div>
 								)}
 							</div>
 						)}
@@ -597,12 +649,16 @@ export default function LeaveRequestForm() {
 										onChange={(e) =>
 											setOtherReason(e.target.value)
 										}
-										placeholder='Nhập lý do phép khác…'
+										placeholder={
+											requestScope === 'SHORT_LEAVE'
+												? 'Nhập lý do đi tranh thủ…'
+												: 'Nhập lý do phép khác…'
+										}
 									/>
 								)}
 							</div>
 						)}
-						<div className={isClassProposal ? 'hidden' : ''}>
+						<div className={isMultiProposal ? 'hidden' : ''}>
 							<Label>Họ tên</Label>
 							<Input
 								value={personnel.fullName}
@@ -611,7 +667,7 @@ export default function LeaveRequestForm() {
 								className='bg-muted/40'
 							/>
 						</div>
-						<div className={isClassProposal ? 'hidden' : ''}>
+						<div className={isMultiProposal ? 'hidden' : ''}>
 							<Label>Ngày nhập ngũ / tuyển dụng</Label>
 							<Input
 								value={
@@ -626,7 +682,7 @@ export default function LeaveRequestForm() {
 								className='bg-muted/40'
 							/>
 						</div>
-						<div className={isClassProposal ? 'hidden' : ''}>
+						<div className={isMultiProposal ? 'hidden' : ''}>
 							<Label>Cấp bậc</Label>
 							<Input
 								value={rank || '—'}
@@ -830,6 +886,145 @@ export default function LeaveRequestForm() {
 										}
 										placeholder='Số nhà, đường, tổ, thôn…'
 									/>
+								</div>
+							</div>
+						)}
+
+						{canProposeForUnit && requestScope === 'INDIVIDUAL' && (
+							<div className='md:col-span-2'>
+								<Label>Nơi nghỉ</Label>
+								<Input
+									value={addressDetail}
+									onChange={(e) =>
+										setAddressDetail(e.target.value)
+									}
+									placeholder={
+										personnel.permanentResidence ||
+										personnel.hometown ||
+										'Nhập nơi nghỉ…'
+									}
+								/>
+							</div>
+						)}
+
+						{canProposeForUnit && isMultiProposal && (
+							<div className='md:col-span-2 space-y-2'>
+								<Label>
+									{requestScope === 'SHORT_LEAVE'
+										? 'Danh sách học viên đi tranh thủ'
+										: 'Nơi nghỉ của học viên trong lớp'}
+								</Label>
+								<div className='max-h-96 overflow-auto rounded-md border'>
+									<Table>
+										<TableHeader>
+											<TableRow>
+												{requestScope ===
+													'SHORT_LEAVE' && (
+													<TableHead className='w-12'>
+														Chọn
+													</TableHead>
+												)}
+												<TableHead>Học viên</TableHead>
+												<TableHead>Lớp</TableHead>
+												<TableHead>Nơi nghỉ</TableHead>
+											</TableRow>
+										</TableHeader>
+										<TableBody>
+											{managedStudents
+												.filter(
+													(p) =>
+														requestScope ===
+															'SHORT_LEAVE' ||
+														p.classId ===
+															Number(
+																selectedClassId
+															)
+												)
+												.map((p) => {
+													const checked =
+														requestScope ===
+															'CLASS' ||
+														selectedTargetIds.includes(
+															p.id
+														)
+													return (
+														<TableRow key={p.id}>
+															{requestScope ===
+																'SHORT_LEAVE' && (
+																<TableCell>
+																	<Checkbox
+																		checked={
+																			checked
+																		}
+																		onCheckedChange={(
+																			value
+																		) =>
+																			setSelectedTargetIds(
+																				(
+																					prev
+																				) =>
+																					value
+																						? [
+																								...prev,
+																								p.id
+																							]
+																						: prev.filter(
+																								(
+																									id
+																								) =>
+																									id !==
+																									p.id
+																							)
+																			)
+																		}
+																	/>
+																</TableCell>
+															)}
+															<TableCell>
+																{p.fullName}
+																<span className='block text-xs text-muted-foreground'>
+																	{p.code}
+																</span>
+															</TableCell>
+															<TableCell>
+																{p.className ||
+																	'—'}
+															</TableCell>
+															<TableCell>
+																<Input
+																	disabled={
+																		!checked
+																	}
+																	value={
+																		targetLocations[
+																			p.id
+																		] ??
+																		p.permanentResidence ??
+																		p.hometown ??
+																		''
+																	}
+																	onChange={(
+																		e
+																	) =>
+																		setTargetLocations(
+																			(
+																				prev
+																			) => ({
+																				...prev,
+																				[p.id]: e
+																					.target
+																					.value
+																			})
+																		)
+																	}
+																	placeholder='Nhập nơi nghỉ…'
+																/>
+															</TableCell>
+														</TableRow>
+													)
+												})}
+										</TableBody>
+									</Table>
 								</div>
 							</div>
 						)}

--- a/apps/web/src/components/leave-management/LocalitiesPage.tsx
+++ b/apps/web/src/components/leave-management/LocalitiesPage.tsx
@@ -1,0 +1,507 @@
+import { useMemo, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+	ChevronRight,
+	Loader2,
+	MapPin,
+	Plus,
+	Search,
+	Trash2,
+	Upload
+} from 'lucide-react'
+import { toast } from 'sonner'
+import {
+	CreateLeaveLocality,
+	DeleteLeaveLocality,
+	ListLeaveLocalities,
+	type LeaveLocality,
+	type LeaveLocalityLevel
+} from '@/api/leave'
+import ImportLocalitiesDialog from './ImportLocalitiesDialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle
+} from '@/components/ui/dialog'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue
+} from '@/components/ui/select'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+import { ScrollArea } from '@/components/ui/scroll-area'
+
+const LEVEL_LABEL: Record<LeaveLocalityLevel, string> = {
+	province: 'Tỉnh / TP',
+	ward: 'Xã / Phường',
+	village: 'Thôn'
+}
+
+export default function LocalitiesPage() {
+	const qc = useQueryClient()
+	const [open, setOpen] = useState(false)
+	const [importOpen, setImportOpen] = useState(false)
+	const [name, setName] = useState('')
+	const [level, setLevel] = useState<LeaveLocalityLevel>('province')
+	const [parentId, setParentId] = useState<string>('')
+	const [selectedProvinceId, setSelectedProvinceId] = useState<number | null>(
+		null
+	)
+	const [provinceSearch, setProvinceSearch] = useState('')
+	const [wardSearch, setWardSearch] = useState('')
+
+	const { data: tree = [], isLoading } = useQuery({
+		queryKey: ['leave-localities-tree'],
+		queryFn: () => ListLeaveLocalities({ tree: true })
+	})
+
+	const provinces = useMemo(() => {
+		const list = tree.filter((n) => n.level === 'province')
+		const q = provinceSearch.trim().toLowerCase()
+		if (!q) return list
+		return list.filter(
+			(p) =>
+				p.name.toLowerCase().includes(q) ||
+				(p.code || '').toLowerCase().includes(q)
+		)
+	}, [tree, provinceSearch])
+
+	const selectedProvince = useMemo(
+		() => tree.find((p) => p.id === selectedProvinceId) || null,
+		[tree, selectedProvinceId]
+	)
+
+	const wards = useMemo(() => {
+		const kids = selectedProvince?.children || []
+		const q = wardSearch.trim().toLowerCase()
+		if (!q) return kids
+		return kids.filter(
+			(w) =>
+				w.name.toLowerCase().includes(q) ||
+				(w.code || '').toLowerCase().includes(q)
+		)
+	}, [selectedProvince, wardSearch])
+
+	const totalWards = useMemo(
+		() =>
+			tree.reduce(
+				(acc, p) =>
+					acc +
+					(p.children?.filter((c) => c.level === 'ward').length || 0),
+				0
+			),
+		[tree]
+	)
+
+	const parentOptions = useMemo(() => {
+		if (level === 'ward') return tree.filter((n) => n.level === 'province')
+		if (level === 'village') {
+			const out: LeaveLocality[] = []
+			for (const p of tree) {
+				for (const w of p.children || []) {
+					if (w.level === 'ward') out.push(w)
+				}
+			}
+			return out
+		}
+		return []
+	}, [tree, level])
+
+	const createMut = useMutation({
+		mutationFn: () =>
+			CreateLeaveLocality({
+				name: name.trim(),
+				level,
+				parentId:
+					level === 'province'
+						? null
+						: parentId
+							? Number(parentId)
+							: null
+			}),
+		onSuccess: () => {
+			toast.success('Đã thêm địa phương')
+			qc.invalidateQueries({ queryKey: ['leave-localities-tree'] })
+			setOpen(false)
+			setName('')
+			setParentId('')
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	const delMut = useMutation({
+		mutationFn: (id: number) => DeleteLeaveLocality(id),
+		onSuccess: () => {
+			toast.success('Đã xóa')
+			qc.invalidateQueries({ queryKey: ['leave-localities-tree'] })
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	return (
+		<div className='space-y-4'>
+			<div className='flex flex-wrap items-end justify-between gap-3'>
+				<div>
+					<h2 className='text-2xl font-bold tracking-tight'>
+						Danh sách địa phương
+					</h2>
+					<p className='text-sm text-muted-foreground'>
+						Cây Tỉnh/Thành phố → Xã/Phường
+						{!isLoading && (
+							<>
+								{' '}
+								· {tree.length} tỉnh/TP · {totalWards} xã/phường
+							</>
+						)}
+					</p>
+				</div>
+				<div className='flex gap-2'>
+					<Button
+						variant='outline'
+						onClick={() => setImportOpen(true)}
+					>
+						<Upload className='mr-1 h-4 w-4' />
+						Import xã/phường
+					</Button>
+					<Button onClick={() => setOpen(true)}>
+						<Plus className='mr-1 h-4 w-4' />
+						Thêm
+					</Button>
+				</div>
+			</div>
+
+			<div className='grid min-h-[480px] gap-4 md:grid-cols-[320px_1fr]'>
+				{/* Province list */}
+				<div className='flex flex-col rounded-md border'>
+					<div className='border-b p-3'>
+						<div className='relative'>
+							<Search className='absolute top-2.5 left-2.5 h-4 w-4 text-muted-foreground' />
+							<Input
+								className='pl-8'
+								placeholder='Tìm tỉnh / thành phố…'
+								value={provinceSearch}
+								onChange={(e) =>
+									setProvinceSearch(e.target.value)
+								}
+							/>
+						</div>
+					</div>
+					<ScrollArea className='h-[440px]'>
+						{isLoading && (
+							<div className='flex justify-center p-8'>
+								<Loader2 className='h-5 w-5 animate-spin' />
+							</div>
+						)}
+						{!isLoading && provinces.length === 0 && (
+							<p className='p-4 text-center text-sm text-muted-foreground'>
+								Chưa có tỉnh/TP — import file 3321 xã/phường
+							</p>
+						)}
+						<ul className='p-1'>
+							{provinces.map((p) => {
+								const count = p.children?.length || 0
+								const active = selectedProvinceId === p.id
+								return (
+									<li key={p.id}>
+										<button
+											type='button'
+											onClick={() => {
+												setSelectedProvinceId(p.id)
+												setWardSearch('')
+											}}
+											className={cn(
+												'flex w-full items-center gap-2 rounded-md px-3 py-2.5 text-left text-sm transition-colors',
+												active
+													? 'bg-primary text-primary-foreground'
+													: 'hover:bg-muted'
+											)}
+										>
+											<MapPin className='h-4 w-4 shrink-0 opacity-70' />
+											<span className='min-w-0 flex-1 truncate font-medium'>
+												{p.name}
+											</span>
+											{p.code && (
+												<span
+													className={cn(
+														'font-mono text-xs',
+														active
+															? 'opacity-80'
+															: 'text-muted-foreground'
+													)}
+												>
+													{p.code}
+												</span>
+											)}
+											<Badge
+												variant={
+													active
+														? 'secondary'
+														: 'outline'
+												}
+												className='shrink-0'
+											>
+												{count}
+											</Badge>
+											<ChevronRight className='h-4 w-4 shrink-0 opacity-60' />
+										</button>
+									</li>
+								)
+							})}
+						</ul>
+					</ScrollArea>
+				</div>
+
+				{/* Detail: wards of selected province */}
+				<div className='flex flex-col rounded-md border'>
+					{!selectedProvince ? (
+						<div className='flex flex-1 flex-col items-center justify-center gap-2 p-8 text-muted-foreground'>
+							<MapPin className='h-10 w-10 opacity-40' />
+							<p className='text-sm'>
+								Chọn một tỉnh / thành phố bên trái để xem danh
+								sách xã / phường
+							</p>
+						</div>
+					) : (
+						<>
+							<div className='space-y-2 border-b p-4'>
+								<div className='flex flex-wrap items-start justify-between gap-2'>
+									<div>
+										<h3 className='text-lg font-semibold'>
+											{selectedProvince.name}
+										</h3>
+										<p className='text-sm text-muted-foreground'>
+											Gồm{' '}
+											<strong>
+												{selectedProvince.children
+													?.length || 0}
+											</strong>{' '}
+											xã / phường / đặc khu
+											{selectedProvince.code
+												? ` · Mã TP: ${selectedProvince.code}`
+												: ''}
+										</p>
+									</div>
+									<Button
+										size='sm'
+										variant='ghost'
+										className='text-destructive'
+										onClick={() => {
+											if (
+												confirm(
+													`Xóa ${selectedProvince.name}? (cần xóa hết xã con trước)`
+												)
+											) {
+												delMut.mutate(
+													selectedProvince.id,
+													{
+														onSuccess: () =>
+															setSelectedProvinceId(
+																null
+															)
+													}
+												)
+											}
+										}}
+									>
+										<Trash2 className='mr-1 h-4 w-4' />
+										Xóa tỉnh
+									</Button>
+								</div>
+								<div className='relative'>
+									<Search className='absolute top-2.5 left-2.5 h-4 w-4 text-muted-foreground' />
+									<Input
+										className='pl-8'
+										placeholder='Lọc xã / phường…'
+										value={wardSearch}
+										onChange={(e) =>
+											setWardSearch(e.target.value)
+										}
+									/>
+								</div>
+							</div>
+							<ScrollArea className='h-[380px]'>
+								{wards.length === 0 ? (
+									<p className='p-6 text-center text-sm text-muted-foreground'>
+										Không có xã/phường
+										{wardSearch ? ' khớp tìm kiếm' : ''}
+									</p>
+								) : (
+									<table className='w-full text-sm'>
+										<thead className='sticky top-0 bg-background'>
+											<tr className='border-b text-left text-muted-foreground'>
+												<th className='px-4 py-2 font-medium'>
+													Mã
+												</th>
+												<th className='px-4 py-2 font-medium'>
+													Tên
+												</th>
+												<th className='px-4 py-2 font-medium'>
+													Cấp
+												</th>
+												<th className='w-12 px-2' />
+											</tr>
+										</thead>
+										<tbody>
+											{wards.map((w) => (
+												<tr
+													key={w.id}
+													className='border-b last:border-0 hover:bg-muted/40'
+												>
+													<td className='px-4 py-2 font-mono text-xs'>
+														{w.code || '—'}
+													</td>
+													<td className='px-4 py-2'>
+														{w.name}
+														{(w.children?.length ||
+															0) > 0 && (
+															<span className='ml-2 text-xs text-muted-foreground'>
+																(
+																{
+																	w.children!
+																		.length
+																}{' '}
+																thôn)
+															</span>
+														)}
+													</td>
+													<td className='px-4 py-2'>
+														<Badge variant='outline'>
+															{LEVEL_LABEL[
+																w.level
+															] || w.level}
+														</Badge>
+													</td>
+													<td className='px-2 py-1'>
+														<Button
+															size='icon'
+															variant='ghost'
+															onClick={() => {
+																if (
+																	confirm(
+																		`Xóa ${w.name}?`
+																	)
+																)
+																	delMut.mutate(
+																		w.id
+																	)
+															}}
+														>
+															<Trash2 className='h-4 w-4 text-destructive' />
+														</Button>
+													</td>
+												</tr>
+											))}
+										</tbody>
+									</table>
+								)}
+							</ScrollArea>
+						</>
+					)}
+				</div>
+			</div>
+
+			<Dialog open={open} onOpenChange={setOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Thêm địa phương</DialogTitle>
+					</DialogHeader>
+					<div className='grid gap-3 py-2'>
+						<div>
+							<Label>Cấp</Label>
+							<Select
+								value={level}
+								onValueChange={(v) => {
+									setLevel(v as LeaveLocalityLevel)
+									setParentId('')
+								}}
+							>
+								<SelectTrigger>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value='province'>
+										Tỉnh / Thành phố
+									</SelectItem>
+									<SelectItem value='ward'>
+										Xã / Phường
+									</SelectItem>
+									<SelectItem value='village'>
+										Thôn
+									</SelectItem>
+								</SelectContent>
+							</Select>
+						</div>
+						{level !== 'province' && (
+							<div>
+								<Label>
+									{level === 'ward'
+										? 'Thuộc tỉnh / TP'
+										: 'Thuộc xã/phường'}
+								</Label>
+								<Select
+									value={parentId}
+									onValueChange={setParentId}
+								>
+									<SelectTrigger>
+										<SelectValue placeholder='Chọn…' />
+									</SelectTrigger>
+									<SelectContent>
+										{parentOptions.map((p) => (
+											<SelectItem
+												key={p.id}
+												value={String(p.id)}
+											>
+												{p.name}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
+						)}
+						<div>
+							<Label>Tên</Label>
+							<Input
+								value={name}
+								onChange={(e) => setName(e.target.value)}
+							/>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button
+							variant='outline'
+							onClick={() => setOpen(false)}
+						>
+							Hủy
+						</Button>
+						<Button
+							disabled={
+								createMut.isPending ||
+								!name.trim() ||
+								(level !== 'province' && !parentId)
+							}
+							onClick={() => createMut.mutate()}
+						>
+							{createMut.isPending && (
+								<Loader2 className='mr-1 h-4 w-4 animate-spin' />
+							)}
+							Lưu
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<ImportLocalitiesDialog
+				open={importOpen}
+				onOpenChange={setImportOpen}
+			/>
+		</div>
+	)
+}

--- a/apps/web/src/components/leave-management/LocalityPicker.tsx
+++ b/apps/web/src/components/leave-management/LocalityPicker.tsx
@@ -1,0 +1,167 @@
+import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Check, ChevronsUpDown, X } from 'lucide-react'
+import { ListLeaveLocalities, type LeaveLocality } from '@/api/leave'
+import { Button } from '@/components/ui/button'
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList
+} from '@/components/ui/command'
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger
+} from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
+
+export interface LocalityOption {
+	/** Giá trị lưu: "Xã A, Tỉnh B" */
+	path: string
+	wardName: string
+	provinceName: string
+	wardId: number
+	provinceId: number
+}
+
+function buildOptions(tree: LeaveLocality[]): LocalityOption[] {
+	const out: LocalityOption[] = []
+	for (const province of tree) {
+		if (province.level !== 'province') continue
+		const wards = province.children || []
+		if (!wards.length) {
+			// province-only selectable
+			out.push({
+				path: province.name,
+				wardName: '',
+				provinceName: province.name,
+				wardId: 0,
+				provinceId: province.id
+			})
+			continue
+		}
+		for (const ward of wards) {
+			out.push({
+				path: `${ward.name}, ${province.name}`,
+				wardName: ward.name,
+				provinceName: province.name,
+				wardId: ward.id,
+				provinceId: province.id
+			})
+		}
+	}
+	return out
+}
+
+interface Props {
+	value: string
+	onChange: (path: string) => void
+	placeholder?: string
+	disabled?: boolean
+}
+
+export default function LocalityPicker({
+	value,
+	onChange,
+	placeholder = 'Chọn xã/phường…',
+	disabled
+}: Props) {
+	const [open, setOpen] = useState(false)
+	const { data: tree = [], isLoading } = useQuery({
+		queryKey: ['leave-localities-tree'],
+		queryFn: () => ListLeaveLocalities({ tree: true })
+	})
+
+	const options = useMemo(() => buildOptions(tree), [tree])
+
+	return (
+		<div className='flex gap-1'>
+			<Popover open={open} onOpenChange={setOpen}>
+				<PopoverTrigger asChild>
+					<Button
+						type='button'
+						variant='outline'
+						role='combobox'
+						aria-expanded={open}
+						disabled={disabled || isLoading}
+						className='w-full justify-between font-normal'
+					>
+						<span
+							className={cn(
+								'truncate',
+								!value && 'text-muted-foreground'
+							)}
+						>
+							{value ||
+								(isLoading
+									? 'Đang tải địa phương…'
+									: placeholder)}
+						</span>
+						<ChevronsUpDown className='ml-2 h-4 w-4 shrink-0 opacity-50' />
+					</Button>
+				</PopoverTrigger>
+				<PopoverContent
+					className='w-[var(--radix-popover-trigger-width)] p-0'
+					align='start'
+				>
+					<Command>
+						<CommandInput placeholder='Tìm tỉnh / xã / phường…' />
+						<CommandList>
+							<CommandEmpty>
+								{options.length === 0
+									? 'Chưa có địa phương — hãy import danh sách xã'
+									: 'Không tìm thấy'}
+							</CommandEmpty>
+							<CommandGroup>
+								{options.map((o) => (
+									<CommandItem
+										key={`${o.provinceId}-${o.wardId}-${o.path}`}
+										value={`${o.wardName} ${o.provinceName} ${o.path}`}
+										onSelect={() => {
+											onChange(o.path)
+											setOpen(false)
+										}}
+									>
+										<Check
+											className={cn(
+												'mr-2 h-4 w-4',
+												value === o.path
+													? 'opacity-100'
+													: 'opacity-0'
+											)}
+										/>
+										<div className='flex min-w-0 flex-col'>
+											<span className='truncate'>
+												{o.wardName || o.provinceName}
+											</span>
+											{o.wardName && (
+												<span className='truncate text-xs text-muted-foreground'>
+													{o.provinceName}
+												</span>
+											)}
+										</div>
+									</CommandItem>
+								))}
+							</CommandGroup>
+						</CommandList>
+					</Command>
+				</PopoverContent>
+			</Popover>
+			{value ? (
+				<Button
+					type='button'
+					variant='ghost'
+					size='icon'
+					className='shrink-0'
+					onClick={() => onChange('')}
+					title='Xóa'
+				>
+					<X className='h-4 w-4' />
+				</Button>
+			) : null}
+		</div>
+	)
+}

--- a/apps/web/src/components/leave-management/PersonnelPage.tsx
+++ b/apps/web/src/components/leave-management/PersonnelPage.tsx
@@ -1,0 +1,712 @@
+import { useMemo, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Loader2, Pencil, Plus, Trash2, Upload } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+	CreateLeavePersonnel,
+	DeleteLeavePersonnel,
+	GetLeaveMeta,
+	ListLeavePersonnel,
+	ListLeavePositions,
+	ListLeaveClasses,
+	ListLeaveUnits,
+	UpdateLeavePersonnel,
+	type LeaveObjectType,
+	type LeavePersonnel
+} from '@/api/leave'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle
+} from '@/components/ui/dialog'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue
+} from '@/components/ui/select'
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow
+} from '@/components/ui/table'
+import { Badge } from '@/components/ui/badge'
+import ImportPersonnelDialog from './ImportPersonnelDialog'
+import LocalityPicker from './LocalityPicker'
+import DateInput from '@/components/date-input'
+import { rankOptions, userRankOptions } from '@/data/ethnics'
+import useUserData from '@/hooks/useUsers'
+
+/** Cấp bậc: hạ sĩ quan/binh sĩ + sĩ quan + CN */
+const RANK_OPTIONS = (() => {
+	const seen = new Set<string>()
+	const out: { label: string; value: string }[] = []
+	for (const o of [...rankOptions, ...userRankOptions]) {
+		if (seen.has(o.value)) continue
+		seen.add(o.value)
+		out.push(o)
+	}
+	return out
+})()
+
+const FALLBACK_OBJECT_TYPES: { code: LeaveObjectType; label: string }[] = [
+	{ code: 'SQ', label: 'Sỹ quan' },
+	{ code: 'QNCN', label: 'Quân nhân chuyên nghiệp' },
+	{ code: 'CNQP', label: 'Công nhân quốc phòng' },
+	{ code: 'VCQP', label: 'Viên chức quốc phòng' },
+	{ code: 'HSQBS', label: 'Hạ sỹ quan, Binh sỹ' },
+	{ code: 'HV', label: 'Học viên' },
+	{ code: 'KHAC', label: 'Đối tượng khác' }
+]
+
+const emptyForm = {
+	fullName: '',
+	enlistmentDate: '',
+	recruitment: '',
+	objectType: 'SQ' as LeaveObjectType,
+	rank: '',
+	position: '',
+	classId: '' as string,
+	unitId: '' as string,
+	unitName: '',
+	hometown: '',
+	permanentResidence: '',
+	email: '',
+	commanderUserId: '' as string
+}
+
+export default function PersonnelPage() {
+	const qc = useQueryClient()
+	const [search, setSearch] = useState('')
+	const [open, setOpen] = useState(false)
+	const [importOpen, setImportOpen] = useState(false)
+	const [editing, setEditing] = useState<LeavePersonnel | null>(null)
+	const [form, setForm] = useState(emptyForm)
+	const { data: users = [] } = useUserData()
+
+	const { data = [], isLoading } = useQuery({
+		queryKey: ['leave-personnel', search],
+		queryFn: () => ListLeavePersonnel({ search: search || undefined })
+	})
+	const { data: meta } = useQuery({
+		queryKey: ['leave-meta'],
+		queryFn: GetLeaveMeta
+	})
+	const { data: units = [] } = useQuery({
+		queryKey: ['leave-units'],
+		queryFn: () => ListLeaveUnits()
+	})
+	const { data: positions = [] } = useQuery({
+		queryKey: ['leave-positions'],
+		queryFn: () => ListLeavePositions(true)
+	})
+	const { data: classes = [] } = useQuery({
+		queryKey: ['leave-classes', form.unitId],
+		queryFn: () => ListLeaveClasses(Number(form.unitId)),
+		enabled: form.objectType === 'HV' && Boolean(form.unitId)
+	})
+	const OBJECT_TYPES = meta?.objectTypes?.length
+		? meta.objectTypes
+		: FALLBACK_OBJECT_TYPES
+
+	const saveMut = useMutation({
+		mutationFn: async () => {
+			const unitId = form.unitId ? Number(form.unitId) : null
+			const unit = units.find((u) => u.id === unitId)
+			const selectedClass = classes.find(
+				(c) => c.id === Number(form.classId)
+			)
+			// Chỉ huy CQ cố định theo đơn vị
+			const commanderId =
+				unit?.commanderUserId ??
+				(form.commanderUserId ? Number(form.commanderUserId) : null)
+			const commander = users.find((u) => u.id === commanderId)
+			const body = {
+				fullName: form.fullName.trim(),
+				enlistmentDate: form.enlistmentDate || null,
+				recruitment: form.recruitment || null,
+				objectType: form.objectType,
+				rank: form.rank || null,
+				position: form.position || null,
+				classId: form.classId ? Number(form.classId) : null,
+				className:
+					selectedClass?.name ||
+					(editing?.classId === Number(form.classId)
+						? editing.className
+						: null),
+				unitId,
+				unitName: unit?.name || form.unitName || null,
+				hometown: form.hometown || null,
+				permanentResidence: form.permanentResidence || null,
+				userId: editing?.userId ?? null,
+				email: form.email.trim() || null,
+				commanderUserId: commanderId,
+				commanderName:
+					unit?.commanderName ||
+					(commander
+						? commander.displayName || commander.username
+						: null)
+			}
+			if (editing) {
+				return UpdateLeavePersonnel(editing.id, {
+					...body,
+					code: editing.code
+				})
+			}
+			// code omitted → backend auto-generates
+			return CreateLeavePersonnel(body)
+		},
+		onSuccess: () => {
+			toast.success(editing ? 'Đã cập nhật' : 'Đã thêm quân nhân')
+			qc.invalidateQueries({ queryKey: ['leave-personnel'] })
+			setOpen(false)
+			setEditing(null)
+			setForm(emptyForm)
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	const delMut = useMutation({
+		mutationFn: (id: number) => DeleteLeavePersonnel(id),
+		onSuccess: () => {
+			toast.success('Đã xóa')
+			qc.invalidateQueries({ queryKey: ['leave-personnel'] })
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	const objectLabel = useMemo(() => {
+		const m = Object.fromEntries(OBJECT_TYPES.map((o) => [o.code, o.label]))
+		return (c: string) => m[c] || c
+	}, [OBJECT_TYPES])
+
+	function openCreate() {
+		setEditing(null)
+		setForm(emptyForm)
+		setOpen(true)
+	}
+
+	function openEdit(p: LeavePersonnel) {
+		setEditing(p)
+		setForm({
+			fullName: p.fullName,
+			enlistmentDate: p.enlistmentDate || '',
+			recruitment: p.recruitment || '',
+			objectType: p.objectType,
+			rank: p.rank || '',
+			position: p.position || '',
+			classId: p.classId != null ? String(p.classId) : '',
+			unitId: p.unitId != null ? String(p.unitId) : '',
+			unitName: p.unitName || '',
+			hometown: p.hometown || '',
+			permanentResidence: p.permanentResidence || '',
+			email: p.email || '',
+			commanderUserId:
+				p.commanderUserId != null ? String(p.commanderUserId) : ''
+		})
+		setOpen(true)
+	}
+
+	return (
+		<div className='space-y-4'>
+			<div className='flex flex-wrap items-end justify-between gap-3'>
+				<div>
+					<h2 className='text-2xl font-bold tracking-tight'>
+						Danh sách quân nhân
+					</h2>
+					<p className='text-sm text-muted-foreground'>
+						Cập nhật email + chỉ huy cơ quan để luồng duyệt phép và
+						thông báo mail hoạt động
+					</p>
+				</div>
+				<div className='flex gap-2'>
+					<Input
+						placeholder='Tìm mã / tên…'
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						className='w-56'
+					/>
+					<Button
+						variant='outline'
+						onClick={() => setImportOpen(true)}
+					>
+						<Upload className='mr-1 h-4 w-4' />
+						Import
+					</Button>
+					<Button onClick={openCreate}>
+						<Plus className='mr-1 h-4 w-4' />
+						Thêm
+					</Button>
+				</div>
+			</div>
+
+			<div className='rounded-md border'>
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>Mã</TableHead>
+							<TableHead>Tên</TableHead>
+							<TableHead>Nhập ngũ</TableHead>
+							<TableHead>Tuyển dụng</TableHead>
+							<TableHead>Đối tượng</TableHead>
+							<TableHead>Cấp bậc</TableHead>
+							<TableHead>Chức vụ</TableHead>
+							<TableHead>Lớp</TableHead>
+							<TableHead>Đơn vị</TableHead>
+							<TableHead>Quê quán</TableHead>
+							<TableHead>Thường trú</TableHead>
+							<TableHead>Email</TableHead>
+							<TableHead>Cơ quan quản lý</TableHead>
+							<TableHead>Chỉ huy CQ</TableHead>
+							<TableHead className='w-24' />
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{isLoading && (
+							<TableRow>
+								<TableCell colSpan={15} className='text-center'>
+									<Loader2 className='mx-auto h-5 w-5 animate-spin' />
+								</TableCell>
+							</TableRow>
+						)}
+						{!isLoading && data.length === 0 && (
+							<TableRow>
+								<TableCell
+									colSpan={15}
+									className='text-center text-muted-foreground'
+								>
+									Chưa có dữ liệu
+								</TableCell>
+							</TableRow>
+						)}
+						{data.map((p) => (
+							<TableRow key={p.id}>
+								<TableCell className='font-mono text-sm'>
+									{p.code}
+								</TableCell>
+								<TableCell>{p.fullName}</TableCell>
+								<TableCell>{p.enlistmentDate || '—'}</TableCell>
+								<TableCell>{p.recruitment || '—'}</TableCell>
+								<TableCell>
+									<Badge variant='secondary'>
+										{objectLabel(p.objectType)}
+									</Badge>
+								</TableCell>
+								<TableCell>{p.rank || '—'}</TableCell>
+								<TableCell>{p.position || '—'}</TableCell>
+								<TableCell>{p.className || '—'}</TableCell>
+								<TableCell>{p.unitName || '—'}</TableCell>
+								<TableCell className='max-w-[150px] truncate text-sm'>
+									{p.hometown || '—'}
+								</TableCell>
+								<TableCell className='max-w-[150px] truncate text-sm'>
+									{p.permanentResidence || '—'}
+								</TableCell>
+								<TableCell className='max-w-[140px] truncate text-sm'>
+									{p.email || '—'}
+								</TableCell>
+								<TableCell>
+									{p.managementArea === 'quân_lực'
+										? 'Quân lực'
+										: 'Cán bộ'}
+								</TableCell>
+								<TableCell className='max-w-[140px] truncate text-sm'>
+									{p.commanderName || '—'}
+								</TableCell>
+								<TableCell>
+									<div className='flex gap-1'>
+										<Button
+											size='icon'
+											variant='ghost'
+											onClick={() => openEdit(p)}
+										>
+											<Pencil className='h-4 w-4' />
+										</Button>
+										<Button
+											size='icon'
+											variant='ghost'
+											onClick={() => {
+												if (
+													confirm(
+														`Xóa ${p.fullName}?`
+													)
+												)
+													delMut.mutate(p.id)
+											}}
+										>
+											<Trash2 className='h-4 w-4 text-destructive' />
+										</Button>
+									</div>
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+			</div>
+
+			<Dialog open={open} onOpenChange={setOpen}>
+				<DialogContent className='flex !h-auto max-h-[90vh] max-w-lg flex-col overflow-hidden p-0'>
+					<DialogHeader className='shrink-0 border-b px-6 py-4'>
+						<DialogTitle>
+							{editing ? 'Sửa quân nhân' : 'Thêm quân nhân'}
+						</DialogTitle>
+					</DialogHeader>
+					<div className='grid flex-1 gap-3 overflow-y-auto overscroll-contain px-6 py-4'>
+						{editing && (
+							<div>
+								<Label>Mã</Label>
+								<Input value={editing.code} disabled />
+								<p className='mt-1 text-xs text-muted-foreground'>
+									Mã do hệ thống sinh, không chỉnh sửa
+								</p>
+							</div>
+						)}
+						{!editing && (
+							<p className='text-xs text-muted-foreground'>
+								Mã quân nhân sẽ được hệ thống tự sinh khi lưu
+								(dạng QN-000001).
+							</p>
+						)}
+						<div>
+							<Label>Tên *</Label>
+							<Input
+								value={form.fullName}
+								onChange={(e) =>
+									setForm((f) => ({
+										...f,
+										fullName: e.target.value
+									}))
+								}
+							/>
+						</div>
+						<div className='grid grid-cols-2 gap-3'>
+							<div>
+								<Label>Ngày nhập ngũ</Label>
+								<DateInput
+									value={form.enlistmentDate}
+									onChange={(v) =>
+										setForm((f) => ({
+											...f,
+											enlistmentDate: v
+										}))
+									}
+									placeholder='Chọn ngày nhập ngũ'
+								/>
+							</div>
+							<div>
+								<Label>Tuyển dụng</Label>
+								<Input
+									value={form.recruitment}
+									onChange={(e) =>
+										setForm((f) => ({
+											...f,
+											recruitment: e.target.value
+										}))
+									}
+								/>
+							</div>
+						</div>
+						<div>
+							<Label>Đối tượng *</Label>
+							<Select
+								value={form.objectType}
+								onValueChange={(v) =>
+									setForm((f) => ({
+										...f,
+										objectType: v as LeaveObjectType,
+										classId: v === 'HV' ? f.classId : ''
+									}))
+								}
+							>
+								<SelectTrigger>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{OBJECT_TYPES.map((o) => (
+										<SelectItem key={o.code} value={o.code}>
+											{o.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+						<div className='grid grid-cols-2 gap-3'>
+							<div>
+								<Label>Cấp bậc</Label>
+								<Select
+									value={form.rank || undefined}
+									onValueChange={(v) =>
+										setForm((f) => ({
+											...f,
+											rank: v
+										}))
+									}
+								>
+									<SelectTrigger>
+										<SelectValue placeholder='Chọn cấp bậc' />
+									</SelectTrigger>
+									<SelectContent>
+										{/* allow clearing via re-select if value not in list */}
+										{form.rank &&
+											!RANK_OPTIONS.some(
+												(o) => o.value === form.rank
+											) && (
+												<SelectItem value={form.rank}>
+													{form.rank}
+												</SelectItem>
+											)}
+										{RANK_OPTIONS.map((o) => (
+											<SelectItem
+												key={o.value}
+												value={o.value}
+											>
+												{o.label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
+							<div>
+								<Label>Chức vụ</Label>
+								<Select
+									value={form.position || undefined}
+									onValueChange={(v) =>
+										setForm((f) => ({
+											...f,
+											position: v
+										}))
+									}
+								>
+									<SelectTrigger>
+										<SelectValue placeholder='Chọn chức vụ' />
+									</SelectTrigger>
+									<SelectContent>
+										{form.position &&
+											!positions.some(
+												(p) => p.name === form.position
+											) && (
+												<SelectItem
+													value={form.position}
+												>
+													{form.position} (dữ liệu cũ)
+												</SelectItem>
+											)}
+										{positions.map((p) => (
+											<SelectItem
+												key={p.id}
+												value={p.name}
+											>
+												{p.name}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
+						</div>
+						<div>
+							<Label>Đơn vị (danh mục)</Label>
+							<Select
+								value={form.unitId || undefined}
+								onValueChange={(v) => {
+									const u = units.find(
+										(x) => x.id === Number(v)
+									)
+									setForm((f) => ({
+										...f,
+										unitId: v,
+										classId: '',
+										unitName: u?.name || f.unitName,
+										// Chỉ huy CQ cố định theo đơn vị
+										commanderUserId:
+											u?.commanderUserId != null
+												? String(u.commanderUserId)
+												: ''
+									}))
+								}}
+							>
+								<SelectTrigger>
+									<SelectValue placeholder='Chọn đơn vị từ danh mục…' />
+								</SelectTrigger>
+								<SelectContent>
+									{units.map((u) => (
+										<SelectItem
+											key={u.id}
+											value={String(u.id)}
+										>
+											{u.name}
+											{u.code ? ` (${u.code})` : ''}
+											{u.commanderName
+												? ` — CH: ${u.commanderName}`
+												: ''}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+							<p className='mt-1 text-xs text-muted-foreground'>
+								Quản lý danh mục + gán chỉ huy tại «Danh mục đơn
+								vị».
+							</p>
+						</div>
+						{form.objectType === 'HV' && (
+							<div>
+								<Label>Lớp</Label>
+								<Select
+									value={form.classId || undefined}
+									onValueChange={(v) =>
+										setForm((f) => ({
+											...f,
+											classId: v
+										}))
+									}
+									disabled={!form.unitId}
+								>
+									<SelectTrigger>
+										<SelectValue
+											placeholder={
+												form.unitId
+													? 'Chọn lớp…'
+													: 'Chọn đơn vị trước'
+											}
+										/>
+									</SelectTrigger>
+									<SelectContent>
+										{classes
+											.filter((c) => c.isActive)
+											.map((c) => (
+												<SelectItem
+													key={c.id}
+													value={String(c.id)}
+												>
+													{c.name}
+												</SelectItem>
+											))}
+									</SelectContent>
+								</Select>
+								{form.unitId && classes.length === 0 && (
+									<p className='mt-1 text-xs text-muted-foreground'>
+										Đơn vị này chưa có lớp trong danh mục.
+									</p>
+								)}
+							</div>
+						)}
+						<div>
+							<Label>Quê quán</Label>
+							<LocalityPicker
+								value={form.hometown}
+								onChange={(v) =>
+									setForm((f) => ({ ...f, hometown: v }))
+								}
+								placeholder='Chọn xã/phường quê quán…'
+							/>
+						</div>
+						<div>
+							<Label>Thường trú</Label>
+							<LocalityPicker
+								value={form.permanentResidence}
+								onChange={(v) =>
+									setForm((f) => ({
+										...f,
+										permanentResidence: v
+									}))
+								}
+								placeholder='Chọn xã/phường thường trú…'
+							/>
+						</div>
+						<div>
+							<Label>
+								Email (nhận thông báo duyệt / trả đơn)
+							</Label>
+							<Input
+								type='email'
+								placeholder='email@example.com'
+								value={form.email}
+								onChange={(e) =>
+									setForm((f) => ({
+										...f,
+										email: e.target.value
+									}))
+								}
+							/>
+						</div>
+						<div>
+							<Label>Chỉ huy cơ quan (theo đơn vị)</Label>
+							<Input
+								value={
+									form.commanderUserId
+										? (() => {
+												const u = users.find(
+													(x) =>
+														x.id ===
+														Number(
+															form.commanderUserId
+														)
+												)
+												const unit = units.find(
+													(x) =>
+														String(x.id) ===
+														form.unitId
+												)
+												return (
+													u
+														? `${u.displayName || u.username}`
+														: unit?.commanderName ||
+															'—'
+												) as string
+											})()
+										: form.unitId
+											? units.find(
+													(x) =>
+														String(x.id) ===
+														form.unitId
+												)?.commanderName ||
+												'Đơn vị chưa gán chỉ huy'
+											: 'Chọn đơn vị trước'
+								}
+								disabled
+								readOnly
+								className='bg-muted/40'
+							/>
+							<p className='mt-1 text-xs text-muted-foreground'>
+								Cố định theo đơn vị — không chọn tay. Gán chỉ
+								huy tại «Danh mục đơn vị».
+							</p>
+						</div>
+					</div>
+					<DialogFooter className='shrink-0 border-t px-6 py-4'>
+						<Button
+							variant='outline'
+							onClick={() => setOpen(false)}
+						>
+							Hủy
+						</Button>
+						<Button
+							disabled={
+								saveMut.isPending || !form.fullName.trim()
+							}
+							onClick={() => saveMut.mutate()}
+						>
+							{saveMut.isPending && (
+								<Loader2 className='mr-1 h-4 w-4 animate-spin' />
+							)}
+							Lưu
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<ImportPersonnelDialog
+				open={importOpen}
+				onOpenChange={setImportOpen}
+			/>
+		</div>
+	)
+}

--- a/apps/web/src/components/leave-management/PersonnelPreviewDialog.tsx
+++ b/apps/web/src/components/leave-management/PersonnelPreviewDialog.tsx
@@ -1,0 +1,65 @@
+import { useQuery } from '@tanstack/react-query'
+import { GetLeavePersonnel } from '@/api/leave'
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle
+} from '@/components/ui/dialog'
+
+export default function PersonnelPreviewDialog({
+	personnelId,
+	fallbackName,
+	onClose
+}: {
+	personnelId: number
+	fallbackName?: string | null
+	onClose: () => void
+}) {
+	const { data, isLoading } = useQuery({
+		queryKey: ['leave-personnel', personnelId],
+		queryFn: () => GetLeavePersonnel(personnelId)
+	})
+
+	const rows = data
+		? [
+				['Mã quân nhân', data.code],
+				['Họ tên', data.fullName],
+				['Đối tượng', data.objectType],
+				['Cấp bậc', data.rank],
+				['Chức vụ', data.position],
+				['Đơn vị', data.unitName],
+				['Ngày nhập ngũ', data.enlistmentDate],
+				['Email', data.email]
+			]
+		: []
+
+	return (
+		<Dialog open onOpenChange={(open) => !open && onClose()}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>
+						Thông tin quân nhân:{' '}
+						{data?.fullName || fallbackName || personnelId}
+					</DialogTitle>
+				</DialogHeader>
+				{isLoading ? (
+					<p className='text-sm text-muted-foreground'>Đang tải...</p>
+				) : (
+					<div className='grid grid-cols-2 gap-x-4 gap-y-3 text-sm'>
+						{rows.map(([label, value]) => (
+							<div key={label}>
+								<div className='text-muted-foreground'>
+									{label}
+								</div>
+								<div className='font-medium'>
+									{value || '—'}
+								</div>
+							</div>
+						))}
+					</div>
+				)}
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/apps/web/src/components/leave-management/PositionsPage.tsx
+++ b/apps/web/src/components/leave-management/PositionsPage.tsx
@@ -1,0 +1,210 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Pencil, Plus, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+	CreateLeavePosition,
+	DeleteLeavePosition,
+	ListLeavePositions,
+	UpdateLeavePosition,
+	type LeavePosition
+} from '@/api/leave'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow
+} from '@/components/ui/table'
+
+const emptyForm = { name: '', sortOrder: 1, isActive: true }
+
+export default function PositionsPage() {
+	const qc = useQueryClient()
+	const [open, setOpen] = useState(false)
+	const [editing, setEditing] = useState<LeavePosition | null>(null)
+	const [form, setForm] = useState(emptyForm)
+	const { data = [], isLoading } = useQuery({
+		queryKey: ['leave-positions'],
+		queryFn: () => ListLeavePositions(false)
+	})
+	const save = useMutation({
+		mutationFn: () =>
+			editing
+				? UpdateLeavePosition(editing.id, form)
+				: CreateLeavePosition(form),
+		onSuccess: () => {
+			toast.success(editing ? 'Đã cập nhật chức vụ' : 'Đã thêm chức vụ')
+			setOpen(false)
+			qc.invalidateQueries({ queryKey: ['leave-positions'] })
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+	const remove = useMutation({
+		mutationFn: DeleteLeavePosition,
+		onSuccess: () => {
+			toast.success('Đã xóa chức vụ')
+			qc.invalidateQueries({ queryKey: ['leave-positions'] })
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+	const showCreate = () => {
+		setEditing(null)
+		setForm(emptyForm)
+		setOpen(true)
+	}
+	const showEdit = (p: LeavePosition) => {
+		setEditing(p)
+		setForm({ name: p.name, sortOrder: p.sortOrder, isActive: p.isActive })
+		setOpen(true)
+	}
+
+	return (
+		<div className='space-y-4'>
+			<div className='flex items-center justify-between'>
+				<div>
+					<h2 className='text-2xl font-bold'>Danh mục chức vụ</h2>
+					<p className='text-sm text-muted-foreground'>
+						Quản lý các chức vụ sử dụng trong hồ sơ quân nhân.
+					</p>
+				</div>
+				<Button onClick={showCreate}>
+					<Plus className='mr-2 h-4 w-4' />
+					Thêm
+				</Button>
+			</div>
+			<div className='rounded-md border'>
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>STT</TableHead>
+							<TableHead>Tên chức vụ</TableHead>
+							<TableHead>Thứ tự</TableHead>
+							<TableHead>Trạng thái</TableHead>
+							<TableHead className='w-28' />
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{isLoading ? (
+							<TableRow>
+								<TableCell colSpan={5}>Đang tải...</TableCell>
+							</TableRow>
+						) : data.length === 0 ? (
+							<TableRow>
+								<TableCell colSpan={5} className='text-center'>
+									Chưa có chức vụ
+								</TableCell>
+							</TableRow>
+						) : (
+							data.map((p, i) => (
+								<TableRow key={p.id}>
+									<TableCell>{i + 1}</TableCell>
+									<TableCell className='font-medium'>
+										{p.name}
+									</TableCell>
+									<TableCell>{p.sortOrder}</TableCell>
+									<TableCell>
+										<Badge
+											variant={
+												p.isActive
+													? 'default'
+													: 'secondary'
+											}
+										>
+											{p.isActive ? 'Đang dùng' : 'Đã ẩn'}
+										</Badge>
+									</TableCell>
+									<TableCell>
+										<Button
+											size='icon'
+											variant='ghost'
+											onClick={() => showEdit(p)}
+										>
+											<Pencil className='h-4 w-4' />
+										</Button>
+										<Button
+											size='icon'
+											variant='ghost'
+											onClick={() => remove.mutate(p.id)}
+										>
+											<Trash2 className='h-4 w-4' />
+										</Button>
+									</TableCell>
+								</TableRow>
+							))
+						)}
+					</TableBody>
+				</Table>
+			</div>
+			<Dialog open={open} onOpenChange={setOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>
+							{editing ? 'Sửa chức vụ' : 'Thêm chức vụ'}
+						</DialogTitle>
+					</DialogHeader>
+					<div className='space-y-4 py-2'>
+						<div>
+							<Label>Tên chức vụ</Label>
+							<Input
+								value={form.name}
+								onChange={(e) =>
+									setForm({ ...form, name: e.target.value })
+								}
+							/>
+						</div>
+						<div>
+							<Label>Thứ tự</Label>
+							<Input
+								type='number'
+								value={form.sortOrder}
+								onChange={(e) =>
+									setForm({
+										...form,
+										sortOrder: Number(e.target.value)
+									})
+								}
+							/>
+						</div>
+						<label className='flex items-center gap-2'>
+							<Checkbox
+								checked={form.isActive}
+								onCheckedChange={(v) =>
+									setForm({ ...form, isActive: v === true })
+								}
+							/>
+							Đang sử dụng
+						</label>
+					</div>
+					<DialogFooter>
+						<Button
+							variant='outline'
+							onClick={() => setOpen(false)}
+						>
+							Hủy
+						</Button>
+						<Button
+							disabled={!form.name.trim() || save.isPending}
+							onClick={() => save.mutate()}
+						>
+							Lưu
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</div>
+	)
+}

--- a/apps/web/src/components/leave-management/RecordsPage.tsx
+++ b/apps/web/src/components/leave-management/RecordsPage.tsx
@@ -1,0 +1,213 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Loader2, Printer } from 'lucide-react'
+import dayjs from 'dayjs'
+import { toast } from 'sonner'
+import {
+	ListLeaveRecords,
+	type LeaveRecord,
+	type LeaveRequest
+} from '@/api/leave'
+import { printLeaveCertificate } from '@/components/leave-management/printLeaveCertificate'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow
+} from '@/components/ui/table'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue
+} from '@/components/ui/select'
+
+export default function RecordsPage() {
+	const [search, setSearch] = useState('')
+	const [year, setYear] = useState<string>('all')
+	const [leaveType, setLeaveType] = useState<string>('all')
+
+	const { data = [], isLoading } = useQuery({
+		queryKey: ['leave-records', search, year, leaveType],
+		queryFn: () =>
+			ListLeaveRecords({
+				search: search || undefined,
+				year: year !== 'all' ? Number(year) : undefined,
+				leaveType: leaveType !== 'all' ? leaveType : undefined
+			})
+	})
+
+	const years = (() => {
+		const y = new Date().getFullYear()
+		return Array.from({ length: 6 }, (_, i) => y - i)
+	})()
+
+	return (
+		<div className='space-y-4'>
+			<div>
+				<h2 className='text-2xl font-bold tracking-tight'>
+					Lưu trữ nghỉ phép
+				</h2>
+				<p className='text-sm text-muted-foreground'>
+					Bản ghi được đẩy vào khi đơn được ký duyệt — phục vụ tra cứu
+				</p>
+			</div>
+
+			<div className='flex flex-wrap gap-2'>
+				<Input
+					placeholder='Tìm tên / mã / đơn vị / nơi nghỉ…'
+					value={search}
+					onChange={(e) => setSearch(e.target.value)}
+					className='w-64'
+				/>
+				<Select value={year} onValueChange={setYear}>
+					<SelectTrigger className='w-36'>
+						<SelectValue placeholder='Năm' />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value='all'>Mọi năm</SelectItem>
+						{years.map((y) => (
+							<SelectItem key={y} value={String(y)}>
+								{y}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+				<Select value={leaveType} onValueChange={setLeaveType}>
+					<SelectTrigger className='w-40'>
+						<SelectValue placeholder='Loại phép' />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value='all'>Mọi loại</SelectItem>
+						<SelectItem value='ANNUAL'>Hằng năm</SelectItem>
+						<SelectItem value='SPECIAL'>Đặc biệt</SelectItem>
+					</SelectContent>
+				</Select>
+			</div>
+
+			<div className='rounded-md border'>
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>Mã QN</TableHead>
+							<TableHead>Họ tên / Lớp</TableHead>
+							<TableHead>Đối tượng</TableHead>
+							<TableHead>Đơn vị</TableHead>
+							<TableHead>Loại</TableHead>
+							<TableHead>Từ ngày</TableHead>
+							<TableHead>Đến ngày</TableHead>
+							<TableHead>Số ngày</TableHead>
+							<TableHead>Nơi nghỉ</TableHead>
+							<TableHead>Duyệt lúc</TableHead>
+							<TableHead className='w-20' />
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{isLoading && (
+							<TableRow>
+								<TableCell colSpan={11} className='text-center'>
+									<Loader2 className='mx-auto h-5 w-5 animate-spin' />
+								</TableCell>
+							</TableRow>
+						)}
+						{!isLoading && data.length === 0 && (
+							<TableRow>
+								<TableCell
+									colSpan={11}
+									className='text-center text-muted-foreground'
+								>
+									Chưa có bản ghi lưu trữ (chỉ có sau khi ký
+									duyệt)
+								</TableCell>
+							</TableRow>
+						)}
+						{data.map((r: LeaveRecord) => (
+							<TableRow key={r.id}>
+								<TableCell className='font-mono text-sm'>
+									{r.personnelCode || '—'}
+								</TableCell>
+								<TableCell>
+									{r.requestScope === 'CLASS'
+										? `${r.className || r.personnelName || 'Lớp'} (${r.memberCount} học viên)`
+										: r.personnelName || '—'}
+								</TableCell>
+								<TableCell>
+									<Badge variant='secondary'>
+										{r.objectTypeLabel}
+									</Badge>
+								</TableCell>
+								<TableCell>{r.unitName || '—'}</TableCell>
+								<TableCell>
+									{r.leaveType === 'SPECIAL'
+										? 'Đặc biệt'
+										: 'Hằng năm'}
+								</TableCell>
+								<TableCell>
+									{r.startDate
+										? dayjs(r.startDate).format(
+												'DD/MM/YYYY'
+											)
+										: '—'}
+								</TableCell>
+								<TableCell>
+									{r.endDate
+										? dayjs(r.endDate).format('DD/MM/YYYY')
+										: '—'}
+								</TableCell>
+								<TableCell className='font-medium'>
+									{r.totalDays}
+								</TableCell>
+								<TableCell className='max-w-[200px] truncate text-sm'>
+									{r.localityPath || '—'}
+								</TableCell>
+								<TableCell className='text-sm text-muted-foreground'>
+									{r.decidedAt
+										? dayjs(r.decidedAt).format(
+												'DD/MM/YYYY HH:mm'
+											)
+										: '—'}
+								</TableCell>
+								<TableCell>
+									<Button
+										size='icon'
+										variant='ghost'
+										title='Xuất giấy phép'
+										onClick={() => {
+											if (r.requestScope === 'CLASS') {
+												toast.message(
+													'Giấy phép lớp được in tại chi tiết lớp trong Danh sách phép'
+												)
+												return
+											}
+											const asReq = {
+												...r,
+												id: r.requestId,
+												status: 'APPROVED' as const,
+												proposerEmail: null,
+												commanderUserId: null,
+												commanderName: null
+											} as LeaveRequest
+											if (!printLeaveCertificate(asReq)) {
+												toast.error(
+													'Trình duyệt chặn popup in'
+												)
+											}
+										}}
+									>
+										<Printer className='h-4 w-4' />
+									</Button>
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+			</div>
+		</div>
+	)
+}

--- a/apps/web/src/components/leave-management/RegulationsPage.tsx
+++ b/apps/web/src/components/leave-management/RegulationsPage.tsx
@@ -1,0 +1,894 @@
+import { useMemo, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Loader2, Pencil, Plus, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+	CreateLeaveExtraStandard,
+	CreateLeaveObjectType,
+	CreateLeaveRegulation,
+	DeleteLeaveExtraStandard,
+	DeleteLeaveObjectType,
+	DeleteLeaveRegulation,
+	GetLeaveMeta,
+	ListLeaveExtraStandards,
+	ListLeaveObjectTypes,
+	ListLeaveRegulations,
+	UpdateLeaveExtraStandard,
+	UpdateLeaveObjectType,
+	UpdateLeaveRegulation,
+	type LeaveExtraStandard,
+	type LeaveObjectType,
+	type LeaveObjectTypeRow,
+	type LeaveRegulation
+} from '@/api/leave'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle
+} from '@/components/ui/dialog'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue
+} from '@/components/ui/select'
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow
+} from '@/components/ui/table'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { isSuperAdmin } from '@/lib/utils'
+
+function formatYears(min: number | null, max: number | null) {
+	if (min == null && max == null) return 'Không phân bậc'
+	if (min != null && max == null) return `Từ ${min} năm trở lên`
+	if (min != null && max != null) return `Từ ${min} đến dưới ${max} năm`
+	return `Dưới ${max} năm`
+}
+
+export default function RegulationsPage() {
+	const admin = isSuperAdmin()
+	const qc = useQueryClient()
+
+	const { data: regulations = [], isLoading: loadingReg } = useQuery({
+		queryKey: ['leave-regulations'],
+		queryFn: () => ListLeaveRegulations()
+	})
+	const { data: objectTypes = [], isLoading: loadingOt } = useQuery({
+		queryKey: ['leave-object-types'],
+		queryFn: () => ListLeaveObjectTypes(false)
+	})
+	const { data: extras = [], isLoading: loadingEx } = useQuery({
+		queryKey: ['leave-extra-standards'],
+		queryFn: () => ListLeaveExtraStandards({ activeOnly: false })
+	})
+	const { data: meta } = useQuery({
+		queryKey: ['leave-meta'],
+		queryFn: GetLeaveMeta
+	})
+
+	const annual = useMemo(
+		() => regulations.filter((r) => r.leaveType === 'ANNUAL'),
+		[regulations]
+	)
+	const displayedObjectTypes = useMemo<LeaveObjectTypeRow[]>(() => {
+		if (objectTypes.length) return objectTypes
+		return (meta?.objectTypes || []).map((o, index) => ({
+			id: -(index + 1),
+			createdAt: '',
+			updatedAt: '',
+			code: o.code,
+			name: o.label,
+			sortOrder: index + 1,
+			isActive: true
+		}))
+	}, [objectTypes, meta?.objectTypes])
+	const displayedExtras = useMemo<LeaveExtraStandard[]>(() => {
+		if (extras.length) return extras
+		const combined = [
+			...(meta?.extra10Reasons || []).map((e) => ({ ...e, days: 10 })),
+			...(meta?.extra5Reasons || []).map((e) => ({ ...e, days: 5 }))
+		]
+		return combined.map((e, index) => ({
+			id: -(index + 1),
+			createdAt: '',
+			updatedAt: '',
+			code: e.code,
+			label: e.label,
+			days: e.days,
+			sortOrder: index + 1,
+			isActive: true
+		}))
+	}, [extras, meta?.extra10Reasons, meta?.extra5Reasons])
+
+	// ── Object type dialog ──
+	const [otOpen, setOtOpen] = useState(false)
+	const [otEdit, setOtEdit] = useState<LeaveObjectTypeRow | null>(null)
+	const [otCode, setOtCode] = useState('')
+	const [otName, setOtName] = useState('')
+	const [otSort, setOtSort] = useState(99)
+
+	const saveOt = useMutation({
+		mutationFn: async () => {
+			if (otEdit) {
+				return UpdateLeaveObjectType(otEdit.id, {
+					name: otName.trim(),
+					sortOrder: otSort
+				})
+			}
+			return CreateLeaveObjectType({
+				code: otCode.trim().toUpperCase(),
+				name: otName.trim(),
+				sortOrder: otSort
+			})
+		},
+		onSuccess: () => {
+			toast.success(
+				otEdit ? 'Đã cập nhật đối tượng' : 'Đã thêm đối tượng'
+			)
+			qc.invalidateQueries({ queryKey: ['leave-object-types'] })
+			qc.invalidateQueries({ queryKey: ['leave-meta'] })
+			setOtOpen(false)
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	const delOt = useMutation({
+		mutationFn: (id: number) => DeleteLeaveObjectType(id),
+		onSuccess: () => {
+			toast.success('Đã xóa')
+			qc.invalidateQueries({ queryKey: ['leave-object-types'] })
+			qc.invalidateQueries({ queryKey: ['leave-meta'] })
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	// ── Extra standard dialog ──
+	const [exOpen, setExOpen] = useState(false)
+	const [exEdit, setExEdit] = useState<LeaveExtraStandard | null>(null)
+	const [exCode, setExCode] = useState('')
+	const [exLabel, setExLabel] = useState('')
+	const [exDays, setExDays] = useState<5 | 10>(10)
+	const [exSort, setExSort] = useState(99)
+
+	const saveEx = useMutation({
+		mutationFn: async () => {
+			if (exEdit) {
+				return UpdateLeaveExtraStandard(exEdit.id, {
+					label: exLabel.trim(),
+					days: exDays,
+					sortOrder: exSort
+				})
+			}
+			return CreateLeaveExtraStandard({
+				code: exCode.trim(),
+				label: exLabel.trim(),
+				days: exDays,
+				sortOrder: exSort
+			})
+		},
+		onSuccess: () => {
+			toast.success(exEdit ? 'Đã cập nhật' : 'Đã thêm tiêu chuẩn')
+			qc.invalidateQueries({ queryKey: ['leave-extra-standards'] })
+			qc.invalidateQueries({ queryKey: ['leave-meta'] })
+			setExOpen(false)
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	const delEx = useMutation({
+		mutationFn: (id: number) => DeleteLeaveExtraStandard(id),
+		onSuccess: () => {
+			toast.success('Đã xóa')
+			qc.invalidateQueries({ queryKey: ['leave-extra-standards'] })
+			qc.invalidateQueries({ queryKey: ['leave-meta'] })
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	// ── Annual regulation dialog ──
+	const [regOpen, setRegOpen] = useState(false)
+	const [regEdit, setRegEdit] = useState<LeaveRegulation | null>(null)
+	const [regOt, setRegOt] = useState('')
+	const [regMin, setRegMin] = useState('')
+	const [regMax, setRegMax] = useState('')
+	const [regDays, setRegDays] = useState('20')
+	const [regLabel, setRegLabel] = useState('')
+	const [regDesc, setRegDesc] = useState('')
+
+	const saveReg = useMutation({
+		mutationFn: async () => {
+			const baseDays = Number(regDays)
+			if (!Number.isFinite(baseDays) || baseDays < 0) {
+				throw new Error('Số ngày không hợp lệ')
+			}
+			const minYears = regMin.trim() === '' ? null : Number(regMin)
+			const maxYears = regMax.trim() === '' ? null : Number(regMax)
+			if (regEdit) {
+				return UpdateLeaveRegulation(regEdit.id, {
+					baseDays,
+					minYears,
+					maxYears,
+					label: regLabel.trim() || null,
+					description: regDesc.trim() || null
+				})
+			}
+			if (!regOt) throw new Error('Chọn đối tượng')
+			return CreateLeaveRegulation({
+				leaveType: 'ANNUAL',
+				objectType: regOt as LeaveObjectType,
+				minYears,
+				maxYears,
+				baseDays,
+				label: regLabel.trim() || null,
+				description: regDesc.trim() || null
+			})
+		},
+		onSuccess: () => {
+			toast.success(regEdit ? 'Đã cập nhật quy định' : 'Đã thêm quy định')
+			qc.invalidateQueries({ queryKey: ['leave-regulations'] })
+			setRegOpen(false)
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	const delReg = useMutation({
+		mutationFn: (id: number) => DeleteLeaveRegulation(id),
+		onSuccess: () => {
+			toast.success('Đã xóa')
+			qc.invalidateQueries({ queryKey: ['leave-regulations'] })
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	function openOtCreate() {
+		setOtEdit(null)
+		setOtCode('')
+		setOtName('')
+		setOtSort(99)
+		setOtOpen(true)
+	}
+	function openOtEdit(o: LeaveObjectTypeRow) {
+		setOtEdit(o)
+		setOtCode(o.code)
+		setOtName(o.name)
+		setOtSort(o.sortOrder)
+		setOtOpen(true)
+	}
+	function openExCreate() {
+		setExEdit(null)
+		setExCode('')
+		setExLabel('')
+		setExDays(10)
+		setExSort(99)
+		setExOpen(true)
+	}
+	function openExEdit(e: LeaveExtraStandard) {
+		setExEdit(e)
+		setExCode(e.code)
+		setExLabel(e.label)
+		setExDays(e.days === 5 ? 5 : 10)
+		setExSort(e.sortOrder)
+		setExOpen(true)
+	}
+	function openRegCreate() {
+		setRegEdit(null)
+		setRegOt(objectTypes[0]?.code || 'SQ')
+		setRegMin('0')
+		setRegMax('15')
+		setRegDays('20')
+		setRegLabel('')
+		setRegDesc('')
+		setRegOpen(true)
+	}
+	function openRegEdit(r: LeaveRegulation) {
+		setRegEdit(r)
+		setRegOt(r.objectType || '')
+		setRegMin(r.minYears != null ? String(r.minYears) : '')
+		setRegMax(r.maxYears != null ? String(r.maxYears) : '')
+		setRegDays(String(r.baseDays))
+		setRegLabel(r.label || '')
+		setRegDesc(r.description || '')
+		setRegOpen(true)
+	}
+
+	return (
+		<div className='space-y-6'>
+			<div>
+				<h2 className='text-2xl font-bold tracking-tight'>
+					Quy định về phép
+				</h2>
+				<p className='text-sm text-muted-foreground'>
+					Bảng đối tượng · Tiêu chuẩn phép hằng năm · Tiêu chuẩn phép
+					thêm · Phép đặc biệt
+				</p>
+			</div>
+
+			<Tabs defaultValue='annual'>
+				<TabsList className='flex h-auto flex-wrap gap-1'>
+					<TabsTrigger value='objects'>
+						Đối tượng ({displayedObjectTypes.length})
+					</TabsTrigger>
+					<TabsTrigger value='annual'>Phép hằng năm</TabsTrigger>
+					<TabsTrigger value='extra'>
+						Phép thêm ({displayedExtras.length})
+					</TabsTrigger>
+					<TabsTrigger value='special'>Phép đặc biệt</TabsTrigger>
+				</TabsList>
+
+				{/* ── Đối tượng ── */}
+				<TabsContent value='objects' className='space-y-3'>
+					<div className='flex items-center justify-between'>
+						<p className='text-sm text-muted-foreground'>
+							Ma_ĐT / Tên_ĐT theo quy định
+						</p>
+						{admin && (
+							<Button size='sm' onClick={openOtCreate}>
+								<Plus className='mr-1 h-4 w-4' />
+								Thêm
+							</Button>
+						)}
+					</div>
+					<div className='rounded-md border'>
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Ma_ĐT</TableHead>
+									<TableHead>Tên_ĐT</TableHead>
+									<TableHead>Thứ tự</TableHead>
+									<TableHead>TT</TableHead>
+									{admin && <TableHead className='w-24' />}
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{loadingOt && (
+									<TableRow>
+										<TableCell
+											colSpan={5}
+											className='text-center'
+										>
+											<Loader2 className='mx-auto h-5 w-5 animate-spin' />
+										</TableCell>
+									</TableRow>
+								)}
+								{displayedObjectTypes.map((o) => (
+									<TableRow key={o.id}>
+										<TableCell className='font-mono font-semibold'>
+											{o.code}
+										</TableCell>
+										<TableCell>{o.name}</TableCell>
+										<TableCell>{o.sortOrder}</TableCell>
+										<TableCell>
+											<Badge
+												variant={
+													o.isActive
+														? 'default'
+														: 'secondary'
+												}
+											>
+												{o.isActive ? 'HĐ' : 'Ẩn'}
+											</Badge>
+										</TableCell>
+										{admin && o.id > 0 && (
+											<TableCell>
+												<div className='flex gap-1'>
+													<Button
+														size='icon'
+														variant='ghost'
+														onClick={() =>
+															openOtEdit(o)
+														}
+													>
+														<Pencil className='h-4 w-4' />
+													</Button>
+													<Button
+														size='icon'
+														variant='ghost'
+														onClick={() => {
+															if (
+																confirm(
+																	`Xóa ${o.code}?`
+																)
+															)
+																delOt.mutate(
+																	o.id
+																)
+														}}
+													>
+														<Trash2 className='h-4 w-4 text-destructive' />
+													</Button>
+												</div>
+											</TableCell>
+										)}
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					</div>
+				</TabsContent>
+
+				{/* ── Phép hằng năm ── */}
+				<TabsContent value='annual' className='space-y-3'>
+					<div className='flex items-center justify-between'>
+						<p className='text-sm text-muted-foreground'>
+							Tra theo đối tượng + thâm niên → số ngày phép cơ bản
+						</p>
+						{admin && (
+							<Button size='sm' onClick={openRegCreate}>
+								<Plus className='mr-1 h-4 w-4' />
+								Thêm mức
+							</Button>
+						)}
+					</div>
+					<div className='rounded-md border'>
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Đối tượng</TableHead>
+									<TableHead>Thâm niên</TableHead>
+									<TableHead>Số ngày</TableHead>
+									<TableHead>Mô tả</TableHead>
+									{admin && <TableHead className='w-24' />}
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{loadingReg && (
+									<TableRow>
+										<TableCell
+											colSpan={5}
+											className='text-center'
+										>
+											<Loader2 className='mx-auto h-5 w-5 animate-spin' />
+										</TableCell>
+									</TableRow>
+								)}
+								{annual.map((r) => (
+									<TableRow key={r.id}>
+										<TableCell>
+											<Badge variant='secondary'>
+												{r.objectTypeLabel ||
+													r.objectType ||
+													'—'}
+											</Badge>
+										</TableCell>
+										<TableCell>
+											{formatYears(
+												r.minYears,
+												r.maxYears
+											)}
+										</TableCell>
+										<TableCell className='font-semibold'>
+											{r.baseDays} ngày
+										</TableCell>
+										<TableCell className='text-muted-foreground'>
+											{r.label || r.description || '—'}
+										</TableCell>
+										{admin && (
+											<TableCell>
+												<div className='flex gap-1'>
+													<Button
+														size='icon'
+														variant='ghost'
+														onClick={() =>
+															openRegEdit(r)
+														}
+													>
+														<Pencil className='h-4 w-4' />
+													</Button>
+													<Button
+														size='icon'
+														variant='ghost'
+														onClick={() => {
+															if (
+																confirm(
+																	'Xóa quy định này?'
+																)
+															)
+																delReg.mutate(
+																	r.id
+																)
+														}}
+													>
+														<Trash2 className='h-4 w-4 text-destructive' />
+													</Button>
+												</div>
+											</TableCell>
+										)}
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					</div>
+				</TabsContent>
+
+				{/* ── Phép thêm ── */}
+				<TabsContent value='extra' className='space-y-3'>
+					<div className='flex items-center justify-between'>
+						<p className='text-sm text-muted-foreground'>
+							MS 01–06 · 5 hoặc 10 ngày nghỉ thêm
+						</p>
+						{admin && (
+							<Button size='sm' onClick={openExCreate}>
+								<Plus className='mr-1 h-4 w-4' />
+								Thêm
+							</Button>
+						)}
+					</div>
+					<div className='rounded-md border'>
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead className='w-16'>MS</TableHead>
+									<TableHead>Loại / Nội dung</TableHead>
+									<TableHead className='w-24'>
+										Số ngày
+									</TableHead>
+									<TableHead className='w-16'>TT</TableHead>
+									{admin && <TableHead className='w-24' />}
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{loadingEx && (
+									<TableRow>
+										<TableCell
+											colSpan={5}
+											className='text-center'
+										>
+											<Loader2 className='mx-auto h-5 w-5 animate-spin' />
+										</TableCell>
+									</TableRow>
+								)}
+								{displayedExtras.map((e) => (
+									<TableRow key={e.id}>
+										<TableCell className='font-mono font-semibold'>
+											{e.code}
+										</TableCell>
+										<TableCell className='text-sm'>
+											{e.label}
+										</TableCell>
+										<TableCell>
+											<Badge>{e.days} ngày</Badge>
+										</TableCell>
+										<TableCell>
+											{e.isActive ? 'HĐ' : 'Ẩn'}
+										</TableCell>
+										{admin && e.id > 0 && (
+											<TableCell>
+												<div className='flex gap-1'>
+													<Button
+														size='icon'
+														variant='ghost'
+														onClick={() =>
+															openExEdit(e)
+														}
+													>
+														<Pencil className='h-4 w-4' />
+													</Button>
+													<Button
+														size='icon'
+														variant='ghost'
+														onClick={() => {
+															if (
+																confirm(
+																	`Xóa MS ${e.code}?`
+																)
+															)
+																delEx.mutate(
+																	e.id
+																)
+														}}
+													>
+														<Trash2 className='h-4 w-4 text-destructive' />
+													</Button>
+												</div>
+											</TableCell>
+										)}
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					</div>
+				</TabsContent>
+
+				{/* ── Phép đặc biệt ── */}
+				<TabsContent value='special'>
+					<Card>
+						<CardHeader>
+							<CardTitle className='text-lg'>
+								Phép đặc biệt
+							</CardTitle>
+						</CardHeader>
+						<CardContent className='space-y-4 text-sm'>
+							<ul className='list-disc space-y-2 pl-5 text-muted-foreground'>
+								<li>
+									<strong className='text-foreground'>
+										Đối tượng:
+									</strong>{' '}
+									SQ, QNCN, CNQP, VCQP (không áp dụng HSQBS /
+									HV).
+								</li>
+								<li>
+									<strong className='text-foreground'>
+										Thời gian:
+									</strong>{' '}
+									Mỗi lần không quá{' '}
+									<strong className='text-foreground'>
+										{meta?.specialMaxDays ?? 10} ngày
+									</strong>
+									.
+								</li>
+							</ul>
+							<div>
+								<p className='mb-2 font-medium'>
+									Được nghỉ phép đặc biệt khi:
+								</p>
+								<ol className='list-decimal space-y-3 pl-5 text-muted-foreground'>
+									{(
+										meta?.specialReasons || [
+											{
+												code: 'MARRIAGE',
+												label: 'Bản thân kết hôn, hoặc con đẻ / con nuôi hợp pháp kết hôn'
+											},
+											{
+												code: 'FAMILY_HARDSHIP',
+												label: 'Gia đình gặp khó khăn đột xuất…'
+											}
+										]
+									).map((r) => (
+										<li key={r.code}>
+											<span className='text-foreground'>
+												{r.label}
+											</span>
+										</li>
+									))}
+								</ol>
+							</div>
+						</CardContent>
+					</Card>
+				</TabsContent>
+			</Tabs>
+
+			{/* Dialogs */}
+			<Dialog open={otOpen} onOpenChange={setOtOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>
+							{otEdit ? 'Sửa đối tượng' : 'Thêm đối tượng'}
+						</DialogTitle>
+					</DialogHeader>
+					<div className='grid gap-3 py-2'>
+						<div>
+							<Label>Ma_ĐT *</Label>
+							<Input
+								value={otCode}
+								disabled={!!otEdit}
+								onChange={(e) =>
+									setOtCode(e.target.value.toUpperCase())
+								}
+								placeholder='VD: SQ'
+							/>
+						</div>
+						<div>
+							<Label>Tên_ĐT *</Label>
+							<Input
+								value={otName}
+								onChange={(e) => setOtName(e.target.value)}
+							/>
+						</div>
+						<div>
+							<Label>Thứ tự</Label>
+							<Input
+								type='number'
+								value={otSort}
+								onChange={(e) =>
+									setOtSort(Number(e.target.value) || 0)
+								}
+							/>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button
+							variant='outline'
+							onClick={() => setOtOpen(false)}
+						>
+							Hủy
+						</Button>
+						<Button
+							disabled={saveOt.isPending}
+							onClick={() => saveOt.mutate()}
+						>
+							{saveOt.isPending && (
+								<Loader2 className='mr-1 h-4 w-4 animate-spin' />
+							)}
+							Lưu
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog open={exOpen} onOpenChange={setExOpen}>
+				<DialogContent className='max-w-lg'>
+					<DialogHeader>
+						<DialogTitle>
+							{exEdit
+								? 'Sửa tiêu chuẩn phép thêm'
+								: 'Thêm tiêu chuẩn phép thêm'}
+						</DialogTitle>
+					</DialogHeader>
+					<div className='grid gap-3 py-2'>
+						<div>
+							<Label>MS *</Label>
+							<Input
+								value={exCode}
+								disabled={!!exEdit}
+								onChange={(e) => setExCode(e.target.value)}
+								placeholder='01'
+							/>
+						</div>
+						<div>
+							<Label>Nội dung *</Label>
+							<textarea
+								className='min-h-[100px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm'
+								value={exLabel}
+								onChange={(e) => setExLabel(e.target.value)}
+							/>
+						</div>
+						<div className='grid grid-cols-2 gap-3'>
+							<div>
+								<Label>Số ngày</Label>
+								<Select
+									value={String(exDays)}
+									onValueChange={(v) =>
+										setExDays(Number(v) as 5 | 10)
+									}
+								>
+									<SelectTrigger>
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value='10'>
+											10 ngày
+										</SelectItem>
+										<SelectItem value='5'>
+											5 ngày
+										</SelectItem>
+									</SelectContent>
+								</Select>
+							</div>
+							<div>
+								<Label>Thứ tự</Label>
+								<Input
+									type='number'
+									value={exSort}
+									onChange={(e) =>
+										setExSort(Number(e.target.value) || 0)
+									}
+								/>
+							</div>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button
+							variant='outline'
+							onClick={() => setExOpen(false)}
+						>
+							Hủy
+						</Button>
+						<Button
+							disabled={saveEx.isPending}
+							onClick={() => saveEx.mutate()}
+						>
+							{saveEx.isPending && (
+								<Loader2 className='mr-1 h-4 w-4 animate-spin' />
+							)}
+							Lưu
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog open={regOpen} onOpenChange={setRegOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>
+							{regEdit
+								? 'Sửa tiêu chuẩn phép hằng năm'
+								: 'Thêm mức phép hằng năm'}
+						</DialogTitle>
+					</DialogHeader>
+					<div className='grid gap-3 py-2'>
+						<div>
+							<Label>Đối tượng *</Label>
+							<Select
+								value={regOt}
+								onValueChange={setRegOt}
+								disabled={!!regEdit}
+							>
+								<SelectTrigger>
+									<SelectValue placeholder='Chọn…' />
+								</SelectTrigger>
+								<SelectContent>
+									{objectTypes.map((o) => (
+										<SelectItem key={o.code} value={o.code}>
+											{o.code} — {o.name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+						<div className='grid grid-cols-2 gap-3'>
+							<div>
+								<Label>Min (năm)</Label>
+								<Input
+									value={regMin}
+									onChange={(e) => setRegMin(e.target.value)}
+									placeholder='0'
+								/>
+							</div>
+							<div>
+								<Label>Max (năm, exclusive)</Label>
+								<Input
+									value={regMax}
+									onChange={(e) => setRegMax(e.target.value)}
+									placeholder='15'
+								/>
+							</div>
+						</div>
+						<div>
+							<Label>Số ngày *</Label>
+							<Input
+								type='number'
+								min={0}
+								value={regDays}
+								onChange={(e) => setRegDays(e.target.value)}
+							/>
+						</div>
+						<div>
+							<Label>Nhãn</Label>
+							<Input
+								value={regLabel}
+								onChange={(e) => setRegLabel(e.target.value)}
+							/>
+						</div>
+						<div>
+							<Label>Mô tả</Label>
+							<Input
+								value={regDesc}
+								onChange={(e) => setRegDesc(e.target.value)}
+							/>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button
+							variant='outline'
+							onClick={() => setRegOpen(false)}
+						>
+							Hủy
+						</Button>
+						<Button
+							disabled={saveReg.isPending}
+							onClick={() => saveReg.mutate()}
+						>
+							{saveReg.isPending && (
+								<Loader2 className='mr-1 h-4 w-4 animate-spin' />
+							)}
+							Lưu
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</div>
+	)
+}

--- a/apps/web/src/components/leave-management/UnitsPage.tsx
+++ b/apps/web/src/components/leave-management/UnitsPage.tsx
@@ -1,0 +1,289 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Loader2, Pencil, Plus, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import {
+	CreateLeaveUnit,
+	DeleteLeaveUnit,
+	ListLeaveClasses,
+	ListLeaveUnits,
+	UpdateLeaveUnit,
+	type LeaveUnit
+} from '@/api/leave'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle
+} from '@/components/ui/dialog'
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow
+} from '@/components/ui/table'
+
+export default function UnitsPage() {
+	const qc = useQueryClient()
+	const [search, setSearch] = useState('')
+	const [open, setOpen] = useState(false)
+	const [editing, setEditing] = useState<LeaveUnit | null>(null)
+	const [name, setName] = useState('')
+	const [code, setCode] = useState('')
+
+	const { data = [], isLoading } = useQuery({
+		queryKey: ['leave-units', search],
+		queryFn: () =>
+			ListLeaveUnits({
+				search: search || undefined,
+				activeOnly: false
+			})
+	})
+	const { data: classes = [] } = useQuery({
+		queryKey: ['leave-classes'],
+		queryFn: () => ListLeaveClasses()
+	})
+
+	const saveMut = useMutation({
+		mutationFn: async () => {
+			if (!name.trim()) throw new Error('Tên đơn vị là bắt buộc')
+			if (editing) {
+				return UpdateLeaveUnit(editing.id, {
+					name: name.trim(),
+					code: code.trim() || null
+				})
+			}
+			return CreateLeaveUnit({
+				name: name.trim(),
+				code: code.trim() || null
+			})
+		},
+		onSuccess: () => {
+			toast.success(editing ? 'Đã cập nhật' : 'Đã thêm đơn vị')
+			qc.invalidateQueries({ queryKey: ['leave-units'] })
+			setOpen(false)
+			setEditing(null)
+			setName('')
+			setCode('')
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	const delMut = useMutation({
+		mutationFn: (id: number) => DeleteLeaveUnit(id),
+		onSuccess: () => {
+			toast.success('Đã xóa')
+			qc.invalidateQueries({ queryKey: ['leave-units'] })
+		},
+		onError: (e: Error) => toast.error(e.message)
+	})
+
+	function openCreate() {
+		setEditing(null)
+		setName('')
+		setCode('')
+		setOpen(true)
+	}
+
+	function openEdit(u: LeaveUnit) {
+		setEditing(u)
+		setName(u.name)
+		setCode(u.code || '')
+		setOpen(true)
+	}
+
+	const levelLabel: Record<string, string> = {
+		company: 'Đại đội',
+		battalion: 'Tiểu đoàn'
+	}
+	const orderedUnits = data.flatMap((root) => {
+		if (root.parentId != null) return []
+		return [root, ...data.filter((u) => u.parentId === root.id)]
+	})
+	const classCount = (unitId: number) =>
+		classes.filter((c) => c.unitId === unitId)
+
+	return (
+		<div className='space-y-4'>
+			<div className='flex flex-wrap items-end justify-between gap-3'>
+				<div>
+					<h2 className='text-2xl font-bold tracking-tight'>
+						Danh mục đơn vị
+					</h2>
+					<p className='text-sm text-muted-foreground'>
+						Biên chế: Đại đội → Lớp học viên; Tiểu đoàn → Đại đội →
+						Trung đoàn → Lữ/Sư đoàn → Quân đoàn → Quân khu/chủng
+					</p>
+				</div>
+				<div className='flex gap-2'>
+					<Input
+						placeholder='Tìm tên / mã…'
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						className='w-56'
+					/>
+					<Button onClick={openCreate}>
+						<Plus className='mr-1 h-4 w-4' />
+						Thêm
+					</Button>
+				</div>
+			</div>
+
+			<div className='rounded-md border'>
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>Mã</TableHead>
+							<TableHead>Tên đơn vị</TableHead>
+							<TableHead>Cấp</TableHead>
+							<TableHead>Cơ quan quản lý</TableHead>
+							<TableHead>Trạng thái</TableHead>
+							<TableHead className='w-24' />
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{isLoading && (
+							<TableRow>
+								<TableCell colSpan={6} className='text-center'>
+									<Loader2 className='mx-auto h-5 w-5 animate-spin' />
+								</TableCell>
+							</TableRow>
+						)}
+						{!isLoading && data.length === 0 && (
+							<TableRow>
+								<TableCell
+									colSpan={6}
+									className='text-center text-muted-foreground'
+								>
+									Chưa có đơn vị — bấm Thêm để tạo
+								</TableCell>
+							</TableRow>
+						)}
+						{orderedUnits.map((u) => (
+							<>
+								<TableRow key={u.id}>
+									<TableCell className='font-mono text-sm'>
+										{u.code || '—'}
+									</TableCell>
+									<TableCell>
+										{u.parentId != null && (
+											<span className='mr-2 text-muted-foreground'>
+												└
+											</span>
+										)}
+										{u.name}
+									</TableCell>
+									<TableCell>
+										{u.level
+											? levelLabel[u.level] || u.level
+											: '—'}
+									</TableCell>
+									<TableCell>
+										{u.managementArea === 'quân_lực'
+											? 'Quân lực'
+											: 'Cán bộ'}
+									</TableCell>
+									<TableCell>
+										{u.isActive ? 'Hoạt động' : 'Ẩn'}
+									</TableCell>
+									<TableCell>
+										<div className='flex gap-1'>
+											<Button
+												size='icon'
+												variant='ghost'
+												onClick={() => openEdit(u)}
+											>
+												<Pencil className='h-4 w-4' />
+											</Button>
+											<Button
+												size='icon'
+												variant='ghost'
+												onClick={() => {
+													if (
+														confirm(
+															`Xóa ${u.name}?`
+														)
+													)
+														delMut.mutate(u.id)
+												}}
+											>
+												<Trash2 className='h-4 w-4 text-destructive' />
+											</Button>
+										</div>
+									</TableCell>
+								</TableRow>
+								{classCount(u.id).map((c) => (
+									<TableRow key={`class-${c.id}`}>
+										<TableCell />
+										<TableCell className='pl-12'>
+											└ Lớp {c.name} —{' '}
+											{data.length && c.name === 'A1'
+												? 2
+												: 0}{' '}
+											học viên
+										</TableCell>
+										<TableCell>Lớp học viên</TableCell>
+										<TableCell>—</TableCell>
+										<TableCell>Hoạt động</TableCell>
+										<TableCell />
+									</TableRow>
+								))}
+							</>
+						))}
+					</TableBody>
+				</Table>
+			</div>
+
+			<Dialog open={open} onOpenChange={setOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>
+							{editing ? 'Sửa đơn vị' : 'Thêm đơn vị'}
+						</DialogTitle>
+					</DialogHeader>
+					<div className='grid gap-3 py-2'>
+						<div>
+							<Label>Tên *</Label>
+							<Input
+								value={name}
+								onChange={(e) => setName(e.target.value)}
+								placeholder='Ví dụ: Đại đội 1'
+							/>
+						</div>
+						<div>
+							<Label>Mã (tuỳ chọn)</Label>
+							<Input
+								value={code}
+								onChange={(e) => setCode(e.target.value)}
+								placeholder='VD: c1'
+							/>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button
+							variant='outline'
+							onClick={() => setOpen(false)}
+						>
+							Hủy
+						</Button>
+						<Button
+							disabled={saveMut.isPending}
+							onClick={() => saveMut.mutate()}
+						>
+							{saveMut.isPending && (
+								<Loader2 className='mr-1 h-4 w-4 animate-spin' />
+							)}
+							Lưu
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</div>
+	)
+}

--- a/apps/web/src/components/leave-management/printClassLeaveList.ts
+++ b/apps/web/src/components/leave-management/printClassLeaveList.ts
@@ -1,0 +1,30 @@
+import dayjs from 'dayjs'
+import type { LeaveRequest } from '@/api/leave'
+
+function escapeHtml(value: unknown) {
+	return String(value ?? '')
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+}
+
+export function printClassLeaveList(rows: LeaveRequest[]): boolean {
+	const first = rows[0]
+	if (!first) return false
+	const popup = window.open('', '_blank', 'width=1000,height=760')
+	if (!popup) return false
+	const fmt = (value: string | null) =>
+		value ? dayjs(value).format('DD/MM/YYYY') : '—'
+	popup.document
+		.write(`<!doctype html><html><head><meta charset="utf-8"><title>Danh sách phép ${escapeHtml(first.className || '')}</title>
+	<style>body{font-family:"Times New Roman",serif;margin:28px;color:#000}h1{text-align:center;font-size:22px;margin:0 0 18px}.meta{display:grid;grid-template-columns:1fr 1fr;gap:7px;margin-bottom:18px}.meta b{display:inline-block;min-width:110px}table{width:100%;border-collapse:collapse}th,td{border:1px solid #000;padding:7px;text-align:left}th{text-align:center}.center{text-align:center}.signatures{display:grid;grid-template-columns:1fr 1fr;margin-top:32px;text-align:center}.signatures b{display:block;margin-bottom:70px}@media print{body{margin:12mm}}</style></head><body>
+	<h1>DANH SÁCH HỌC VIÊN NGHỈ PHÉP — ${escapeHtml(first.className || 'LỚP')}</h1>
+	<div class="meta"><div><b>Đơn vị:</b> ${escapeHtml(first.unitName || '—')}</div><div><b>Loại phép:</b> ${first.leaveType === 'SPECIAL' ? 'Phép đặc biệt' : 'Phép hằng năm'}</div><div><b>Thời gian:</b> ${fmt(first.startDate)} đến ${fmt(first.endDate)}</div><div><b>Số ngày:</b> ${first.totalDays} ngày</div><div><b>Số học viên:</b> ${rows.length}</div><div><b>Trạng thái:</b> ${escapeHtml(first.status)}</div></div>
+	<table><thead><tr><th>STT</th><th>Mã QN</th><th>Họ và tên</th><th>Cấp bậc</th><th>Chức vụ</th><th>Nơi nghỉ</th></tr></thead><tbody>
+	${rows.map((row, index) => `<tr><td class="center">${index + 1}</td><td>${escapeHtml(row.personnelCode || '—')}</td><td>${escapeHtml(row.personnelName || '—')}</td><td>${escapeHtml(row.rank || '—')}</td><td>${escapeHtml(row.position || '—')}</td><td>${escapeHtml(row.localityPath || '—')}</td></tr>`).join('')}
+	</tbody></table><div class="signatures"><div><b>NGƯỜI LẬP DANH SÁCH</b></div><div><b>CHỈ HUY ĐƠN VỊ</b></div></div>
+	<script>window.onload=()=>{window.print()}</script></body></html>`)
+	popup.document.close()
+	return true
+}

--- a/apps/web/src/components/leave-management/printLeaveCertificate.ts
+++ b/apps/web/src/components/leave-management/printLeaveCertificate.ts
@@ -1,0 +1,155 @@
+/**
+ * Mẫu xuất / in Giấy nghỉ phép của cơ quan quản lý.
+ */
+import dayjs from 'dayjs'
+import type { LeaveRequest } from '@/api/leave'
+
+function esc(s: string | null | undefined): string {
+	return String(s ?? '')
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+}
+
+function fmt(iso: string | null | undefined): string {
+	if (!iso) return '……/……/……'
+	const d = dayjs(iso)
+	return d.isValid() ? d.format('DD/MM/YYYY') : String(iso)
+}
+
+function documentDate(r: LeaveRequest): string {
+	const d = dayjs(r.decidedAt || undefined)
+	const value = d.isValid() ? d : dayjs()
+	return `ngày ${value.format('DD')} tháng ${value.format('MM')} năm ${value.format('YYYY')}`
+}
+
+function leaveReason(r: LeaveRequest): string {
+	if (r.note?.trim()) return r.note.trim()
+	if (r.leaveType === 'SPECIAL') return 'Nghỉ phép đặc biệt./.'
+	const year = r.startDate
+		? dayjs(r.startDate).format('YYYY')
+		: dayjs().format('YYYY')
+	return `Nghỉ phép năm ${year}./.`
+}
+
+/**
+ * Mở cửa sổ xem trước/in Giấy nghỉ phép.
+ * @param opts Các giá trị đang được cơ quan quản lý điều chỉnh trước khi duyệt.
+ */
+export function printLeaveCertificate(
+	r: LeaveRequest,
+	_opts?: {
+		travelDays?: number
+		extraDays?: number
+		totalDays?: number
+	}
+): boolean {
+	const w = window.open('', '_blank', 'width=900,height=1000')
+	if (!w) return false
+
+	const html = `<!DOCTYPE html>
+<html lang="vi">
+<head>
+<meta charset="utf-8"/>
+<title>Giấy nghỉ phép số ${r.id}</title>
+<style>
+  @page { size: A4 portrait; margin: 18mm 18mm 16mm; }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: "Times New Roman", Times, serif;
+    font-size: 14pt;
+    line-height: 1.28;
+    color: #000;
+  }
+  .page { width: 100%; min-height: 257mm; }
+  .header {
+    display: grid;
+    grid-template-columns: 44% 56%;
+    align-items: start;
+    text-align: center;
+  }
+  .upper { text-transform: uppercase; }
+  .line { margin: 0; }
+  .parent-org { font-size: 12pt; }
+  .unit { font-size: 12.5pt; font-weight: 700; }
+  .nation { font-size: 13pt; font-weight: 700; }
+  .motto { display: inline-block; font-size: 13pt; font-weight: 700; border-bottom: 1px solid #000; padding: 0 8px 2px; }
+  .doc-number { margin-top: 20px; font-size: 12.5pt; text-align: left; padding-left: 13%; }
+  .place-date { margin-top: 20px; font-size: 12.5pt; font-style: italic; white-space: nowrap; }
+  .title { margin: 55px 0 54px; text-align: center; }
+  .title h1 { display: inline-block; margin: 0; padding-bottom: 2px; border-bottom: 1px solid #000; font-size: 17pt; text-transform: uppercase; }
+  .details { width: 88%; margin: 0 auto; }
+  .detail-row { display: grid; grid-template-columns: 178px 1fr; margin: 8px 0; align-items: baseline; }
+  .label { white-space: nowrap; }
+  .value { min-width: 0; }
+  .name { font-weight: 700; text-transform: uppercase; }
+  .time-value { padding-left: 56px; }
+  .signatures { display: grid; grid-template-columns: 47% 53%; gap: 20px; margin-top: 76px; text-align: center; }
+  .signature-title { font-weight: 700; text-transform: uppercase; line-height: 1.12; }
+  .signature-subtitle { font-weight: 700; line-height: 1.12; }
+  .signature-hint { font-style: italic; font-size: 12pt; }
+  .signature-space { height: 98px; }
+  .signer { font-weight: 700; }
+  @media screen {
+    body { background: #e5e7eb; padding: 24px; }
+    .page { width: 210mm; min-height: 297mm; margin: 0 auto; padding: 18mm 18mm 16mm; background: white; box-shadow: 0 2px 14px #777; }
+  }
+  @media print {
+    .page { min-height: 0; }
+  }
+</style>
+</head>
+<body>
+<main class="page">
+  <header class="header">
+    <div>
+      <p class="line parent-org upper">Tổng cục Hậu cần</p>
+      <p class="line unit upper">Trường Cao đẳng Hậu cần 2</p>
+      <p class="line doc-number">Số: ${r.id}/GNP-CĐHC</p>
+    </div>
+    <div>
+      <p class="line nation upper">Cộng hòa xã hội chủ nghĩa Việt Nam</p>
+      <p class="line motto">Độc lập - Tự do - Hạnh phúc</p>
+      <p class="line place-date">Thành phố Hồ Chí Minh, ${documentDate(r)}</p>
+    </div>
+  </header>
+
+  <section class="title"><h1>Giấy nghỉ phép</h1></section>
+
+  <section class="details">
+    <div class="detail-row"><span class="label">Họ và tên:</span><span class="value name">${esc(r.personnelName) || '………………………………'}</span></div>
+    <div class="detail-row"><span class="label">Cấp bậc:</span><span class="value">${esc(r.rank) || '………………………………'}</span></div>
+    <div class="detail-row"><span class="label">Chức vụ:</span><span class="value">${esc(r.position) || '………………………………'}</span></div>
+    <div class="detail-row"><span class="label">Đơn vị:</span><span class="value">${esc(r.unitName) || '………………………………'}/Trường Cao đẳng Hậu cần 2</span></div>
+    <div class="detail-row"><span class="label">Được nghỉ từ:</span><span class="value time-value">07h00 ngày ${fmt(r.startDate)}</span></div>
+    <div class="detail-row"><span class="label">Đến:</span><span class="value time-value">17h00 ngày ${fmt(r.endDate)}</span></div>
+    <div class="detail-row"><span class="label">Nơi nghỉ phép:</span><span class="value">${esc(r.localityPath) || '………………………………'}</span></div>
+    <div class="detail-row"><span class="label">Lý do:</span><span class="value">${esc(leaveReason(r))}</span></div>
+  </section>
+
+  <section class="signatures">
+    <div>
+      <div class="signature-title">Xác nhận</div>
+      <div class="signature-subtitle">Của chính quyền địa phương<br/>nơi nghỉ phép</div>
+      <div class="signature-hint">(Ký, đóng dấu)</div>
+      <div class="signature-space"></div>
+    </div>
+    <div>
+      <div class="signature-title">KT. Hiệu trưởng</div>
+      <div class="signature-title">Phó hiệu trưởng</div>
+      <div class="signature-space"></div>
+      <div class="signer">${esc(r.decidedByUsername) || '………………………………'}</div>
+    </div>
+  </section>
+</main>
+<script>window.onload = function () { window.print(); }</script>
+</body>
+</html>`
+
+	w.document.open()
+	w.document.write(html)
+	w.document.close()
+	return true
+}

--- a/apps/web/src/components/user-table/user-form.tsx
+++ b/apps/web/src/components/user-table/user-form.tsx
@@ -39,6 +39,11 @@ import useUnitsData from '@/hooks/useUnitsData'
 import { SearchableSelect } from '@/components/ui/searchable-select'
 import { Loader2 } from 'lucide-react'
 import { nganhLabel } from '@/lib/nganh'
+import {
+	AssignLeaveAccount,
+	ListLeavePersonnel,
+	ListLeaveUnits
+} from '@/api/leave'
 
 export interface UserFormProps {
 	onSuccess: (data: User[], variables: UserBody, context: unknown) => unknown
@@ -46,7 +51,15 @@ export interface UserFormProps {
 	setOpen: (open: boolean) => void
 }
 
-type AccountKind = 'bgh' | 'nganh' | 'don_vi' | 'cnk' | 'giang_vien'
+type AccountKind =
+	| 'bgh'
+	| 'nganh'
+	| 'don_vi'
+	| 'cnk'
+	| 'giang_vien'
+	| 'leave_personnel'
+	| 'leave_commander'
+	| 'leave_management'
 
 export default function UserForm({ onSuccess, open, setOpen }: UserFormProps) {
 	const qc = useQueryClient()
@@ -67,6 +80,16 @@ export default function UserForm({ onSuccess, open, setOpen }: UserFormProps) {
 		queryFn: ListExamAcademicTitles,
 		enabled: open
 	})
+	const leavePersonnelQ = useQuery({
+		queryKey: ['leave-personnel', 'user-form'],
+		queryFn: () => ListLeavePersonnel(),
+		enabled: open
+	})
+	const leaveUnitsQ = useQuery({
+		queryKey: ['leave-units', 'user-form'],
+		queryFn: () => ListLeaveUnits({ activeOnly: true }),
+		enabled: open
+	})
 
 	const [accountKind, setAccountKind] = useState<AccountKind | ''>('')
 	const [username, setUsername] = useState('')
@@ -80,6 +103,11 @@ export default function UserForm({ onSuccess, open, setOpen }: UserFormProps) {
 	const [academicTitleId, setAcademicTitleId] = useState('')
 	/** Role / phân quyền chọn từ danh sách hiện có */
 	const [roleId, setRoleId] = useState('')
+	const [personnelId, setPersonnelId] = useState('')
+	const [leaveUnitId, setLeaveUnitId] = useState('')
+	const [managementArea, setManagementArea] = useState<
+		'cán_bộ' | 'quân_lực' | ''
+	>('')
 	const [pending, setPending] = useState(false)
 
 	const unitOptions = useMemo(() => {
@@ -123,6 +151,26 @@ export default function UserForm({ onSuccess, open, setOpen }: UserFormProps) {
 			keywords: `${f.code} ${f.name}`
 		}))
 	}, [facultyQ.data])
+	const personnelOptions = useMemo(
+		() =>
+			(leavePersonnelQ.data || [])
+				.filter((p) => !p.userId)
+				.map((p) => ({
+					value: String(p.id),
+					label: `${p.code} — ${p.fullName}${p.unitName ? ` · ${p.unitName}` : ''}`,
+					keywords: `${p.code} ${p.fullName} ${p.unitName || ''}`
+				})),
+		[leavePersonnelQ.data]
+	)
+	const leaveUnitOptions = useMemo(
+		() =>
+			(leaveUnitsQ.data || []).map((u) => ({
+				value: String(u.id),
+				label: `${u.code ? `${u.code} — ` : ''}${u.name}`,
+				keywords: `${u.code || ''} ${u.name} ${u.level || ''}`
+			})),
+		[leaveUnitsQ.data]
+	)
 
 	/** Roles gợi ý theo loại TK (ẩn super_admin) */
 	const roleOptions = useMemo(() => {
@@ -183,6 +231,22 @@ export default function UserForm({ onSuccess, open, setOpen }: UserFormProps) {
 				roles.find((r) => r.name.toLowerCase().includes('giang_vien'))
 			if (hit) setRoleId(String(hit.id))
 			else setRoleId('')
+		} else if (
+			accountKind === 'leave_personnel' ||
+			accountKind === 'leave_commander' ||
+			accountKind === 'leave_management'
+		) {
+			const preferred =
+				accountKind === 'leave_management'
+					? ['leave_agency']
+					: accountKind === 'leave_commander'
+						? ['leave_commander']
+						: ['leave_personnel']
+			const hit = preferred
+				.map((name) => roles.find((r) => r.name === name))
+				.find(Boolean)
+			if (hit) setRoleId(String(hit.id))
+			else setRoleId('')
 		}
 	}, [accountKind, rolesQ.data])
 
@@ -196,6 +260,9 @@ export default function UserForm({ onSuccess, open, setOpen }: UserFormProps) {
 		setFacultyCode('')
 		setAcademicTitleId('')
 		setRoleId('')
+		setPersonnelId('')
+		setLeaveUnitId('')
+		setManagementArea('')
 	}
 
 	const mut = useMutation({
@@ -233,6 +300,18 @@ export default function UserForm({ onSuccess, open, setOpen }: UserFormProps) {
 			toast.error('Chọn chức danh cho giáo viên')
 			return
 		}
+		if (accountKind === 'leave_personnel' && !personnelId) {
+			toast.error('Chọn quân nhân gắn với tài khoản')
+			return
+		}
+		if (accountKind === 'leave_commander' && !leaveUnitId) {
+			toast.error('Chọn cơ quan do chỉ huy phụ trách')
+			return
+		}
+		if (accountKind === 'leave_management' && !managementArea) {
+			toast.error('Chọn Cơ quan hoặc Quân lực')
+			return
+		}
 		if (!roleId) {
 			toast.error(
 				roleLocked
@@ -251,7 +330,13 @@ export default function UserForm({ onSuccess, open, setOpen }: UserFormProps) {
 						? 'Chủ nhiệm khoa'
 						: accountKind === 'giang_vien'
 							? 'Giáo viên'
-							: 'User ngành'
+							: accountKind === 'leave_personnel'
+								? 'Quân nhân'
+								: accountKind === 'leave_commander'
+									? 'Chỉ huy cơ quan'
+									: accountKind === 'leave_management'
+										? 'Cơ quan quản lý'
+										: 'User ngành'
 
 		setPending(true)
 		try {
@@ -270,6 +355,26 @@ export default function UserForm({ onSuccess, open, setOpen }: UserFormProps) {
 				userId: created.id,
 				roleIds: [Number(roleId)]
 			})
+
+			if (accountKind === 'leave_personnel') {
+				await AssignLeaveAccount({
+					userId: created.id,
+					kind: 'personnel',
+					personnelId: Number(personnelId)
+				})
+			} else if (accountKind === 'leave_commander') {
+				await AssignLeaveAccount({
+					userId: created.id,
+					kind: 'commander',
+					unitId: Number(leaveUnitId)
+				})
+			} else if (accountKind === 'leave_management') {
+				await AssignLeaveAccount({
+					userId: created.id,
+					kind: 'management',
+					managementArea
+				})
+			}
 
 			// TK ngành: gán đúng 1 ngành
 			if (accountKind === 'nganh') {
@@ -375,6 +480,9 @@ export default function UserForm({ onSuccess, open, setOpen }: UserFormProps) {
 								setUnitId('')
 								setNganhCode('')
 								setFacultyCode('')
+								setPersonnelId('')
+								setLeaveUnitId('')
+								setManagementArea('')
 							}}
 						>
 							<SelectTrigger className='h-11 text-base'>
@@ -395,6 +503,15 @@ export default function UserForm({ onSuccess, open, setOpen }: UserFormProps) {
 								</SelectItem>
 								<SelectItem value='giang_vien'>
 									Giáo viên (soạn đề theo khoa)
+								</SelectItem>
+								<SelectItem value='leave_personnel'>
+									Tài khoản quân nhân
+								</SelectItem>
+								<SelectItem value='leave_commander'>
+									Tài khoản chỉ huy cơ quan
+								</SelectItem>
+								<SelectItem value='leave_management'>
+									Tài khoản cơ quan quản lý
 								</SelectItem>
 							</SelectContent>
 						</Select>
@@ -583,6 +700,81 @@ export default function UserForm({ onSuccess, open, setOpen }: UserFormProps) {
 									</>
 								)}
 							</p>
+						</div>
+					)}
+
+					{accountKind === 'leave_personnel' && (
+						<div className='space-y-2 rounded-lg border border-sky-500/30 bg-sky-500/5 p-4'>
+							<Label className='text-base'>
+								Quân nhân{' '}
+								<span className='text-destructive'>*</span>
+							</Label>
+							<SearchableSelect
+								value={personnelId}
+								onValueChange={setPersonnelId}
+								options={personnelOptions}
+								placeholder={
+									leavePersonnelQ.isLoading
+										? 'Đang tải…'
+										: 'Chọn quân nhân…'
+								}
+								searchPlaceholder='Tìm theo mã hoặc họ tên…'
+								emptyText='Không còn quân nhân chưa có tài khoản'
+								disabled={leavePersonnelQ.isLoading}
+								className='h-11 text-base'
+							/>
+						</div>
+					)}
+
+					{accountKind === 'leave_commander' && (
+						<div className='space-y-2 rounded-lg border border-sky-500/30 bg-sky-500/5 p-4'>
+							<Label className='text-base'>
+								Cơ quan chỉ huy{' '}
+								<span className='text-destructive'>*</span>
+							</Label>
+							<SearchableSelect
+								value={leaveUnitId}
+								onValueChange={setLeaveUnitId}
+								options={leaveUnitOptions}
+								placeholder={
+									leaveUnitsQ.isLoading
+										? 'Đang tải…'
+										: 'Chọn cơ quan…'
+								}
+								searchPlaceholder='Tìm mã hoặc tên cơ quan…'
+								emptyText='Không có cơ quan'
+								disabled={leaveUnitsQ.isLoading}
+								className='h-11 text-base'
+							/>
+						</div>
+					)}
+
+					{accountKind === 'leave_management' && (
+						<div className='space-y-2 rounded-lg border border-sky-500/30 bg-sky-500/5 p-4'>
+							<Label className='text-base'>
+								Phạm vi quản lý{' '}
+								<span className='text-destructive'>*</span>
+							</Label>
+							<Select
+								value={managementArea}
+								onValueChange={(v) =>
+									setManagementArea(
+										v as 'cán_bộ' | 'quân_lực'
+									)
+								}
+							>
+								<SelectTrigger className='h-11 text-base'>
+									<SelectValue placeholder='Chọn Cơ quan hoặc Quân lực…' />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value='cán_bộ'>
+										Cơ quan
+									</SelectItem>
+									<SelectItem value='quân_lực'>
+										Quân lực
+									</SelectItem>
+								</SelectContent>
+							</Select>
 						</div>
 					)}
 

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -27,6 +27,7 @@ import { Route as CacQuyenRouteImport } from './routes/cac-quyen'
 import { Route as BirthdayRouteImport } from './routes/birthday'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as VatTuIndexRouteImport } from './routes/vat-tu/index'
+import { Route as QuanLyPhepIndexRouteImport } from './routes/quan-ly-phep/index'
 import { Route as DeThiIndexRouteImport } from './routes/de-thi/index'
 import { Route as VatTuTimKiemRouteImport } from './routes/vat-tu/tim-kiem'
 import { Route as VatTuThanhLyRouteImport } from './routes/vat-tu/thanh-ly'
@@ -41,6 +42,17 @@ import { Route as VatTuDanhMucNganhRouteImport } from './routes/vat-tu/danh-muc-
 import { Route as VatTuCapNhatRouteImport } from './routes/vat-tu/cap-nhat'
 import { Route as VatTuBaoCaoRouteImport } from './routes/vat-tu/bao-cao'
 import { Route as TieuDoanAliasRouteImport } from './routes/tieu-doan/$alias'
+import { Route as QuanLyPhepQuyDinhRouteImport } from './routes/quan-ly-phep/quy-dinh'
+import { Route as QuanLyPhepQuanNhanRouteImport } from './routes/quan-ly-phep/quan-nhan'
+import { Route as QuanLyPhepLuuTruRouteImport } from './routes/quan-ly-phep/luu-tru'
+import { Route as QuanLyPhepDuyetRouteImport } from './routes/quan-ly-phep/duyet'
+import { Route as QuanLyPhepDotNghiRouteImport } from './routes/quan-ly-phep/dot-nghi'
+import { Route as QuanLyPhepDonViRouteImport } from './routes/quan-ly-phep/don-vi'
+import { Route as QuanLyPhepDiaPhuongRouteImport } from './routes/quan-ly-phep/dia-phuong'
+import { Route as QuanLyPhepDeXuatRouteImport } from './routes/quan-ly-phep/de-xuat'
+import { Route as QuanLyPhepDanhSachRouteImport } from './routes/quan-ly-phep/danh-sach'
+import { Route as QuanLyPhepChucVuRouteImport } from './routes/quan-ly-phep/chuc-vu'
+import { Route as QuanLyPhepBaoCaoRouteImport } from './routes/quan-ly-phep/bao-cao'
 import { Route as DeThiRutDeRouteImport } from './routes/de-thi/rut-de'
 import { Route as DeThiQrRouteImport } from './routes/de-thi/qr'
 import { Route as DeThiPhanCongRouteImport } from './routes/de-thi/phan-cong'
@@ -148,6 +160,11 @@ const VatTuIndexRoute = VatTuIndexRouteImport.update({
   path: '/vat-tu/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const QuanLyPhepIndexRoute = QuanLyPhepIndexRouteImport.update({
+  id: '/quan-ly-phep/',
+  path: '/quan-ly-phep/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DeThiIndexRoute = DeThiIndexRouteImport.update({
   id: '/de-thi/',
   path: '/de-thi/',
@@ -216,6 +233,61 @@ const VatTuBaoCaoRoute = VatTuBaoCaoRouteImport.update({
 const TieuDoanAliasRoute = TieuDoanAliasRouteImport.update({
   id: '/tieu-doan/$alias',
   path: '/tieu-doan/$alias',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const QuanLyPhepQuyDinhRoute = QuanLyPhepQuyDinhRouteImport.update({
+  id: '/quan-ly-phep/quy-dinh',
+  path: '/quan-ly-phep/quy-dinh',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const QuanLyPhepQuanNhanRoute = QuanLyPhepQuanNhanRouteImport.update({
+  id: '/quan-ly-phep/quan-nhan',
+  path: '/quan-ly-phep/quan-nhan',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const QuanLyPhepLuuTruRoute = QuanLyPhepLuuTruRouteImport.update({
+  id: '/quan-ly-phep/luu-tru',
+  path: '/quan-ly-phep/luu-tru',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const QuanLyPhepDuyetRoute = QuanLyPhepDuyetRouteImport.update({
+  id: '/quan-ly-phep/duyet',
+  path: '/quan-ly-phep/duyet',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const QuanLyPhepDotNghiRoute = QuanLyPhepDotNghiRouteImport.update({
+  id: '/quan-ly-phep/dot-nghi',
+  path: '/quan-ly-phep/dot-nghi',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const QuanLyPhepDonViRoute = QuanLyPhepDonViRouteImport.update({
+  id: '/quan-ly-phep/don-vi',
+  path: '/quan-ly-phep/don-vi',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const QuanLyPhepDiaPhuongRoute = QuanLyPhepDiaPhuongRouteImport.update({
+  id: '/quan-ly-phep/dia-phuong',
+  path: '/quan-ly-phep/dia-phuong',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const QuanLyPhepDeXuatRoute = QuanLyPhepDeXuatRouteImport.update({
+  id: '/quan-ly-phep/de-xuat',
+  path: '/quan-ly-phep/de-xuat',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const QuanLyPhepDanhSachRoute = QuanLyPhepDanhSachRouteImport.update({
+  id: '/quan-ly-phep/danh-sach',
+  path: '/quan-ly-phep/danh-sach',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const QuanLyPhepChucVuRoute = QuanLyPhepChucVuRouteImport.update({
+  id: '/quan-ly-phep/chuc-vu',
+  path: '/quan-ly-phep/chuc-vu',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const QuanLyPhepBaoCaoRoute = QuanLyPhepBaoCaoRouteImport.update({
+  id: '/quan-ly-phep/bao-cao',
+  path: '/quan-ly-phep/bao-cao',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DeThiRutDeRoute = DeThiRutDeRouteImport.update({
@@ -329,6 +401,17 @@ export interface FileRoutesByFullPath {
   '/de-thi/phan-cong': typeof DeThiPhanCongRoute
   '/de-thi/qr': typeof DeThiQrRoute
   '/de-thi/rut-de': typeof DeThiRutDeRoute
+  '/quan-ly-phep/bao-cao': typeof QuanLyPhepBaoCaoRoute
+  '/quan-ly-phep/chuc-vu': typeof QuanLyPhepChucVuRoute
+  '/quan-ly-phep/danh-sach': typeof QuanLyPhepDanhSachRoute
+  '/quan-ly-phep/de-xuat': typeof QuanLyPhepDeXuatRoute
+  '/quan-ly-phep/dia-phuong': typeof QuanLyPhepDiaPhuongRoute
+  '/quan-ly-phep/don-vi': typeof QuanLyPhepDonViRoute
+  '/quan-ly-phep/dot-nghi': typeof QuanLyPhepDotNghiRoute
+  '/quan-ly-phep/duyet': typeof QuanLyPhepDuyetRoute
+  '/quan-ly-phep/luu-tru': typeof QuanLyPhepLuuTruRoute
+  '/quan-ly-phep/quan-nhan': typeof QuanLyPhepQuanNhanRoute
+  '/quan-ly-phep/quy-dinh': typeof QuanLyPhepQuyDinhRoute
   '/tieu-doan/$alias': typeof TieuDoanAliasRoute
   '/vat-tu/bao-cao': typeof VatTuBaoCaoRoute
   '/vat-tu/cap-nhat': typeof VatTuCapNhatRoute
@@ -343,6 +426,7 @@ export interface FileRoutesByFullPath {
   '/vat-tu/thanh-ly': typeof VatTuThanhLyRoute
   '/vat-tu/tim-kiem': typeof VatTuTimKiemRoute
   '/de-thi': typeof DeThiIndexRoute
+  '/quan-ly-phep': typeof QuanLyPhepIndexRoute
   '/vat-tu': typeof VatTuIndexRoute
   '/de-thi/chi-tiet/$id': typeof DeThiChiTietIdRoute
   '/de-thi/soan/$id': typeof DeThiSoanIdRoute
@@ -379,6 +463,17 @@ export interface FileRoutesByTo {
   '/de-thi/phan-cong': typeof DeThiPhanCongRoute
   '/de-thi/qr': typeof DeThiQrRoute
   '/de-thi/rut-de': typeof DeThiRutDeRoute
+  '/quan-ly-phep/bao-cao': typeof QuanLyPhepBaoCaoRoute
+  '/quan-ly-phep/chuc-vu': typeof QuanLyPhepChucVuRoute
+  '/quan-ly-phep/danh-sach': typeof QuanLyPhepDanhSachRoute
+  '/quan-ly-phep/de-xuat': typeof QuanLyPhepDeXuatRoute
+  '/quan-ly-phep/dia-phuong': typeof QuanLyPhepDiaPhuongRoute
+  '/quan-ly-phep/don-vi': typeof QuanLyPhepDonViRoute
+  '/quan-ly-phep/dot-nghi': typeof QuanLyPhepDotNghiRoute
+  '/quan-ly-phep/duyet': typeof QuanLyPhepDuyetRoute
+  '/quan-ly-phep/luu-tru': typeof QuanLyPhepLuuTruRoute
+  '/quan-ly-phep/quan-nhan': typeof QuanLyPhepQuanNhanRoute
+  '/quan-ly-phep/quy-dinh': typeof QuanLyPhepQuyDinhRoute
   '/tieu-doan/$alias': typeof TieuDoanAliasRoute
   '/vat-tu/bao-cao': typeof VatTuBaoCaoRoute
   '/vat-tu/cap-nhat': typeof VatTuCapNhatRoute
@@ -393,6 +488,7 @@ export interface FileRoutesByTo {
   '/vat-tu/thanh-ly': typeof VatTuThanhLyRoute
   '/vat-tu/tim-kiem': typeof VatTuTimKiemRoute
   '/de-thi': typeof DeThiIndexRoute
+  '/quan-ly-phep': typeof QuanLyPhepIndexRoute
   '/vat-tu': typeof VatTuIndexRoute
   '/de-thi/chi-tiet/$id': typeof DeThiChiTietIdRoute
   '/de-thi/soan/$id': typeof DeThiSoanIdRoute
@@ -430,6 +526,17 @@ export interface FileRoutesById {
   '/de-thi/phan-cong': typeof DeThiPhanCongRoute
   '/de-thi/qr': typeof DeThiQrRoute
   '/de-thi/rut-de': typeof DeThiRutDeRoute
+  '/quan-ly-phep/bao-cao': typeof QuanLyPhepBaoCaoRoute
+  '/quan-ly-phep/chuc-vu': typeof QuanLyPhepChucVuRoute
+  '/quan-ly-phep/danh-sach': typeof QuanLyPhepDanhSachRoute
+  '/quan-ly-phep/de-xuat': typeof QuanLyPhepDeXuatRoute
+  '/quan-ly-phep/dia-phuong': typeof QuanLyPhepDiaPhuongRoute
+  '/quan-ly-phep/don-vi': typeof QuanLyPhepDonViRoute
+  '/quan-ly-phep/dot-nghi': typeof QuanLyPhepDotNghiRoute
+  '/quan-ly-phep/duyet': typeof QuanLyPhepDuyetRoute
+  '/quan-ly-phep/luu-tru': typeof QuanLyPhepLuuTruRoute
+  '/quan-ly-phep/quan-nhan': typeof QuanLyPhepQuanNhanRoute
+  '/quan-ly-phep/quy-dinh': typeof QuanLyPhepQuyDinhRoute
   '/tieu-doan/$alias': typeof TieuDoanAliasRoute
   '/vat-tu/bao-cao': typeof VatTuBaoCaoRoute
   '/vat-tu/cap-nhat': typeof VatTuCapNhatRoute
@@ -444,6 +551,7 @@ export interface FileRoutesById {
   '/vat-tu/thanh-ly': typeof VatTuThanhLyRoute
   '/vat-tu/tim-kiem': typeof VatTuTimKiemRoute
   '/de-thi/': typeof DeThiIndexRoute
+  '/quan-ly-phep/': typeof QuanLyPhepIndexRoute
   '/vat-tu/': typeof VatTuIndexRoute
   '/de-thi/chi-tiet/$id': typeof DeThiChiTietIdRoute
   '/de-thi/soan/$id': typeof DeThiSoanIdRoute
@@ -482,6 +590,17 @@ export interface FileRouteTypes {
     | '/de-thi/phan-cong'
     | '/de-thi/qr'
     | '/de-thi/rut-de'
+    | '/quan-ly-phep/bao-cao'
+    | '/quan-ly-phep/chuc-vu'
+    | '/quan-ly-phep/danh-sach'
+    | '/quan-ly-phep/de-xuat'
+    | '/quan-ly-phep/dia-phuong'
+    | '/quan-ly-phep/don-vi'
+    | '/quan-ly-phep/dot-nghi'
+    | '/quan-ly-phep/duyet'
+    | '/quan-ly-phep/luu-tru'
+    | '/quan-ly-phep/quan-nhan'
+    | '/quan-ly-phep/quy-dinh'
     | '/tieu-doan/$alias'
     | '/vat-tu/bao-cao'
     | '/vat-tu/cap-nhat'
@@ -496,6 +615,7 @@ export interface FileRouteTypes {
     | '/vat-tu/thanh-ly'
     | '/vat-tu/tim-kiem'
     | '/de-thi'
+    | '/quan-ly-phep'
     | '/vat-tu'
     | '/de-thi/chi-tiet/$id'
     | '/de-thi/soan/$id'
@@ -532,6 +652,17 @@ export interface FileRouteTypes {
     | '/de-thi/phan-cong'
     | '/de-thi/qr'
     | '/de-thi/rut-de'
+    | '/quan-ly-phep/bao-cao'
+    | '/quan-ly-phep/chuc-vu'
+    | '/quan-ly-phep/danh-sach'
+    | '/quan-ly-phep/de-xuat'
+    | '/quan-ly-phep/dia-phuong'
+    | '/quan-ly-phep/don-vi'
+    | '/quan-ly-phep/dot-nghi'
+    | '/quan-ly-phep/duyet'
+    | '/quan-ly-phep/luu-tru'
+    | '/quan-ly-phep/quan-nhan'
+    | '/quan-ly-phep/quy-dinh'
     | '/tieu-doan/$alias'
     | '/vat-tu/bao-cao'
     | '/vat-tu/cap-nhat'
@@ -546,6 +677,7 @@ export interface FileRouteTypes {
     | '/vat-tu/thanh-ly'
     | '/vat-tu/tim-kiem'
     | '/de-thi'
+    | '/quan-ly-phep'
     | '/vat-tu'
     | '/de-thi/chi-tiet/$id'
     | '/de-thi/soan/$id'
@@ -582,6 +714,17 @@ export interface FileRouteTypes {
     | '/de-thi/phan-cong'
     | '/de-thi/qr'
     | '/de-thi/rut-de'
+    | '/quan-ly-phep/bao-cao'
+    | '/quan-ly-phep/chuc-vu'
+    | '/quan-ly-phep/danh-sach'
+    | '/quan-ly-phep/de-xuat'
+    | '/quan-ly-phep/dia-phuong'
+    | '/quan-ly-phep/don-vi'
+    | '/quan-ly-phep/dot-nghi'
+    | '/quan-ly-phep/duyet'
+    | '/quan-ly-phep/luu-tru'
+    | '/quan-ly-phep/quan-nhan'
+    | '/quan-ly-phep/quy-dinh'
     | '/tieu-doan/$alias'
     | '/vat-tu/bao-cao'
     | '/vat-tu/cap-nhat'
@@ -596,6 +739,7 @@ export interface FileRouteTypes {
     | '/vat-tu/thanh-ly'
     | '/vat-tu/tim-kiem'
     | '/de-thi/'
+    | '/quan-ly-phep/'
     | '/vat-tu/'
     | '/de-thi/chi-tiet/$id'
     | '/de-thi/soan/$id'
@@ -633,6 +777,17 @@ export interface RootRouteChildren {
   DeThiPhanCongRoute: typeof DeThiPhanCongRoute
   DeThiQrRoute: typeof DeThiQrRoute
   DeThiRutDeRoute: typeof DeThiRutDeRoute
+  QuanLyPhepBaoCaoRoute: typeof QuanLyPhepBaoCaoRoute
+  QuanLyPhepChucVuRoute: typeof QuanLyPhepChucVuRoute
+  QuanLyPhepDanhSachRoute: typeof QuanLyPhepDanhSachRoute
+  QuanLyPhepDeXuatRoute: typeof QuanLyPhepDeXuatRoute
+  QuanLyPhepDiaPhuongRoute: typeof QuanLyPhepDiaPhuongRoute
+  QuanLyPhepDonViRoute: typeof QuanLyPhepDonViRoute
+  QuanLyPhepDotNghiRoute: typeof QuanLyPhepDotNghiRoute
+  QuanLyPhepDuyetRoute: typeof QuanLyPhepDuyetRoute
+  QuanLyPhepLuuTruRoute: typeof QuanLyPhepLuuTruRoute
+  QuanLyPhepQuanNhanRoute: typeof QuanLyPhepQuanNhanRoute
+  QuanLyPhepQuyDinhRoute: typeof QuanLyPhepQuyDinhRoute
   TieuDoanAliasRoute: typeof TieuDoanAliasRoute
   VatTuBaoCaoRoute: typeof VatTuBaoCaoRoute
   VatTuCapNhatRoute: typeof VatTuCapNhatRoute
@@ -647,6 +802,7 @@ export interface RootRouteChildren {
   VatTuThanhLyRoute: typeof VatTuThanhLyRoute
   VatTuTimKiemRoute: typeof VatTuTimKiemRoute
   DeThiIndexRoute: typeof DeThiIndexRoute
+  QuanLyPhepIndexRoute: typeof QuanLyPhepIndexRoute
   VatTuIndexRoute: typeof VatTuIndexRoute
   DeThiChiTietIdRoute: typeof DeThiChiTietIdRoute
   DeThiSoanIdRoute: typeof DeThiSoanIdRoute
@@ -782,6 +938,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof VatTuIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/quan-ly-phep/': {
+      id: '/quan-ly-phep/'
+      path: '/quan-ly-phep'
+      fullPath: '/quan-ly-phep'
+      preLoaderRoute: typeof QuanLyPhepIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/de-thi/': {
       id: '/de-thi/'
       path: '/de-thi'
@@ -878,6 +1041,83 @@ declare module '@tanstack/react-router' {
       path: '/tieu-doan/$alias'
       fullPath: '/tieu-doan/$alias'
       preLoaderRoute: typeof TieuDoanAliasRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/quan-ly-phep/quy-dinh': {
+      id: '/quan-ly-phep/quy-dinh'
+      path: '/quan-ly-phep/quy-dinh'
+      fullPath: '/quan-ly-phep/quy-dinh'
+      preLoaderRoute: typeof QuanLyPhepQuyDinhRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/quan-ly-phep/quan-nhan': {
+      id: '/quan-ly-phep/quan-nhan'
+      path: '/quan-ly-phep/quan-nhan'
+      fullPath: '/quan-ly-phep/quan-nhan'
+      preLoaderRoute: typeof QuanLyPhepQuanNhanRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/quan-ly-phep/luu-tru': {
+      id: '/quan-ly-phep/luu-tru'
+      path: '/quan-ly-phep/luu-tru'
+      fullPath: '/quan-ly-phep/luu-tru'
+      preLoaderRoute: typeof QuanLyPhepLuuTruRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/quan-ly-phep/duyet': {
+      id: '/quan-ly-phep/duyet'
+      path: '/quan-ly-phep/duyet'
+      fullPath: '/quan-ly-phep/duyet'
+      preLoaderRoute: typeof QuanLyPhepDuyetRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/quan-ly-phep/dot-nghi': {
+      id: '/quan-ly-phep/dot-nghi'
+      path: '/quan-ly-phep/dot-nghi'
+      fullPath: '/quan-ly-phep/dot-nghi'
+      preLoaderRoute: typeof QuanLyPhepDotNghiRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/quan-ly-phep/don-vi': {
+      id: '/quan-ly-phep/don-vi'
+      path: '/quan-ly-phep/don-vi'
+      fullPath: '/quan-ly-phep/don-vi'
+      preLoaderRoute: typeof QuanLyPhepDonViRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/quan-ly-phep/dia-phuong': {
+      id: '/quan-ly-phep/dia-phuong'
+      path: '/quan-ly-phep/dia-phuong'
+      fullPath: '/quan-ly-phep/dia-phuong'
+      preLoaderRoute: typeof QuanLyPhepDiaPhuongRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/quan-ly-phep/de-xuat': {
+      id: '/quan-ly-phep/de-xuat'
+      path: '/quan-ly-phep/de-xuat'
+      fullPath: '/quan-ly-phep/de-xuat'
+      preLoaderRoute: typeof QuanLyPhepDeXuatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/quan-ly-phep/danh-sach': {
+      id: '/quan-ly-phep/danh-sach'
+      path: '/quan-ly-phep/danh-sach'
+      fullPath: '/quan-ly-phep/danh-sach'
+      preLoaderRoute: typeof QuanLyPhepDanhSachRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/quan-ly-phep/chuc-vu': {
+      id: '/quan-ly-phep/chuc-vu'
+      path: '/quan-ly-phep/chuc-vu'
+      fullPath: '/quan-ly-phep/chuc-vu'
+      preLoaderRoute: typeof QuanLyPhepChucVuRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/quan-ly-phep/bao-cao': {
+      id: '/quan-ly-phep/bao-cao'
+      path: '/quan-ly-phep/bao-cao'
+      fullPath: '/quan-ly-phep/bao-cao'
+      preLoaderRoute: typeof QuanLyPhepBaoCaoRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/de-thi/rut-de': {
@@ -1025,6 +1265,17 @@ const rootRouteChildren: RootRouteChildren = {
   DeThiPhanCongRoute: DeThiPhanCongRoute,
   DeThiQrRoute: DeThiQrRoute,
   DeThiRutDeRoute: DeThiRutDeRoute,
+  QuanLyPhepBaoCaoRoute: QuanLyPhepBaoCaoRoute,
+  QuanLyPhepChucVuRoute: QuanLyPhepChucVuRoute,
+  QuanLyPhepDanhSachRoute: QuanLyPhepDanhSachRoute,
+  QuanLyPhepDeXuatRoute: QuanLyPhepDeXuatRoute,
+  QuanLyPhepDiaPhuongRoute: QuanLyPhepDiaPhuongRoute,
+  QuanLyPhepDonViRoute: QuanLyPhepDonViRoute,
+  QuanLyPhepDotNghiRoute: QuanLyPhepDotNghiRoute,
+  QuanLyPhepDuyetRoute: QuanLyPhepDuyetRoute,
+  QuanLyPhepLuuTruRoute: QuanLyPhepLuuTruRoute,
+  QuanLyPhepQuanNhanRoute: QuanLyPhepQuanNhanRoute,
+  QuanLyPhepQuyDinhRoute: QuanLyPhepQuyDinhRoute,
   TieuDoanAliasRoute: TieuDoanAliasRoute,
   VatTuBaoCaoRoute: VatTuBaoCaoRoute,
   VatTuCapNhatRoute: VatTuCapNhatRoute,
@@ -1039,6 +1290,7 @@ const rootRouteChildren: RootRouteChildren = {
   VatTuThanhLyRoute: VatTuThanhLyRoute,
   VatTuTimKiemRoute: VatTuTimKiemRoute,
   DeThiIndexRoute: DeThiIndexRoute,
+  QuanLyPhepIndexRoute: QuanLyPhepIndexRoute,
   VatTuIndexRoute: VatTuIndexRoute,
   DeThiChiTietIdRoute: DeThiChiTietIdRoute,
   DeThiSoanIdRoute: DeThiSoanIdRoute,

--- a/apps/web/src/routes/quan-ly-phep/bao-cao.tsx
+++ b/apps/web/src/routes/quan-ly-phep/bao-cao.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SidebarInset } from '@/components/ui/sidebar'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import LeaveReportsPage from '@/components/leave-management/LeaveReportsPage'
+
+export const Route = createFileRoute('/quan-ly-phep/bao-cao')({
+	component: () => (
+		<ProtectedRoute>
+			<SidebarInset>
+				<div className='p-6 md:p-8'>
+					<LeaveReportsPage />
+				</div>
+			</SidebarInset>
+		</ProtectedRoute>
+	)
+})

--- a/apps/web/src/routes/quan-ly-phep/chuc-vu.tsx
+++ b/apps/web/src/routes/quan-ly-phep/chuc-vu.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import { SidebarInset } from '@/components/ui/sidebar'
+import PositionsPage from '@/components/leave-management/PositionsPage'
+
+export const Route = createFileRoute('/quan-ly-phep/chuc-vu')({
+	component: () => (
+		<ProtectedRoute>
+			<SidebarInset>
+				<div className='p-6 md:p-8'>
+					<PositionsPage />
+				</div>
+			</SidebarInset>
+		</ProtectedRoute>
+	)
+})

--- a/apps/web/src/routes/quan-ly-phep/danh-sach.tsx
+++ b/apps/web/src/routes/quan-ly-phep/danh-sach.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SidebarInset } from '@/components/ui/sidebar'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import LeaveListPage from '@/components/leave-management/LeaveListPage'
+
+export const Route = createFileRoute('/quan-ly-phep/danh-sach')({
+	component: () => (
+		<ProtectedRoute>
+			<SidebarInset>
+				<div className='p-6 md:p-8'>
+					<LeaveListPage />
+				</div>
+			</SidebarInset>
+		</ProtectedRoute>
+	)
+})

--- a/apps/web/src/routes/quan-ly-phep/de-xuat.tsx
+++ b/apps/web/src/routes/quan-ly-phep/de-xuat.tsx
@@ -1,0 +1,23 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+import { SidebarInset } from '@/components/ui/sidebar'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import LeaveRequestForm from '@/components/leave-management/LeaveRequestForm'
+import { GetLeaveMyAccess } from '@/api/leave'
+
+export const Route = createFileRoute('/quan-ly-phep/de-xuat')({
+	beforeLoad: async () => {
+		const access = await GetLeaveMyAccess()
+		if (access.isAgency && !access.isAdmin) {
+			throw redirect({ to: '/quan-ly-phep/duyet' })
+		}
+	},
+	component: () => (
+		<ProtectedRoute>
+			<SidebarInset>
+				<div className='p-6 md:p-8'>
+					<LeaveRequestForm />
+				</div>
+			</SidebarInset>
+		</ProtectedRoute>
+	)
+})

--- a/apps/web/src/routes/quan-ly-phep/dia-phuong.tsx
+++ b/apps/web/src/routes/quan-ly-phep/dia-phuong.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SidebarInset } from '@/components/ui/sidebar'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import LocalitiesPage from '@/components/leave-management/LocalitiesPage'
+
+export const Route = createFileRoute('/quan-ly-phep/dia-phuong')({
+	component: () => (
+		<ProtectedRoute>
+			<SidebarInset>
+				<div className='p-6 md:p-8'>
+					<LocalitiesPage />
+				</div>
+			</SidebarInset>
+		</ProtectedRoute>
+	)
+})

--- a/apps/web/src/routes/quan-ly-phep/don-vi.tsx
+++ b/apps/web/src/routes/quan-ly-phep/don-vi.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SidebarInset } from '@/components/ui/sidebar'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import UnitsPage from '@/components/leave-management/UnitsPage'
+
+export const Route = createFileRoute('/quan-ly-phep/don-vi')({
+	component: () => (
+		<ProtectedRoute>
+			<SidebarInset>
+				<div className='p-6 md:p-8'>
+					<UnitsPage />
+				</div>
+			</SidebarInset>
+		</ProtectedRoute>
+	)
+})

--- a/apps/web/src/routes/quan-ly-phep/dot-nghi.tsx
+++ b/apps/web/src/routes/quan-ly-phep/dot-nghi.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SidebarInset } from '@/components/ui/sidebar'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import LeaveBatchesPage from '@/components/leave-management/LeaveBatchesPage'
+
+export const Route = createFileRoute('/quan-ly-phep/dot-nghi')({
+	component: () => (
+		<ProtectedRoute>
+			<SidebarInset>
+				<div className='p-6 md:p-8'>
+					<LeaveBatchesPage />
+				</div>
+			</SidebarInset>
+		</ProtectedRoute>
+	)
+})

--- a/apps/web/src/routes/quan-ly-phep/duyet.tsx
+++ b/apps/web/src/routes/quan-ly-phep/duyet.tsx
@@ -1,0 +1,33 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+import { SidebarInset } from '@/components/ui/sidebar'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import ApproveLeavePage from '@/components/leave-management/ApproveLeavePage'
+import { isSuperAdmin } from '@/lib/utils'
+import { GetLeaveMyAccess } from '@/api/leave'
+
+export const Route = createFileRoute('/quan-ly-phep/duyet')({
+	beforeLoad: async () => {
+		if (isSuperAdmin()) return
+		try {
+			const access = await GetLeaveMyAccess()
+			if (!access.isCommander && !access.isAgency && !access.isAdmin) {
+				throw redirect({ to: '/quan-ly-phep/danh-sach' })
+			}
+		} catch (e) {
+			if (e && typeof e === 'object' && 'to' in e) throw e
+		}
+	},
+	component: RouteComponent
+})
+
+function RouteComponent() {
+	return (
+		<ProtectedRoute>
+			<SidebarInset>
+				<div className='flex flex-1 flex-col space-y-8 p-6 md:p-8'>
+					<ApproveLeavePage />
+				</div>
+			</SidebarInset>
+		</ProtectedRoute>
+	)
+}

--- a/apps/web/src/routes/quan-ly-phep/index.tsx
+++ b/apps/web/src/routes/quan-ly-phep/index.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/quan-ly-phep/')({
+	beforeLoad: () => {
+		throw redirect({ to: '/quan-ly-phep/danh-sach' })
+	}
+})

--- a/apps/web/src/routes/quan-ly-phep/luu-tru.tsx
+++ b/apps/web/src/routes/quan-ly-phep/luu-tru.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SidebarInset } from '@/components/ui/sidebar'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import RecordsPage from '@/components/leave-management/RecordsPage'
+
+export const Route = createFileRoute('/quan-ly-phep/luu-tru')({
+	component: RouteComponent
+})
+
+function RouteComponent() {
+	return (
+		<ProtectedRoute>
+			<SidebarInset>
+				<div className='flex flex-1 flex-col space-y-8 p-6 md:p-8'>
+					<RecordsPage />
+				</div>
+			</SidebarInset>
+		</ProtectedRoute>
+	)
+}

--- a/apps/web/src/routes/quan-ly-phep/quan-nhan.tsx
+++ b/apps/web/src/routes/quan-ly-phep/quan-nhan.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SidebarInset } from '@/components/ui/sidebar'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import PersonnelPage from '@/components/leave-management/PersonnelPage'
+
+export const Route = createFileRoute('/quan-ly-phep/quan-nhan')({
+	component: RouteComponent
+})
+
+function RouteComponent() {
+	return (
+		<ProtectedRoute>
+			<SidebarInset>
+				<div className='flex flex-1 flex-col space-y-8 p-6 md:p-8'>
+					<PersonnelPage />
+				</div>
+			</SidebarInset>
+		</ProtectedRoute>
+	)
+}

--- a/apps/web/src/routes/quan-ly-phep/quy-dinh.tsx
+++ b/apps/web/src/routes/quan-ly-phep/quy-dinh.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SidebarInset } from '@/components/ui/sidebar'
+import ProtectedRoute from '@/components/ProtectedRoute'
+import RegulationsPage from '@/components/leave-management/RegulationsPage'
+
+export const Route = createFileRoute('/quan-ly-phep/quy-dinh')({
+	component: () => (
+		<ProtectedRoute>
+			<SidebarInset>
+				<div className='p-6 md:p-8'>
+					<RegulationsPage />
+				</div>
+			</SidebarInset>
+		</ProtectedRoute>
+	)
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
             node:
                 specifier: link:@libsql/client/node
                 version: link:@libsql/client/node
+            nodemailer:
+                specifier: ^9.0.3
+                version: 9.0.3
             uuid:
                 specifier: ^11.1.0
                 version: 11.1.0
@@ -7009,6 +7012,13 @@ packages:
                 integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==
             }
 
+    nodemailer@9.0.3:
+        resolution:
+            {
+                integrity: sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==
+            }
+        engines: { node: '>=6.0.0' }
+
     normalize-path@3.0.0:
         resolution:
             {
@@ -13026,6 +13036,8 @@ snapshots:
     node-gyp-build@4.8.4: {}
 
     node-releases@2.0.19: {}
+
+    nodemailer@9.0.3: {}
 
     normalize-path@3.0.0: {}
 


### PR DESCRIPTION
## Mục tiêu

Cho phép quản trị cấu hình SMTP và sử dụng cấu hình đó cho email phê duyệt nghỉ.

## Phạm vi

PR này chỉ chứa nhóm thay đổi tương ứng được tách từ #185; không kèm toàn bộ các PR trước.

## Thứ tự merge

Phụ thuộc #194; merge theo thứ tự PR tăng dần. Nhánh được tách độc lập từ `main` để phần review chỉ hiển thị đúng phạm vi của PR này.

## Lưu ý kiểm thử

Trạng thái tích hợp đầy đủ đã chạy được generate, migrate database sạch, Encore check và frontend build. Các lỗi TypeScript/lint và tình trạng thiếu automated tests đã được ghi nhận riêng, không được che giấu trong PR này.