### PR TITLE
feat(asset): expand asset workflows and standalone unit APIs

### DIFF
--- a/apps/api/asset-management/catalog.ts
+++ b/apps/api/asset-management/catalog.ts
@@ -43,6 +43,12 @@ export interface CatalogMaterial {
 	stockQuantity: number
 	/** SL danh mục (materials.quantity) — tăng/giảm user ngành */
 	catalogQuantity: number
+	manufactureYear: number | null
+	usageYear: number | null
+	classification: string | null
+	assetStatus: string
+	purchaseDate: string | null
+	expiryDate: string | null
 }
 
 export interface AssetCatalogResponse {
@@ -267,7 +273,13 @@ export const GetAssetCatalog = api(
 				quantity: materials.quantity,
 				categoryId: materials.categoryId,
 				categoryCode: categories.code,
-				categoryName: categories.name
+				categoryName: categories.name,
+				manufactureYear: materials.manufactureYear,
+				usageYear: materials.usageYear,
+				classification: materials.classification,
+				assetStatus: materials.assetStatus,
+				purchaseDate: materials.purchaseDate,
+				expiryDate: materials.expiryDate
 			})
 			.from(materials)
 			.innerJoin(categories, eq(materials.categoryId, categories.id))
@@ -303,7 +315,13 @@ export const GetAssetCatalog = api(
 					categoryName: m.categoryName,
 					nganhCode: nganhFromCode(categoryCode || m.code),
 					stockQuantity: stockMap.get(code) || 0,
-					catalogQuantity: Number(m.quantity) || 0
+					catalogQuantity: Number(m.quantity) || 0,
+					manufactureYear: m.manufactureYear ?? null,
+					usageYear: m.usageYear ?? null,
+					classification: m.classification ?? null,
+					assetStatus: m.assetStatus || 'NORMAL',
+					purchaseDate: m.purchaseDate ?? null,
+					expiryDate: m.expiryDate ?? null
 				}
 			})
 			.filter((m) => {
@@ -456,9 +474,16 @@ export const CreateCatalogMaterial = api(
 		chuyenNganhCode: string
 		name: string
 		unit?: string
+		quantity?: number
 		/** Tùy chọn — nếu trống hệ thống tự sinh */
 		code?: string
 		description?: string
+		manufactureYear?: number
+		usageYear?: number
+		classification?: string
+		assetStatus?: string
+		purchaseDate?: string
+		expiryDate?: string
 	}): Promise<{ data: CatalogMaterial }> => {
 		const cnCode = (body.chuyenNganhCode || '').trim().toUpperCase()
 		const name = (body.name || '').trim()
@@ -509,10 +534,16 @@ export const CreateCatalogMaterial = api(
 				code,
 				name,
 				unit,
-				quantity: 0,
+				quantity: Math.max(0, Math.floor(Number(body.quantity) || 0)),
 				minQuantity: 0,
 				status: 'ACTIVE',
-				description: body.description?.trim() || null
+				description: body.description?.trim() || null,
+				manufactureYear: body.manufactureYear,
+				usageYear: body.usageYear,
+				classification: body.classification?.trim() || null,
+				assetStatus: body.assetStatus || 'NORMAL',
+				purchaseDate: body.purchaseDate || null,
+				expiryDate: body.expiryDate || null
 			})
 			.returning()
 
@@ -546,7 +577,14 @@ export const CreateCatalogMaterial = api(
 				categoryCode: cat.code,
 				categoryName: cat.name,
 				nganhCode: nganhFromCode(cat.code),
-				stockQuantity: 0
+				stockQuantity: 0,
+				catalogQuantity: row.quantity,
+				manufactureYear: row.manufactureYear ?? null,
+				usageYear: row.usageYear ?? null,
+				classification: row.classification ?? null,
+				assetStatus: row.assetStatus || 'NORMAL',
+				purchaseDate: row.purchaseDate ?? null,
+				expiryDate: row.expiryDate ?? null
 			}
 		}
 	}
@@ -568,6 +606,12 @@ export const UpdateCatalogMaterial = api(
 		name?: string
 		unit?: string
 		description?: string | null
+		manufactureYear?: number | null
+		usageYear?: number | null
+		classification?: string | null
+		assetStatus?: string | null
+		purchaseDate?: string | null
+		expiryDate?: string | null
 	}): Promise<{ data: CatalogMaterial }> => {
 		const id = Number(params.id)
 		if (!Number.isFinite(id) || id <= 0) {
@@ -585,6 +629,12 @@ export const UpdateCatalogMaterial = api(
 			name?: string
 			unit?: string
 			description?: string | null
+			manufactureYear?: number | null
+			usageYear?: number | null
+			classification?: string | null
+			assetStatus?: string
+			purchaseDate?: string | null
+			expiryDate?: string | null
 		} = {}
 		const changes: string[] = []
 		if (params.name !== undefined) {
@@ -607,6 +657,22 @@ export const UpdateCatalogMaterial = api(
 				params.description === null
 					? null
 					: params.description.trim() || null
+		}
+		for (const key of [
+			'manufactureYear',
+			'usageYear',
+			'classification',
+			'purchaseDate',
+			'expiryDate'
+		] as const) {
+			if (params[key] !== undefined)
+				(patch as Record<string, unknown>)[key] =
+					typeof params[key] === 'string'
+						? (params[key] as string).trim() || null
+						: params[key]
+		}
+		if (params.assetStatus !== undefined) {
+			patch.assetStatus = params.assetStatus?.trim() || 'NORMAL'
 		}
 		if (Object.keys(patch).length === 0) {
 			throw APIError.invalidArgument('Không có trường để cập nhật')
@@ -642,7 +708,14 @@ export const UpdateCatalogMaterial = api(
 				categoryCode: cat?.code ?? '',
 				categoryName: cat?.name ?? '',
 				nganhCode: cat ? nganhFromCode(cat.code) : '',
-				stockQuantity: 0
+				stockQuantity: 0,
+				catalogQuantity: row.quantity,
+				manufactureYear: row.manufactureYear ?? null,
+				usageYear: row.usageYear ?? null,
+				classification: row.classification ?? null,
+				assetStatus: row.assetStatus || 'NORMAL',
+				purchaseDate: row.purchaseDate ?? null,
+				expiryDate: row.expiryDate ?? null
 			}
 		}
 	}

--- a/apps/api/exam-management/catalog.ts
+++ b/apps/api/exam-management/catalog.ts
@@ -8,7 +8,7 @@
  * Mã môn: {mã_ngành}_{mã_gốc}
  */
 import { api, APIError, Query } from 'encore.dev/api'
-import { and, eq, inArray, like, or, sql } from 'drizzle-orm'
+import { and, eq, inArray, like, or, sql, isNull } from 'drizzle-orm'
 import orm from '../database'
 import {
 	examClasses,
@@ -68,7 +68,7 @@ export interface FacultyResponse {
 	updatedAt: string
 	code: string
 	name: string
-	majorId: number
+	majorId: number | null
 	majorCode?: string | null
 	majorName?: string | null
 	description: string | null
@@ -116,7 +116,7 @@ export interface SubjectResponse {
 	facultyId: number
 	facultyCode?: string | null
 	facultyName?: string | null
-	majorId: number
+	majorId: number | null
 	majorCode?: string | null
 	majorName?: string | null
 	/** Hệ đào tạo (QS/DS) — để UI cố định khi GV import */
@@ -669,7 +669,7 @@ async function mapFaculty(
 		updatedAt: r.updatedAt,
 		code: r.code,
 		name: r.name,
-		majorId: r.majorId,
+		majorId: r.majorId ?? null,
 		majorCode: m?.code ?? null,
 		majorName: m?.name ?? null,
 		description: r.description
@@ -731,7 +731,7 @@ export const CreateExamFaculty = api(
 	async (body: {
 		code: string
 		name: string
-		majorId: number
+		majorId?: number | null
 		description?: string
 	}): Promise<{ data: FacultyResponse }> => {
 		const actor = await getActor()
@@ -740,21 +740,14 @@ export const CreateExamFaculty = api(
 		}
 		const code = body.code.trim().toUpperCase()
 		const name = body.name.trim()
-		if (!code || !name || !body.majorId) {
-			throw APIError.invalidArgument('Mã, tên khoa và ngành bắt buộc')
-		}
-		const [m] = await orm
-			.select()
-			.from(examMajors)
-			.where(eq(examMajors.id, body.majorId))
-			.limit(1)
-		if (!m) throw APIError.notFound('Ngành không tồn tại')
+		if (!code || !name)
+			throw APIError.invalidArgument('Mã và tên khoa bắt buộc')
 		const [row] = await orm
 			.insert(examFaculties)
 			.values({
 				code,
 				name,
-				majorId: body.majorId,
+				majorId: body.majorId ?? null,
 				description: body.description || null
 			})
 			.returning()
@@ -809,7 +802,9 @@ export const UpdateExamFaculty = api(
 				.from(examFaculties)
 				.where(
 					and(
-						eq(examFaculties.majorId, majorId),
+						majorId == null
+							? isNull(examFaculties.majorId)
+							: eq(examFaculties.majorId, majorId),
 						eq(examFaculties.code, code),
 						sql`${examFaculties.id} != ${params.id}`
 					)

--- a/apps/api/migrations/0056_standalone-faculties.sql
+++ b/apps/api/migrations/0056_standalone-faculties.sql
@@ -1,0 +1,18 @@
+-- Khoa là danh mục dùng chung, không phụ thuộc ngành đào tạo.
+-- Một migration cũ từng dùng cùng tên bảng tạm; luôn xóa trước để tránh tái sử
+-- dụng nhầm schema cũ khi cài đặt database từ đầu.
+DROP TABLE IF EXISTS `exam_faculties_new`;--> statement-breakpoint
+CREATE TABLE `exam_faculties_new` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  `updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  `code` text NOT NULL,
+  `name` text NOT NULL,
+  `major_id` integer,
+  `description` text
+);--> statement-breakpoint
+INSERT OR IGNORE INTO `exam_faculties_new` (id, createdAt, updatedAt, code, name, major_id, description)
+SELECT id, createdAt, updatedAt, code, name, major_id, description FROM `exam_faculties`;--> statement-breakpoint
+DROP TABLE IF EXISTS `exam_faculties`;--> statement-breakpoint
+ALTER TABLE `exam_faculties_new` RENAME TO `exam_faculties`;
+-- Dữ liệu cũ có thể lặp mã theo ngành; API sẽ dùng mã độc lập cho bản ghi mới.

--- a/apps/api/migrations/0057_material_asset_defaults.sql
+++ b/apps/api/migrations/0057_material_asset_defaults.sql
@@ -1,0 +1,7 @@
+-- Thuộc tính khai báo mặc định của vật tư danh mục
+ALTER TABLE `materials` ADD COLUMN `manufacture_year` integer;--> statement-breakpoint
+ALTER TABLE `materials` ADD COLUMN `usage_year` integer;--> statement-breakpoint
+ALTER TABLE `materials` ADD COLUMN `classification` text;--> statement-breakpoint
+ALTER TABLE `materials` ADD COLUMN `asset_status` text NOT NULL DEFAULT 'NORMAL';--> statement-breakpoint
+ALTER TABLE `materials` ADD COLUMN `purchase_date` text;--> statement-breakpoint
+ALTER TABLE `materials` ADD COLUMN `expiry_date` text;

--- a/apps/api/migrations/0058_leave_replacement_personnel.sql
+++ b/apps/api/migrations/0058_leave_replacement_personnel.sql
@@ -1,0 +1,7 @@
+-- Người thay thế quân nhân trong thời gian nghỉ phép
+ALTER TABLE `leave_requests` ADD COLUMN `replacement_personnel_id` integer;--> statement-breakpoint
+ALTER TABLE `leave_requests` ADD COLUMN `replacement_personnel_name` text;--> statement-breakpoint
+ALTER TABLE `leave_requests` ADD COLUMN `replacement_position` text;--> statement-breakpoint
+ALTER TABLE `leave_records` ADD COLUMN `replacement_personnel_id` integer;--> statement-breakpoint
+ALTER TABLE `leave_records` ADD COLUMN `replacement_personnel_name` text;--> statement-breakpoint
+ALTER TABLE `leave_records` ADD COLUMN `replacement_position` text;

--- a/apps/api/migrations/0059_burly_banshee.sql
+++ b/apps/api/migrations/0059_burly_banshee.sql
@@ -1,0 +1,3 @@
+-- Baseline snapshot after manual migrations 0042-0058.
+-- No SQL is required: all schema changes are already applied by those migrations.
+SELECT 1;

--- a/apps/api/migrations/0060_white_scarecrow.sql
+++ b/apps/api/migrations/0060_white_scarecrow.sql
@@ -1,0 +1,17 @@
+-- Đồng bộ cả database cũ lẫn database đã cài từ chuỗi migration trước đây:
+-- UNIQUE inline của SQLite tạo auto-index và không thể DROP INDEX trực tiếp.
+DROP TABLE IF EXISTS `exam_faculties_code_sync`;--> statement-breakpoint
+CREATE TABLE `exam_faculties_code_sync` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL,
+	`name` text NOT NULL,
+	`major_id` integer,
+	`description` text
+);--> statement-breakpoint
+INSERT INTO `exam_faculties_code_sync` (`id`, `createdAt`, `updatedAt`, `code`, `name`, `major_id`, `description`)
+SELECT `id`, `createdAt`, `updatedAt`, `code`, `name`, `major_id`, `description` FROM `exam_faculties`;--> statement-breakpoint
+DROP TABLE `exam_faculties`;--> statement-breakpoint
+ALTER TABLE `exam_faculties_code_sync` RENAME TO `exam_faculties`;--> statement-breakpoint
+CREATE INDEX `exam_faculties_code_idx` ON `exam_faculties` (`code`);

--- a/apps/api/migrations/0061_exam_subject_major_nullable.sql
+++ b/apps/api/migrations/0061_exam_subject_major_nullable.sql
@@ -1,0 +1,44 @@
+CREATE TABLE `__new_exam_subjects` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updatedAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`code` text NOT NULL UNIQUE,
+	`name` text NOT NULL,
+	`credit_hours` integer DEFAULT 0,
+	`lesson_hours` integer DEFAULT 0,
+	`major_id` integer,
+	`description` text,
+	`faculty_id` integer,
+	`base_code` text
+);--> statement-breakpoint
+INSERT INTO `__new_exam_subjects` (
+	`id`,
+	`createdAt`,
+	`updatedAt`,
+	`code`,
+	`name`,
+	`credit_hours`,
+	`lesson_hours`,
+	`major_id`,
+	`description`,
+	`faculty_id`,
+	`base_code`
+)
+SELECT
+	`id`,
+	`createdAt`,
+	`updatedAt`,
+	`code`,
+	`name`,
+	`credit_hours`,
+	`lesson_hours`,
+	`major_id`,
+	`description`,
+	`faculty_id`,
+	`base_code`
+FROM `exam_subjects`;--> statement-breakpoint
+DROP TABLE `exam_subjects`;--> statement-breakpoint
+ALTER TABLE `__new_exam_subjects` RENAME TO `exam_subjects`;--> statement-breakpoint
+CREATE INDEX `exam_subjects_major_idx` ON `exam_subjects` (`major_id`);--> statement-breakpoint
+CREATE INDEX `exam_subjects_faculty_idx` ON `exam_subjects` (`faculty_id`);--> statement-breakpoint
+CREATE INDEX `exam_subjects_base_code_idx` ON `exam_subjects` (`base_code`);

--- a/apps/api/migrations/meta/0059_snapshot.json
+++ b/apps/api/migrations/meta/0059_snapshot.json
@@ -1,0 +1,7651 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "0b0df46e-6525-456a-b4c3-ab54a055121d",
+	"prevId": "dfff3282-0fb1-42a4-b9fe-17c78924f6f5",
+	"tables": {
+		"account_audit_logs": {
+			"name": "account_audit_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_is_admin": {
+					"name": "actor_is_admin",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_code": {
+					"name": "room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_name": {
+					"name": "room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"floor_name": {
+					"name": "floor_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_code": {
+					"name": "building_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_name": {
+					"name": "building_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"account_label": {
+					"name": "account_label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"details": {
+					"name": "details",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"actions": {
+			"name": "actions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"actions_name_unique": {
+					"name": "actions_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_broken_logs": {
+			"name": "asset_broken_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_type": {
+					"name": "source_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'OTHER'"
+				},
+				"source_id": {
+					"name": "source_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_request_id": {
+					"name": "repair_request_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source_asset_id": {
+					"name": "source_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_code": {
+					"name": "asset_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"original_code": {
+					"name": "original_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_name": {
+					"name": "asset_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"original_grade": {
+					"name": "original_grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"grade_after": {
+					"name": "grade_after",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status_after": {
+					"name": "status_after",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_code": {
+					"name": "room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_name": {
+					"name": "room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"floor_name": {
+					"name": "floor_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_code": {
+					"name": "building_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_name": {
+					"name": "building_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_name": {
+					"name": "unit_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"result_note": {
+					"name": "result_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"performer": {
+					"name": "performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"event_at": {
+					"name": "event_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_movement_logs": {
+			"name": "asset_movement_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"movement_type": {
+					"name": "movement_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"executed_at": {
+					"name": "executed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"executing_unit": {
+					"name": "executing_unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"install_address": {
+					"name": "install_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_code": {
+					"name": "asset_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_name": {
+					"name": "asset_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"quantity_before": {
+					"name": "quantity_before",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"quantity_after": {
+					"name": "quantity_after",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"grade": {
+					"name": "grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"manufacture_year": {
+					"name": "manufacture_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"usage_year": {
+					"name": "usage_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reason_code": {
+					"name": "reason_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reason_other": {
+					"name": "reason_other",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_date": {
+					"name": "decision_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_number": {
+					"name": "decision_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"signer": {
+					"name": "signer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"performer": {
+					"name": "performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"explanation": {
+					"name": "explanation",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_code": {
+					"name": "building_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_name": {
+					"name": "building_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_code": {
+					"name": "room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_name": {
+					"name": "room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"floor_name": {
+					"name": "floor_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"asset_movement_logs_room_asset_id_room_assets_id_fk": {
+					"name": "asset_movement_logs_room_asset_id_room_assets_id_fk",
+					"tableFrom": "asset_movement_logs",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_proposal_items": {
+			"name": "asset_proposal_items",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"material_id": {
+					"name": "material_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"material_code": {
+					"name": "material_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"material_name": {
+					"name": "material_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source_asset_id": {
+					"name": "source_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"original_grade": {
+					"name": "original_grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"original_code": {
+					"name": "original_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"unit": {
+					"name": "unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"chuyen_nganh_code": {
+					"name": "chuyen_nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"from_room_id": {
+					"name": "from_room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"from_room_code": {
+					"name": "from_room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"from_room_name": {
+					"name": "from_room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"location_note": {
+					"name": "location_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"target_room_id": {
+					"name": "target_room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"target_room_code": {
+					"name": "target_room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"target_room_name": {
+					"name": "target_room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_proposal_logs": {
+			"name": "asset_proposal_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"proposal_type": {
+					"name": "proposal_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"details": {
+					"name": "details",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_is_admin": {
+					"name": "actor_is_admin",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_proposals": {
+			"name": "asset_proposals",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"proposal_type": {
+					"name": "proposal_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'PENDING'"
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_id": {
+					"name": "unit_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_name": {
+					"name": "unit_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_user_id": {
+					"name": "proposed_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_username": {
+					"name": "proposed_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_display_name": {
+					"name": "proposed_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"admin_note": {
+					"name": "admin_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_number": {
+					"name": "decision_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_nganh_code": {
+					"name": "decision_nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_issuing_level": {
+					"name": "decision_issuing_level",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_signer": {
+					"name": "decision_signer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_at": {
+					"name": "decision_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_user_id": {
+					"name": "decided_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_username": {
+					"name": "decided_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_display_name": {
+					"name": "decided_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"buildings": {
+			"name": "buildings",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"manager_code": {
+					"name": "manager_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"area": {
+					"name": "area",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"buildings_code_unique": {
+					"name": "buildings_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"catalog_audit_logs": {
+			"name": "catalog_audit_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"entity_type": {
+					"name": "entity_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_is_admin": {
+					"name": "actor_is_admin",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"entity_id": {
+					"name": "entity_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"entity_code": {
+					"name": "entity_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"entity_name": {
+					"name": "entity_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"parent_code": {
+					"name": "parent_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"parent_name": {
+					"name": "parent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"details": {
+					"name": "details",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"catalog_stock_logs": {
+			"name": "catalog_stock_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"movement_type": {
+					"name": "movement_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"executed_at": {
+					"name": "executed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"material_id": {
+					"name": "material_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"material_code": {
+					"name": "material_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"material_name": {
+					"name": "material_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"chuyen_nganh_code": {
+					"name": "chuyen_nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"chuyen_nganh_name": {
+					"name": "chuyen_nganh_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"quantity_before": {
+					"name": "quantity_before",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"quantity_after": {
+					"name": "quantity_after",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"unit": {
+					"name": "unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_new_material": {
+					"name": "is_new_material",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_is_admin": {
+					"name": "actor_is_admin",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"categories": {
+			"name": "categories",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"categories_code_unique": {
+					"name": "categories_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"classes": {
+			"name": "classes",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"graduatedAt": {
+					"name": "graduatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'ongoing'"
+				},
+				"unitId": {
+					"name": "unitId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"class_unit_unique_constraint": {
+					"name": "class_unit_unique_constraint",
+					"columns": ["name", "unitId"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"classes_unitId_units_id_fk": {
+					"name": "classes_unitId_units_id_fk",
+					"tableFrom": "classes",
+					"tableTo": "units",
+					"columnsFrom": ["unitId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_academic_titles": {
+			"name": "exam_academic_titles",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"percentage": {
+					"name": "percentage",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {
+				"exam_academic_titles_name_uq": {
+					"name": "exam_academic_titles_name_uq",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_classes": {
+			"name": "exam_classes",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"faculty_id": {
+					"name": "faculty_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"cohort": {
+					"name": "cohort",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_classes_code_unique": {
+					"name": "exam_classes_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_draw_logs": {
+			"name": "exam_draw_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"draw_id": {
+					"name": "draw_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"details": {
+					"name": "details",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_draws": {
+			"name": "exam_draws",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"draw_code": {
+					"name": "draw_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"exam_id": {
+					"name": "exam_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"exam_code": {
+					"name": "exam_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"paper_number": {
+					"name": "paper_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"subject_id": {
+					"name": "subject_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"draw_type": {
+					"name": "draw_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_name": {
+					"name": "class_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"drawn_by_user_id": {
+					"name": "drawn_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"drawn_by_username": {
+					"name": "drawn_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"drawn_by_display_name": {
+					"name": "drawn_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"drawn_at": {
+					"name": "drawn_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"printed_at": {
+					"name": "printed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"printed_by_user_id": {
+					"name": "printed_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"printed_by_username": {
+					"name": "printed_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"print_blocked": {
+					"name": "print_blocked",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"print_blocked_at": {
+					"name": "print_blocked_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"print_blocked_reason": {
+					"name": "print_blocked_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"exam_date": {
+					"name": "exam_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"exam_time": {
+					"name": "exam_time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"location": {
+					"name": "location",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_draws_draw_code_unique": {
+					"name": "exam_draws_draw_code_unique",
+					"columns": ["draw_code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_faculties": {
+			"name": "exam_faculties",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_faculties_code_uq": {
+					"name": "exam_faculties_code_uq",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_faculty_heads": {
+			"name": "exam_faculty_heads",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"faculty_code": {
+					"name": "faculty_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"faculty_name": {
+					"name": "faculty_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_faculty_heads_user_fac_uq": {
+					"name": "exam_faculty_heads_user_fac_uq",
+					"columns": ["user_id", "faculty_code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_major_heads": {
+			"name": "exam_major_heads",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_majors": {
+			"name": "exam_majors",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"system_id": {
+					"name": "system_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"level_code": {
+					"name": "level_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"short_code": {
+					"name": "short_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"catalog_number": {
+					"name": "catalog_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"national_major_code": {
+					"name": "national_major_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"qualification": {
+					"name": "qualification",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"training_duration": {
+					"name": "training_duration",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"training_form": {
+					"name": "training_form",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_majors_code_unique": {
+					"name": "exam_majors_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_questions": {
+			"name": "exam_questions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"exam_id": {
+					"name": "exam_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"question_number": {
+					"name": "question_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"answer": {
+					"name": "answer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"points": {
+					"name": "points",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_subjects": {
+			"name": "exam_subjects",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"base_code": {
+					"name": "base_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"credit_hours": {
+					"name": "credit_hours",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 0
+				},
+				"lesson_hours": {
+					"name": "lesson_hours",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 0
+				},
+				"faculty_id": {
+					"name": "faculty_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_subjects_code_unique": {
+					"name": "exam_subjects_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_systems": {
+			"name": "exam_systems",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"letter": {
+					"name": "letter",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"training_type_id": {
+					"name": "training_type_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_systems_code_unique": {
+					"name": "exam_systems_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				},
+				"exam_systems_letter_unique": {
+					"name": "exam_systems_letter_unique",
+					"columns": ["letter"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_teachers": {
+			"name": "exam_teachers",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"faculty_code": {
+					"name": "faculty_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"faculty_name": {
+					"name": "faculty_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"academic_title_id": {
+					"name": "academic_title_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_user_id": {
+					"name": "created_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_username": {
+					"name": "created_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_display_name": {
+					"name": "created_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_teachers_user_uq": {
+					"name": "exam_teachers_user_uq",
+					"columns": ["user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_teaching_assignment_logs": {
+			"name": "exam_teaching_assignment_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"subject_id": {
+					"name": "subject_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"subject_code": {
+					"name": "subject_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"subject_name": {
+					"name": "subject_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"major_code": {
+					"name": "major_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"faculty_id": {
+					"name": "faculty_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"faculty_code": {
+					"name": "faculty_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_code": {
+					"name": "class_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_name": {
+					"name": "class_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teacher_user_id": {
+					"name": "teacher_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teacher_username": {
+					"name": "teacher_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teacher_display_name": {
+					"name": "teacher_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_teaching_assignments": {
+			"name": "exam_teaching_assignments",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"subject_id": {
+					"name": "subject_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teaching_start": {
+					"name": "teaching_start",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teaching_end": {
+					"name": "teaching_end",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_by_user_id": {
+					"name": "assigned_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_by_username": {
+					"name": "assigned_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_by_display_name": {
+					"name": "assigned_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_workflow_logs": {
+			"name": "exam_workflow_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"exam_id": {
+					"name": "exam_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"from_status": {
+					"name": "from_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"to_status": {
+					"name": "to_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exams": {
+			"name": "exams",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"subject_id": {
+					"name": "subject_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"paper_number": {
+					"name": "paper_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'DRAFT'"
+				},
+				"created_by_user_id": {
+					"name": "created_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_username": {
+					"name": "created_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_display_name": {
+					"name": "created_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_user_id": {
+					"name": "approved_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_username": {
+					"name": "approved_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_display_name": {
+					"name": "approved_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_at": {
+					"name": "approved_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_rank": {
+					"name": "approved_by_rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_position": {
+					"name": "approved_by_position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_signature_url": {
+					"name": "approved_by_signature_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_title": {
+					"name": "approved_by_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_user_id": {
+					"name": "dept_head_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_username": {
+					"name": "dept_head_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_display_name": {
+					"name": "dept_head_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_rank": {
+					"name": "dept_head_rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_signature_url": {
+					"name": "dept_head_signature_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_approved_at": {
+					"name": "dept_head_approved_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"qr_code": {
+					"name": "qr_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"locked": {
+					"name": "locked",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_name": {
+					"name": "class_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration_minutes": {
+					"name": "duration_minutes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 60
+				},
+				"question_file_url": {
+					"name": "question_file_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"question_file_name": {
+					"name": "question_file_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"answer_file_url": {
+					"name": "answer_file_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"answer_file_name": {
+					"name": "answer_file_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"return_note": {
+					"name": "return_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exams_code_unique": {
+					"name": "exams_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"floors": {
+			"name": "floors",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"building_id": {
+					"name": "building_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"floor_number": {
+					"name": "floor_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"floors_building_id_buildings_id_fk": {
+					"name": "floors_building_id_buildings_id_fk",
+					"tableFrom": "floors",
+					"tableTo": "buildings",
+					"columnsFrom": ["building_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"resources": {
+			"name": "resources",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"resources_name_unique": {
+					"name": "resources_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"permissions": {
+			"name": "permissions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"resource_id": {
+					"name": "resource_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"action_id": {
+					"name": "action_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"permissions_name_unique": {
+					"name": "permissions_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"permissions_resource_id_resources_id_fk": {
+					"name": "permissions_resource_id_resources_id_fk",
+					"tableFrom": "permissions",
+					"tableTo": "resources",
+					"columnsFrom": ["resource_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"permissions_action_id_actions_id_fk": {
+					"name": "permissions_action_id_actions_id_fk",
+					"tableFrom": "permissions",
+					"tableTo": "actions",
+					"columnsFrom": ["action_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"roles": {
+			"name": "roles",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"roles_name_unique": {
+					"name": "roles_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"role_permissions": {
+			"name": "role_permissions",
+			"columns": {
+				"role_id": {
+					"name": "role_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"permission_id": {
+					"name": "permission_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"role_permissions_role_id_roles_id_fk": {
+					"name": "role_permissions_role_id_roles_id_fk",
+					"tableFrom": "role_permissions",
+					"tableTo": "roles",
+					"columnsFrom": ["role_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"role_permissions_permission_id_permissions_id_fk": {
+					"name": "role_permissions_permission_id_permissions_id_fk",
+					"tableFrom": "role_permissions",
+					"tableTo": "permissions",
+					"columnsFrom": ["permission_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"role_permissions_role_id_permission_id_pk": {
+					"columns": ["role_id", "permission_id"],
+					"name": "role_permissions_role_id_permission_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_roles": {
+			"name": "user_roles",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role_id": {
+					"name": "role_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_roles_user_id_users_id_fk": {
+					"name": "user_roles_user_id_users_id_fk",
+					"tableFrom": "user_roles",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"user_roles_role_id_roles_id_fk": {
+					"name": "user_roles_role_id_roles_id_fk",
+					"tableFrom": "user_roles",
+					"tableTo": "roles",
+					"columnsFrom": ["role_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_roles_user_id_role_id_pk": {
+					"columns": ["user_id", "role_id"],
+					"name": "user_roles_user_id_role_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"displayName": {
+					"name": "displayName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"isSuperUser": {
+					"name": "isSuperUser",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"unitId": {
+					"name": "unitId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"rank": {
+					"name": "rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"position": {
+					"name": "position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"alias": {
+					"name": "alias",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"leave_unit_id": {
+					"name": "leave_unit_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"management_area": {
+					"name": "management_area",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"signature_url": {
+					"name": "signature_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"users_username_unique": {
+					"name": "users_username_unique",
+					"columns": ["username"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"users_unitId_units_id_fk": {
+					"name": "users_unitId_units_id_fk",
+					"tableFrom": "users",
+					"tableTo": "units",
+					"columnsFrom": ["unitId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"units": {
+			"name": "units",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"alias": {
+					"name": "alias",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"level": {
+					"name": "level",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parentId": {
+					"name": "parentId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"units_alias_unique": {
+					"name": "units_alias_unique",
+					"columns": ["alias"],
+					"isUnique": true
+				},
+				"units_name_unique": {
+					"name": "units_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"parent_id_fk": {
+					"name": "parent_id_fk",
+					"tableFrom": "units",
+					"tableTo": "units",
+					"columnsFrom": ["parentId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"students": {
+			"name": "students",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"fullName": {
+					"name": "fullName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"birthPlace": {
+					"name": "birthPlace",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"dob": {
+					"name": "dob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"rank": {
+					"name": "rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"previousUnit": {
+					"name": "previousUnit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"previousPosition": {
+					"name": "previousPosition",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"position": {
+					"name": "position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Học viên'"
+				},
+				"ethnic": {
+					"name": "ethnic",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"religion": {
+					"name": "religion",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"enlistmentPeriod": {
+					"name": "enlistmentPeriod",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"politicalOrg": {
+					"name": "politicalOrg",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"politicalOrgOfficialDate": {
+					"name": "politicalOrgOfficialDate",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"cpvId": {
+					"name": "cpvId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"educationLevel": {
+					"name": "educationLevel",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"schoolName": {
+					"name": "schoolName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"major": {
+					"name": "major",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"isGraduated": {
+					"name": "isGraduated",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": false
+				},
+				"talent": {
+					"name": "talent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"shortcoming": {
+					"name": "shortcoming",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"policyBeneficiaryGroup": {
+					"name": "policyBeneficiaryGroup",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"fatherName": {
+					"name": "fatherName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"fatherDob": {
+					"name": "fatherDob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"fatherPhoneNumber": {
+					"name": "fatherPhoneNumber",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"fatherJob": {
+					"name": "fatherJob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"motherName": {
+					"name": "motherName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"motherDob": {
+					"name": "motherDob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"motherPhoneNumber": {
+					"name": "motherPhoneNumber",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"motherJob": {
+					"name": "motherJob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"isMarried": {
+					"name": "isMarried",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": false
+				},
+				"spouseName": {
+					"name": "spouseName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"spouseDob": {
+					"name": "spouseDob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"spouseJob": {
+					"name": "spouseJob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"spousePhoneNumber": {
+					"name": "spousePhoneNumber",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"childrenInfos": {
+					"name": "childrenInfos",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"familySize": {
+					"name": "familySize",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"familyBackground": {
+					"name": "familyBackground",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"familyBirthOrder": {
+					"name": "familyBirthOrder",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"achievement": {
+					"name": "achievement",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"disciplinaryHistory": {
+					"name": "disciplinaryHistory",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"phone": {
+					"name": "phone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"classId": {
+					"name": "classId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cpvOfficialAt": {
+					"name": "cpvOfficialAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"avatar": {
+					"name": "avatar",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"siblings": {
+					"name": "siblings",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"contactPerson": {
+					"name": "contactPerson",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'{}'"
+				},
+				"studentId": {
+					"name": "studentId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"relatedDocumentations": {
+					"name": "relatedDocumentations",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"students_classId_classes_id_fk": {
+					"name": "students_classId_classes_id_fk",
+					"tableFrom": "students",
+					"tableTo": "classes",
+					"columnsFrom": ["classId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"rooms": {
+			"name": "rooms",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"floor_id": {
+					"name": "floor_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_code": {
+					"name": "room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_name": {
+					"name": "room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_type": {
+					"name": "room_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"manager": {
+					"name": "manager",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"manager_code": {
+					"name": "manager_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"account_password": {
+					"name": "account_password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"capacity": {
+					"name": "capacity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'ACTIVE'"
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"rooms_room_code_unique": {
+					"name": "rooms_room_code_unique",
+					"columns": ["room_code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"rooms_floor_id_floors_id_fk": {
+					"name": "rooms_floor_id_floors_id_fk",
+					"tableFrom": "rooms",
+					"tableTo": "floors",
+					"columnsFrom": ["floor_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"rooms_class_id_classes_id_fk": {
+					"name": "rooms_class_id_classes_id_fk",
+					"tableFrom": "rooms",
+					"tableTo": "classes",
+					"columnsFrom": ["class_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"room_images": {
+			"name": "room_images",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"image_url": {
+					"name": "image_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"room_images_room_id_rooms_id_fk": {
+					"name": "room_images_room_id_rooms_id_fk",
+					"tableFrom": "room_images",
+					"tableTo": "rooms",
+					"columnsFrom": ["room_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"room_assets": {
+			"name": "room_assets",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"broken_quantity": {
+					"name": "broken_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"unit": {
+					"name": "unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"holding_unit_id": {
+					"name": "holding_unit_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"grade": {
+					"name": "grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"manufacture_year": {
+					"name": "manufacture_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"usage_year": {
+					"name": "usage_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"install_address": {
+					"name": "install_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'NORMAL'"
+				},
+				"purchase_date": {
+					"name": "purchase_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expiry_date": {
+					"name": "expiry_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"broken_at": {
+					"name": "broken_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_started_at": {
+					"name": "repair_started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_completed_at": {
+					"name": "repair_completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_performer": {
+					"name": "repair_performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"room_assets_code_unique": {
+					"name": "room_assets_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"room_assets_room_id_rooms_id_fk": {
+					"name": "room_assets_room_id_rooms_id_fk",
+					"tableFrom": "room_assets",
+					"tableTo": "rooms",
+					"columnsFrom": ["room_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"room_assets_holding_unit_id_units_id_fk": {
+					"name": "room_assets_holding_unit_id_units_id_fk",
+					"tableFrom": "room_assets",
+					"tableTo": "units",
+					"columnsFrom": ["holding_unit_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"repair_logs": {
+			"name": "repair_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"repair_date": {
+					"name": "repair_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cost": {
+					"name": "cost",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"performer": {
+					"name": "performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"repair_logs_room_asset_id_room_assets_id_fk": {
+					"name": "repair_logs_room_asset_id_room_assets_id_fk",
+					"tableFrom": "repair_logs",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"inventory_logs": {
+			"name": "inventory_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"inventory_date": {
+					"name": "inventory_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actual_quantity": {
+					"name": "actual_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"expected_quantity": {
+					"name": "expected_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"result": {
+					"name": "result",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"inventory_logs_room_asset_id_room_assets_id_fk": {
+					"name": "inventory_logs_room_asset_id_room_assets_id_fk",
+					"tableFrom": "inventory_logs",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"replacement_logs": {
+			"name": "replacement_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"replacement_date": {
+					"name": "replacement_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"old_asset": {
+					"name": "old_asset",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"new_asset": {
+					"name": "new_asset",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"performer": {
+					"name": "performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"replacement_logs_room_asset_id_room_assets_id_fk": {
+					"name": "replacement_logs_room_asset_id_room_assets_id_fk",
+					"tableFrom": "replacement_logs",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_audit_logs": {
+			"name": "leave_audit_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"entity_type": {
+					"name": "entity_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"entity_id": {
+					"name": "entity_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"details": {
+					"name": "details",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_nganh": {
+			"name": "user_nganh",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_nganh_user_nganh_uq": {
+					"name": "user_nganh_user_nganh_uq",
+					"columns": ["user_id", "nganh_code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"user_nganh_user_id_users_id_fk": {
+					"name": "user_nganh_user_id_users_id_fk",
+					"tableFrom": "user_nganh",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"repair_requests": {
+			"name": "repair_requests",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source_asset_id": {
+					"name": "source_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"original_grade": {
+					"name": "original_grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_name": {
+					"name": "asset_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'PENDING'"
+				},
+				"broken_at": {
+					"name": "broken_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reported_by_name": {
+					"name": "reported_by_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reported_by_user_id": {
+					"name": "reported_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_to_name": {
+					"name": "assigned_to_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_at": {
+					"name": "assigned_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_by_name": {
+					"name": "assigned_by_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_started_at": {
+					"name": "repair_started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"admin_note": {
+					"name": "admin_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"repair_requests_room_id_rooms_id_fk": {
+					"name": "repair_requests_room_id_rooms_id_fk",
+					"tableFrom": "repair_requests",
+					"tableTo": "rooms",
+					"columnsFrom": ["room_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"repair_requests_room_asset_id_room_assets_id_fk": {
+					"name": "repair_requests_room_asset_id_room_assets_id_fk",
+					"tableFrom": "repair_requests",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"repair_requests_source_asset_id_room_assets_id_fk": {
+					"name": "repair_requests_source_asset_id_room_assets_id_fk",
+					"tableFrom": "repair_requests",
+					"tableTo": "room_assets",
+					"columnsFrom": ["source_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"repair_requests_reported_by_user_id_users_id_fk": {
+					"name": "repair_requests_reported_by_user_id_users_id_fk",
+					"tableFrom": "repair_requests",
+					"tableTo": "users",
+					"columnsFrom": ["reported_by_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"suppliers": {
+			"name": "suppliers",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"contact_person": {
+					"name": "contact_person",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"suppliers_code_unique": {
+					"name": "suppliers_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"materials": {
+			"name": "materials",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"category_id": {
+					"name": "category_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"supplier_id": {
+					"name": "supplier_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"unit": {
+					"name": "unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"min_quantity": {
+					"name": "min_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"price": {
+					"name": "price",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'ACTIVE'"
+				},
+				"manufacture_year": {
+					"name": "manufacture_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"usage_year": {
+					"name": "usage_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"classification": {
+					"name": "classification",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_status": {
+					"name": "asset_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'NORMAL'"
+				},
+				"purchase_date": {
+					"name": "purchase_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expiry_date": {
+					"name": "expiry_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"materials_code_unique": {
+					"name": "materials_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"materials_category_id_categories_id_fk": {
+					"name": "materials_category_id_categories_id_fk",
+					"tableFrom": "materials",
+					"tableTo": "categories",
+					"columnsFrom": ["category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"materials_supplier_id_suppliers_id_fk": {
+					"name": "materials_supplier_id_suppliers_id_fk",
+					"tableFrom": "materials",
+					"tableTo": "suppliers",
+					"columnsFrom": ["supplier_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"warehouses": {
+			"name": "warehouses",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"location": {
+					"name": "location",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"manager": {
+					"name": "manager",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"warehouses_code_unique": {
+					"name": "warehouses_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"warehouse_items": {
+			"name": "warehouse_items",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"warehouse_id": {
+					"name": "warehouse_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"material_id": {
+					"name": "material_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"min_quantity": {
+					"name": "min_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"warehouse_items_warehouse_id_warehouses_id_fk": {
+					"name": "warehouse_items_warehouse_id_warehouses_id_fk",
+					"tableFrom": "warehouse_items",
+					"tableTo": "warehouses",
+					"columnsFrom": ["warehouse_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"warehouse_items_material_id_materials_id_fk": {
+					"name": "warehouse_items_material_id_materials_id_fk",
+					"tableFrom": "warehouse_items",
+					"tableTo": "materials",
+					"columnsFrom": ["material_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"notification_items": {
+			"name": "notification_items",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"notifiableType": {
+					"name": "notifiableType",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"notifiableId": {
+					"name": "notifiableId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"notificationId": {
+					"name": "notificationId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"notification_items_notification_idx": {
+					"name": "notification_items_notification_idx",
+					"columns": ["notificationId"],
+					"isUnique": false
+				},
+				"notification_items_item_idx": {
+					"name": "notification_items_item_idx",
+					"columns": ["notifiableType", "notifiableId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"notification_items_notificationId_notifications_id_fk": {
+					"name": "notification_items_notificationId_notifications_id_fk",
+					"tableFrom": "notification_items",
+					"tableTo": "notifications",
+					"columnsFrom": ["notificationId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"notifications": {
+			"name": "notifications",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"readAt": {
+					"name": "readAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notificationType": {
+					"name": "notificationType",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'birthday'"
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"message": {
+					"name": "message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"isBatch": {
+					"name": "isBatch",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": false
+				},
+				"batchKey": {
+					"name": "batchKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"totalCount": {
+					"name": "totalCount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 1
+				},
+				"recipientId": {
+					"name": "recipientId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actorId": {
+					"name": "actorId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"recipient_idx": {
+					"name": "recipient_idx",
+					"columns": ["recipientId"],
+					"isUnique": false
+				},
+				"batch_idx": {
+					"name": "batch_idx",
+					"columns": ["batchKey"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"notifications_recipientId_users_id_fk": {
+					"name": "notifications_recipientId_users_id_fk",
+					"tableFrom": "notifications",
+					"tableTo": "users",
+					"columnsFrom": ["recipientId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"notifications_actorId_users_id_fk": {
+					"name": "notifications_actorId_users_id_fk",
+					"tableFrom": "notifications",
+					"tableTo": "users",
+					"columnsFrom": ["actorId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_alerts": {
+			"name": "leave_alerts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"request_id": {
+					"name": "request_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"message": {
+					"name": "message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"read_at": {
+					"name": "read_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_classes": {
+			"name": "leave_classes",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"unit_id": {
+					"name": "unit_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_extra_standards": {
+			"name": "leave_extra_standards",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"days": {
+					"name": "days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				}
+			},
+			"indexes": {
+				"leave_extra_standards_code_unique": {
+					"name": "leave_extra_standards_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_localities": {
+			"name": "leave_localities",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"level": {
+					"name": "level",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parent_id": {
+					"name": "parent_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_mail_log": {
+			"name": "leave_mail_log",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"request_id": {
+					"name": "request_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"to_email": {
+					"name": "to_email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"subject": {
+					"name": "subject",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ok": {
+					"name": "ok",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preview_url": {
+					"name": "preview_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_object_types": {
+			"name": "leave_object_types",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				}
+			},
+			"indexes": {
+				"leave_object_types_code_unique": {
+					"name": "leave_object_types_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_personnel": {
+			"name": "leave_personnel",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"full_name": {
+					"name": "full_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"enlistment_date": {
+					"name": "enlistment_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"recruitment": {
+					"name": "recruitment",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"object_type": {
+					"name": "object_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"position": {
+					"name": "position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_id": {
+					"name": "unit_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_name": {
+					"name": "unit_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"hometown": {
+					"name": "hometown",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"permanent_residence": {
+					"name": "permanent_residence",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"commander_user_id": {
+					"name": "commander_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"commander_name": {
+					"name": "commander_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_name": {
+					"name": "class_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"management_area": {
+					"name": "management_area",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'cán_bộ'"
+				}
+			},
+			"indexes": {
+				"leave_personnel_code_unique": {
+					"name": "leave_personnel_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_records": {
+			"name": "leave_records",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"request_id": {
+					"name": "request_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'PENDING'"
+				},
+				"leave_type": {
+					"name": "leave_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"personnel_id": {
+					"name": "personnel_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"personnel_code": {
+					"name": "personnel_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"personnel_name": {
+					"name": "personnel_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"object_type": {
+					"name": "object_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"position": {
+					"name": "position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"enlistment_date": {
+					"name": "enlistment_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_id": {
+					"name": "unit_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_name": {
+					"name": "unit_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"service_years": {
+					"name": "service_years",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"base_days": {
+					"name": "base_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"travel_days": {
+					"name": "travel_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"extra_days": {
+					"name": "extra_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"extra_reasons": {
+					"name": "extra_reasons",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"total_days": {
+					"name": "total_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"start_date": {
+					"name": "start_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"end_date": {
+					"name": "end_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"leave_year": {
+					"name": "leave_year",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"locality_id": {
+					"name": "locality_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"locality_path": {
+					"name": "locality_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"replacement_personnel_id": {
+					"name": "replacement_personnel_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"replacement_personnel_name": {
+					"name": "replacement_personnel_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"replacement_position": {
+					"name": "replacement_position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"admin_note": {
+					"name": "admin_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_user_id": {
+					"name": "proposed_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_username": {
+					"name": "proposed_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_display_name": {
+					"name": "proposed_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_user_id": {
+					"name": "decided_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_username": {
+					"name": "decided_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_at": {
+					"name": "decided_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"archived_at": {
+					"name": "archived_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_regulations": {
+			"name": "leave_regulations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"leave_type": {
+					"name": "leave_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"object_type": {
+					"name": "object_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"min_years": {
+					"name": "min_years",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"max_years": {
+					"name": "max_years",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"base_days": {
+					"name": "base_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_requests": {
+			"name": "leave_requests",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"leave_type": {
+					"name": "leave_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"request_scope": {
+					"name": "request_scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'OTHER'"
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_name": {
+					"name": "class_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'PENDING'"
+				},
+				"personnel_id": {
+					"name": "personnel_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"personnel_code": {
+					"name": "personnel_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"personnel_name": {
+					"name": "personnel_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"object_type": {
+					"name": "object_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"position": {
+					"name": "position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"enlistment_date": {
+					"name": "enlistment_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_id": {
+					"name": "unit_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_name": {
+					"name": "unit_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"service_years": {
+					"name": "service_years",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"base_days": {
+					"name": "base_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"travel_days": {
+					"name": "travel_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"extra_days": {
+					"name": "extra_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"extra_reasons": {
+					"name": "extra_reasons",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"total_days": {
+					"name": "total_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"start_date": {
+					"name": "start_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"end_date": {
+					"name": "end_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"leave_year": {
+					"name": "leave_year",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"locality_id": {
+					"name": "locality_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"locality_path": {
+					"name": "locality_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_user_id": {
+					"name": "proposed_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_username": {
+					"name": "proposed_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_display_name": {
+					"name": "proposed_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposer_email": {
+					"name": "proposer_email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"commander_user_id": {
+					"name": "commander_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"commander_name": {
+					"name": "commander_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"replacement_personnel_id": {
+					"name": "replacement_personnel_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"replacement_personnel_name": {
+					"name": "replacement_personnel_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"replacement_position": {
+					"name": "replacement_position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"admin_note": {
+					"name": "admin_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_user_id": {
+					"name": "decided_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_username": {
+					"name": "decided_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_at": {
+					"name": "decided_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_units": {
+			"name": "leave_units",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"level": {
+					"name": "level",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"parent_id": {
+					"name": "parent_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"commander_user_id": {
+					"name": "commander_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"commander_name": {
+					"name": "commander_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"management_area": {
+					"name": "management_area",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'cán_bộ'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_batches": {
+			"name": "leave_batches",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"request_id": {
+					"name": "request_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"personnel_id": {
+					"name": "personnel_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"personnel_code": {
+					"name": "personnel_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"personnel_name": {
+					"name": "personnel_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"object_type": {
+					"name": "object_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"leave_type": {
+					"name": "leave_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"batch_index": {
+					"name": "batch_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"batch_label": {
+					"name": "batch_label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"start_date": {
+					"name": "start_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"end_date": {
+					"name": "end_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"total_days": {
+					"name": "total_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_user_id": {
+					"name": "created_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_positions": {
+			"name": "leave_positions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				}
+			},
+			"indexes": {
+				"leave_positions_name_unique": {
+					"name": "leave_positions_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/apps/api/migrations/meta/0060_snapshot.json
+++ b/apps/api/migrations/meta/0060_snapshot.json
@@ -1,0 +1,7651 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "875c2aa6-d28a-454f-8261-c4c0292252d4",
+	"prevId": "0b0df46e-6525-456a-b4c3-ab54a055121d",
+	"tables": {
+		"account_audit_logs": {
+			"name": "account_audit_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_is_admin": {
+					"name": "actor_is_admin",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_code": {
+					"name": "room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_name": {
+					"name": "room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"floor_name": {
+					"name": "floor_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_code": {
+					"name": "building_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_name": {
+					"name": "building_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"account_label": {
+					"name": "account_label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"details": {
+					"name": "details",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"actions": {
+			"name": "actions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"actions_name_unique": {
+					"name": "actions_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_broken_logs": {
+			"name": "asset_broken_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"source_type": {
+					"name": "source_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'OTHER'"
+				},
+				"source_id": {
+					"name": "source_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_request_id": {
+					"name": "repair_request_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source_asset_id": {
+					"name": "source_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_code": {
+					"name": "asset_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"original_code": {
+					"name": "original_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_name": {
+					"name": "asset_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"original_grade": {
+					"name": "original_grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"grade_after": {
+					"name": "grade_after",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status_after": {
+					"name": "status_after",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_code": {
+					"name": "room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_name": {
+					"name": "room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"floor_name": {
+					"name": "floor_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_code": {
+					"name": "building_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_name": {
+					"name": "building_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_name": {
+					"name": "unit_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"result_note": {
+					"name": "result_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"performer": {
+					"name": "performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"event_at": {
+					"name": "event_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_movement_logs": {
+			"name": "asset_movement_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"movement_type": {
+					"name": "movement_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"executed_at": {
+					"name": "executed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"executing_unit": {
+					"name": "executing_unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"install_address": {
+					"name": "install_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_code": {
+					"name": "asset_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_name": {
+					"name": "asset_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"quantity_before": {
+					"name": "quantity_before",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"quantity_after": {
+					"name": "quantity_after",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"grade": {
+					"name": "grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"manufacture_year": {
+					"name": "manufacture_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"usage_year": {
+					"name": "usage_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reason_code": {
+					"name": "reason_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reason_other": {
+					"name": "reason_other",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_date": {
+					"name": "decision_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_number": {
+					"name": "decision_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"signer": {
+					"name": "signer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"performer": {
+					"name": "performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"explanation": {
+					"name": "explanation",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_code": {
+					"name": "building_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"building_name": {
+					"name": "building_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_code": {
+					"name": "room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"room_name": {
+					"name": "room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"floor_name": {
+					"name": "floor_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"asset_movement_logs_room_asset_id_room_assets_id_fk": {
+					"name": "asset_movement_logs_room_asset_id_room_assets_id_fk",
+					"tableFrom": "asset_movement_logs",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_proposal_items": {
+			"name": "asset_proposal_items",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"material_id": {
+					"name": "material_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"material_code": {
+					"name": "material_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"material_name": {
+					"name": "material_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source_asset_id": {
+					"name": "source_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"original_grade": {
+					"name": "original_grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"original_code": {
+					"name": "original_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"unit": {
+					"name": "unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"chuyen_nganh_code": {
+					"name": "chuyen_nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"from_room_id": {
+					"name": "from_room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"from_room_code": {
+					"name": "from_room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"from_room_name": {
+					"name": "from_room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"location_note": {
+					"name": "location_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"target_room_id": {
+					"name": "target_room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"target_room_code": {
+					"name": "target_room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"target_room_name": {
+					"name": "target_room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_proposal_logs": {
+			"name": "asset_proposal_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"proposal_type": {
+					"name": "proposal_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"details": {
+					"name": "details",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_is_admin": {
+					"name": "actor_is_admin",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"asset_proposals": {
+			"name": "asset_proposals",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"proposal_type": {
+					"name": "proposal_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'PENDING'"
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_id": {
+					"name": "unit_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_name": {
+					"name": "unit_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_user_id": {
+					"name": "proposed_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_username": {
+					"name": "proposed_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_display_name": {
+					"name": "proposed_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"admin_note": {
+					"name": "admin_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_number": {
+					"name": "decision_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_nganh_code": {
+					"name": "decision_nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_issuing_level": {
+					"name": "decision_issuing_level",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_signer": {
+					"name": "decision_signer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decision_at": {
+					"name": "decision_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_user_id": {
+					"name": "decided_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_username": {
+					"name": "decided_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_display_name": {
+					"name": "decided_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"buildings": {
+			"name": "buildings",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"manager_code": {
+					"name": "manager_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"area": {
+					"name": "area",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"buildings_code_unique": {
+					"name": "buildings_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"catalog_audit_logs": {
+			"name": "catalog_audit_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"entity_type": {
+					"name": "entity_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_is_admin": {
+					"name": "actor_is_admin",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"entity_id": {
+					"name": "entity_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"entity_code": {
+					"name": "entity_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"entity_name": {
+					"name": "entity_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"parent_code": {
+					"name": "parent_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"parent_name": {
+					"name": "parent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"details": {
+					"name": "details",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"catalog_stock_logs": {
+			"name": "catalog_stock_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"movement_type": {
+					"name": "movement_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"executed_at": {
+					"name": "executed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"material_id": {
+					"name": "material_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"material_code": {
+					"name": "material_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"material_name": {
+					"name": "material_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"chuyen_nganh_code": {
+					"name": "chuyen_nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"chuyen_nganh_name": {
+					"name": "chuyen_nganh_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"quantity_before": {
+					"name": "quantity_before",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"quantity_after": {
+					"name": "quantity_after",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"unit": {
+					"name": "unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_new_material": {
+					"name": "is_new_material",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_is_admin": {
+					"name": "actor_is_admin",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"categories": {
+			"name": "categories",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"categories_code_unique": {
+					"name": "categories_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"classes": {
+			"name": "classes",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"graduatedAt": {
+					"name": "graduatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'ongoing'"
+				},
+				"unitId": {
+					"name": "unitId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"class_unit_unique_constraint": {
+					"name": "class_unit_unique_constraint",
+					"columns": ["name", "unitId"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"classes_unitId_units_id_fk": {
+					"name": "classes_unitId_units_id_fk",
+					"tableFrom": "classes",
+					"tableTo": "units",
+					"columnsFrom": ["unitId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_academic_titles": {
+			"name": "exam_academic_titles",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"percentage": {
+					"name": "percentage",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {
+				"exam_academic_titles_name_uq": {
+					"name": "exam_academic_titles_name_uq",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_classes": {
+			"name": "exam_classes",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"faculty_id": {
+					"name": "faculty_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"cohort": {
+					"name": "cohort",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_classes_code_unique": {
+					"name": "exam_classes_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_draw_logs": {
+			"name": "exam_draw_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"draw_id": {
+					"name": "draw_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"details": {
+					"name": "details",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_draws": {
+			"name": "exam_draws",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"draw_code": {
+					"name": "draw_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"exam_id": {
+					"name": "exam_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"exam_code": {
+					"name": "exam_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"paper_number": {
+					"name": "paper_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"subject_id": {
+					"name": "subject_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"draw_type": {
+					"name": "draw_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_name": {
+					"name": "class_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"drawn_by_user_id": {
+					"name": "drawn_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"drawn_by_username": {
+					"name": "drawn_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"drawn_by_display_name": {
+					"name": "drawn_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"drawn_at": {
+					"name": "drawn_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"printed_at": {
+					"name": "printed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"printed_by_user_id": {
+					"name": "printed_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"printed_by_username": {
+					"name": "printed_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"print_blocked": {
+					"name": "print_blocked",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"print_blocked_at": {
+					"name": "print_blocked_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"print_blocked_reason": {
+					"name": "print_blocked_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"exam_date": {
+					"name": "exam_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"exam_time": {
+					"name": "exam_time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"location": {
+					"name": "location",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_draws_draw_code_unique": {
+					"name": "exam_draws_draw_code_unique",
+					"columns": ["draw_code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_faculties": {
+			"name": "exam_faculties",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_faculties_code_idx": {
+					"name": "exam_faculties_code_idx",
+					"columns": ["code"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_faculty_heads": {
+			"name": "exam_faculty_heads",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"faculty_code": {
+					"name": "faculty_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"faculty_name": {
+					"name": "faculty_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_faculty_heads_user_fac_uq": {
+					"name": "exam_faculty_heads_user_fac_uq",
+					"columns": ["user_id", "faculty_code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_major_heads": {
+			"name": "exam_major_heads",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_majors": {
+			"name": "exam_majors",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"system_id": {
+					"name": "system_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"level_code": {
+					"name": "level_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"short_code": {
+					"name": "short_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"catalog_number": {
+					"name": "catalog_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"national_major_code": {
+					"name": "national_major_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"qualification": {
+					"name": "qualification",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"training_duration": {
+					"name": "training_duration",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"training_form": {
+					"name": "training_form",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_majors_code_unique": {
+					"name": "exam_majors_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_questions": {
+			"name": "exam_questions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"exam_id": {
+					"name": "exam_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"question_number": {
+					"name": "question_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"answer": {
+					"name": "answer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"points": {
+					"name": "points",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_subjects": {
+			"name": "exam_subjects",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"base_code": {
+					"name": "base_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"credit_hours": {
+					"name": "credit_hours",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 0
+				},
+				"lesson_hours": {
+					"name": "lesson_hours",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 0
+				},
+				"faculty_id": {
+					"name": "faculty_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_subjects_code_unique": {
+					"name": "exam_subjects_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_systems": {
+			"name": "exam_systems",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"letter": {
+					"name": "letter",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"training_type_id": {
+					"name": "training_type_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_systems_code_unique": {
+					"name": "exam_systems_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				},
+				"exam_systems_letter_unique": {
+					"name": "exam_systems_letter_unique",
+					"columns": ["letter"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_teachers": {
+			"name": "exam_teachers",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"faculty_code": {
+					"name": "faculty_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"faculty_name": {
+					"name": "faculty_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"academic_title_id": {
+					"name": "academic_title_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_user_id": {
+					"name": "created_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_username": {
+					"name": "created_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_display_name": {
+					"name": "created_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exam_teachers_user_uq": {
+					"name": "exam_teachers_user_uq",
+					"columns": ["user_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_teaching_assignment_logs": {
+			"name": "exam_teaching_assignment_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"subject_id": {
+					"name": "subject_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"subject_code": {
+					"name": "subject_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"subject_name": {
+					"name": "subject_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"major_id": {
+					"name": "major_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"major_code": {
+					"name": "major_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"faculty_id": {
+					"name": "faculty_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"faculty_code": {
+					"name": "faculty_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_code": {
+					"name": "class_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_name": {
+					"name": "class_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teacher_user_id": {
+					"name": "teacher_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teacher_username": {
+					"name": "teacher_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teacher_display_name": {
+					"name": "teacher_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_teaching_assignments": {
+			"name": "exam_teaching_assignments",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"subject_id": {
+					"name": "subject_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teaching_start": {
+					"name": "teaching_start",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"teaching_end": {
+					"name": "teaching_end",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_by_user_id": {
+					"name": "assigned_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_by_username": {
+					"name": "assigned_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_by_display_name": {
+					"name": "assigned_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exam_workflow_logs": {
+			"name": "exam_workflow_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"exam_id": {
+					"name": "exam_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"from_status": {
+					"name": "from_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"to_status": {
+					"name": "to_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_username": {
+					"name": "actor_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actor_display_name": {
+					"name": "actor_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"exams": {
+			"name": "exams",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"subject_id": {
+					"name": "subject_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"paper_number": {
+					"name": "paper_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'DRAFT'"
+				},
+				"created_by_user_id": {
+					"name": "created_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_username": {
+					"name": "created_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_display_name": {
+					"name": "created_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_user_id": {
+					"name": "approved_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_username": {
+					"name": "approved_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_display_name": {
+					"name": "approved_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_at": {
+					"name": "approved_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_rank": {
+					"name": "approved_by_rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_position": {
+					"name": "approved_by_position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_signature_url": {
+					"name": "approved_by_signature_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approved_by_title": {
+					"name": "approved_by_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_user_id": {
+					"name": "dept_head_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_username": {
+					"name": "dept_head_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_display_name": {
+					"name": "dept_head_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_rank": {
+					"name": "dept_head_rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_signature_url": {
+					"name": "dept_head_signature_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dept_head_approved_at": {
+					"name": "dept_head_approved_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"qr_code": {
+					"name": "qr_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"locked": {
+					"name": "locked",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_name": {
+					"name": "class_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"duration_minutes": {
+					"name": "duration_minutes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 60
+				},
+				"question_file_url": {
+					"name": "question_file_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"question_file_name": {
+					"name": "question_file_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"answer_file_url": {
+					"name": "answer_file_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"answer_file_name": {
+					"name": "answer_file_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"return_note": {
+					"name": "return_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"exams_code_unique": {
+					"name": "exams_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"floors": {
+			"name": "floors",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"building_id": {
+					"name": "building_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"floor_number": {
+					"name": "floor_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"floors_building_id_buildings_id_fk": {
+					"name": "floors_building_id_buildings_id_fk",
+					"tableFrom": "floors",
+					"tableTo": "buildings",
+					"columnsFrom": ["building_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"resources": {
+			"name": "resources",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"resources_name_unique": {
+					"name": "resources_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"permissions": {
+			"name": "permissions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"resource_id": {
+					"name": "resource_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"action_id": {
+					"name": "action_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"permissions_name_unique": {
+					"name": "permissions_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"permissions_resource_id_resources_id_fk": {
+					"name": "permissions_resource_id_resources_id_fk",
+					"tableFrom": "permissions",
+					"tableTo": "resources",
+					"columnsFrom": ["resource_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"permissions_action_id_actions_id_fk": {
+					"name": "permissions_action_id_actions_id_fk",
+					"tableFrom": "permissions",
+					"tableTo": "actions",
+					"columnsFrom": ["action_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"roles": {
+			"name": "roles",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"roles_name_unique": {
+					"name": "roles_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"role_permissions": {
+			"name": "role_permissions",
+			"columns": {
+				"role_id": {
+					"name": "role_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"permission_id": {
+					"name": "permission_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"role_permissions_role_id_roles_id_fk": {
+					"name": "role_permissions_role_id_roles_id_fk",
+					"tableFrom": "role_permissions",
+					"tableTo": "roles",
+					"columnsFrom": ["role_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"role_permissions_permission_id_permissions_id_fk": {
+					"name": "role_permissions_permission_id_permissions_id_fk",
+					"tableFrom": "role_permissions",
+					"tableTo": "permissions",
+					"columnsFrom": ["permission_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"role_permissions_role_id_permission_id_pk": {
+					"columns": ["role_id", "permission_id"],
+					"name": "role_permissions_role_id_permission_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_roles": {
+			"name": "user_roles",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role_id": {
+					"name": "role_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_roles_user_id_users_id_fk": {
+					"name": "user_roles_user_id_users_id_fk",
+					"tableFrom": "user_roles",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"user_roles_role_id_roles_id_fk": {
+					"name": "user_roles_role_id_roles_id_fk",
+					"tableFrom": "user_roles",
+					"tableTo": "roles",
+					"columnsFrom": ["role_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_roles_user_id_role_id_pk": {
+					"columns": ["user_id", "role_id"],
+					"name": "user_roles_user_id_role_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"displayName": {
+					"name": "displayName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"isSuperUser": {
+					"name": "isSuperUser",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"unitId": {
+					"name": "unitId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"rank": {
+					"name": "rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"position": {
+					"name": "position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"alias": {
+					"name": "alias",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"leave_unit_id": {
+					"name": "leave_unit_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"management_area": {
+					"name": "management_area",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"signature_url": {
+					"name": "signature_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"users_username_unique": {
+					"name": "users_username_unique",
+					"columns": ["username"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"users_unitId_units_id_fk": {
+					"name": "users_unitId_units_id_fk",
+					"tableFrom": "users",
+					"tableTo": "units",
+					"columnsFrom": ["unitId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"units": {
+			"name": "units",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"alias": {
+					"name": "alias",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"level": {
+					"name": "level",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parentId": {
+					"name": "parentId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"units_alias_unique": {
+					"name": "units_alias_unique",
+					"columns": ["alias"],
+					"isUnique": true
+				},
+				"units_name_unique": {
+					"name": "units_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"parent_id_fk": {
+					"name": "parent_id_fk",
+					"tableFrom": "units",
+					"tableTo": "units",
+					"columnsFrom": ["parentId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"students": {
+			"name": "students",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"fullName": {
+					"name": "fullName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"birthPlace": {
+					"name": "birthPlace",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"dob": {
+					"name": "dob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"rank": {
+					"name": "rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"previousUnit": {
+					"name": "previousUnit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"previousPosition": {
+					"name": "previousPosition",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"position": {
+					"name": "position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Học viên'"
+				},
+				"ethnic": {
+					"name": "ethnic",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"religion": {
+					"name": "religion",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"enlistmentPeriod": {
+					"name": "enlistmentPeriod",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"politicalOrg": {
+					"name": "politicalOrg",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"politicalOrgOfficialDate": {
+					"name": "politicalOrgOfficialDate",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"cpvId": {
+					"name": "cpvId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"educationLevel": {
+					"name": "educationLevel",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"schoolName": {
+					"name": "schoolName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"major": {
+					"name": "major",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"isGraduated": {
+					"name": "isGraduated",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": false
+				},
+				"talent": {
+					"name": "talent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"shortcoming": {
+					"name": "shortcoming",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"policyBeneficiaryGroup": {
+					"name": "policyBeneficiaryGroup",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"fatherName": {
+					"name": "fatherName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"fatherDob": {
+					"name": "fatherDob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"fatherPhoneNumber": {
+					"name": "fatherPhoneNumber",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"fatherJob": {
+					"name": "fatherJob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"motherName": {
+					"name": "motherName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"motherDob": {
+					"name": "motherDob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"motherPhoneNumber": {
+					"name": "motherPhoneNumber",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"motherJob": {
+					"name": "motherJob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"isMarried": {
+					"name": "isMarried",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": false
+				},
+				"spouseName": {
+					"name": "spouseName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"spouseDob": {
+					"name": "spouseDob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"spouseJob": {
+					"name": "spouseJob",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"spousePhoneNumber": {
+					"name": "spousePhoneNumber",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"childrenInfos": {
+					"name": "childrenInfos",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"familySize": {
+					"name": "familySize",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"familyBackground": {
+					"name": "familyBackground",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"familyBirthOrder": {
+					"name": "familyBirthOrder",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"achievement": {
+					"name": "achievement",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"disciplinaryHistory": {
+					"name": "disciplinaryHistory",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'Không'"
+				},
+				"phone": {
+					"name": "phone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"classId": {
+					"name": "classId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cpvOfficialAt": {
+					"name": "cpvOfficialAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"avatar": {
+					"name": "avatar",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"siblings": {
+					"name": "siblings",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"contactPerson": {
+					"name": "contactPerson",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'{}'"
+				},
+				"studentId": {
+					"name": "studentId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"relatedDocumentations": {
+					"name": "relatedDocumentations",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"students_classId_classes_id_fk": {
+					"name": "students_classId_classes_id_fk",
+					"tableFrom": "students",
+					"tableTo": "classes",
+					"columnsFrom": ["classId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"rooms": {
+			"name": "rooms",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"floor_id": {
+					"name": "floor_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_code": {
+					"name": "room_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_name": {
+					"name": "room_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_type": {
+					"name": "room_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"manager": {
+					"name": "manager",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"manager_code": {
+					"name": "manager_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"account_password": {
+					"name": "account_password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"capacity": {
+					"name": "capacity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'ACTIVE'"
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"rooms_room_code_unique": {
+					"name": "rooms_room_code_unique",
+					"columns": ["room_code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"rooms_floor_id_floors_id_fk": {
+					"name": "rooms_floor_id_floors_id_fk",
+					"tableFrom": "rooms",
+					"tableTo": "floors",
+					"columnsFrom": ["floor_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"rooms_class_id_classes_id_fk": {
+					"name": "rooms_class_id_classes_id_fk",
+					"tableFrom": "rooms",
+					"tableTo": "classes",
+					"columnsFrom": ["class_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"room_images": {
+			"name": "room_images",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"image_url": {
+					"name": "image_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"room_images_room_id_rooms_id_fk": {
+					"name": "room_images_room_id_rooms_id_fk",
+					"tableFrom": "room_images",
+					"tableTo": "rooms",
+					"columnsFrom": ["room_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"room_assets": {
+			"name": "room_assets",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"broken_quantity": {
+					"name": "broken_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"unit": {
+					"name": "unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"holding_unit_id": {
+					"name": "holding_unit_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"grade": {
+					"name": "grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"manufacture_year": {
+					"name": "manufacture_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"usage_year": {
+					"name": "usage_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"install_address": {
+					"name": "install_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'NORMAL'"
+				},
+				"purchase_date": {
+					"name": "purchase_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expiry_date": {
+					"name": "expiry_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"broken_at": {
+					"name": "broken_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_started_at": {
+					"name": "repair_started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_completed_at": {
+					"name": "repair_completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_performer": {
+					"name": "repair_performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"room_assets_code_unique": {
+					"name": "room_assets_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"room_assets_room_id_rooms_id_fk": {
+					"name": "room_assets_room_id_rooms_id_fk",
+					"tableFrom": "room_assets",
+					"tableTo": "rooms",
+					"columnsFrom": ["room_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"room_assets_holding_unit_id_units_id_fk": {
+					"name": "room_assets_holding_unit_id_units_id_fk",
+					"tableFrom": "room_assets",
+					"tableTo": "units",
+					"columnsFrom": ["holding_unit_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"repair_logs": {
+			"name": "repair_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"repair_date": {
+					"name": "repair_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cost": {
+					"name": "cost",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"performer": {
+					"name": "performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"repair_logs_room_asset_id_room_assets_id_fk": {
+					"name": "repair_logs_room_asset_id_room_assets_id_fk",
+					"tableFrom": "repair_logs",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"inventory_logs": {
+			"name": "inventory_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"inventory_date": {
+					"name": "inventory_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"actual_quantity": {
+					"name": "actual_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"expected_quantity": {
+					"name": "expected_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"result": {
+					"name": "result",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"inventory_logs_room_asset_id_room_assets_id_fk": {
+					"name": "inventory_logs_room_asset_id_room_assets_id_fk",
+					"tableFrom": "inventory_logs",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"replacement_logs": {
+			"name": "replacement_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"replacement_date": {
+					"name": "replacement_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"old_asset": {
+					"name": "old_asset",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"new_asset": {
+					"name": "new_asset",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"performer": {
+					"name": "performer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"replacement_logs_room_asset_id_room_assets_id_fk": {
+					"name": "replacement_logs_room_asset_id_room_assets_id_fk",
+					"tableFrom": "replacement_logs",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_audit_logs": {
+			"name": "leave_audit_logs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"entity_type": {
+					"name": "entity_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"entity_id": {
+					"name": "entity_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"details": {
+					"name": "details",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user_nganh": {
+			"name": "user_nganh",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"nganh_code": {
+					"name": "nganh_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_nganh_user_nganh_uq": {
+					"name": "user_nganh_user_nganh_uq",
+					"columns": ["user_id", "nganh_code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"user_nganh_user_id_users_id_fk": {
+					"name": "user_nganh_user_id_users_id_fk",
+					"tableFrom": "user_nganh",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"repair_requests": {
+			"name": "repair_requests",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"room_id": {
+					"name": "room_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"room_asset_id": {
+					"name": "room_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source_asset_id": {
+					"name": "source_asset_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"original_grade": {
+					"name": "original_grade",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_name": {
+					"name": "asset_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'PENDING'"
+				},
+				"broken_at": {
+					"name": "broken_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reported_by_name": {
+					"name": "reported_by_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reported_by_user_id": {
+					"name": "reported_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_to_name": {
+					"name": "assigned_to_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_at": {
+					"name": "assigned_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"assigned_by_name": {
+					"name": "assigned_by_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"repair_started_at": {
+					"name": "repair_started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"admin_note": {
+					"name": "admin_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"repair_requests_room_id_rooms_id_fk": {
+					"name": "repair_requests_room_id_rooms_id_fk",
+					"tableFrom": "repair_requests",
+					"tableTo": "rooms",
+					"columnsFrom": ["room_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"repair_requests_room_asset_id_room_assets_id_fk": {
+					"name": "repair_requests_room_asset_id_room_assets_id_fk",
+					"tableFrom": "repair_requests",
+					"tableTo": "room_assets",
+					"columnsFrom": ["room_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"repair_requests_source_asset_id_room_assets_id_fk": {
+					"name": "repair_requests_source_asset_id_room_assets_id_fk",
+					"tableFrom": "repair_requests",
+					"tableTo": "room_assets",
+					"columnsFrom": ["source_asset_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"repair_requests_reported_by_user_id_users_id_fk": {
+					"name": "repair_requests_reported_by_user_id_users_id_fk",
+					"tableFrom": "repair_requests",
+					"tableTo": "users",
+					"columnsFrom": ["reported_by_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"suppliers": {
+			"name": "suppliers",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"contact_person": {
+					"name": "contact_person",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"suppliers_code_unique": {
+					"name": "suppliers_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"materials": {
+			"name": "materials",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"category_id": {
+					"name": "category_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"supplier_id": {
+					"name": "supplier_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"unit": {
+					"name": "unit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"min_quantity": {
+					"name": "min_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"price": {
+					"name": "price",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'ACTIVE'"
+				},
+				"manufacture_year": {
+					"name": "manufacture_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"usage_year": {
+					"name": "usage_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"classification": {
+					"name": "classification",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"asset_status": {
+					"name": "asset_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'NORMAL'"
+				},
+				"purchase_date": {
+					"name": "purchase_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expiry_date": {
+					"name": "expiry_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"materials_code_unique": {
+					"name": "materials_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"materials_category_id_categories_id_fk": {
+					"name": "materials_category_id_categories_id_fk",
+					"tableFrom": "materials",
+					"tableTo": "categories",
+					"columnsFrom": ["category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"materials_supplier_id_suppliers_id_fk": {
+					"name": "materials_supplier_id_suppliers_id_fk",
+					"tableFrom": "materials",
+					"tableTo": "suppliers",
+					"columnsFrom": ["supplier_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"warehouses": {
+			"name": "warehouses",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"location": {
+					"name": "location",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"manager": {
+					"name": "manager",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"warehouses_code_unique": {
+					"name": "warehouses_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"warehouse_items": {
+			"name": "warehouse_items",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"warehouse_id": {
+					"name": "warehouse_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"material_id": {
+					"name": "material_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"min_quantity": {
+					"name": "min_quantity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"warehouse_items_warehouse_id_warehouses_id_fk": {
+					"name": "warehouse_items_warehouse_id_warehouses_id_fk",
+					"tableFrom": "warehouse_items",
+					"tableTo": "warehouses",
+					"columnsFrom": ["warehouse_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"warehouse_items_material_id_materials_id_fk": {
+					"name": "warehouse_items_material_id_materials_id_fk",
+					"tableFrom": "warehouse_items",
+					"tableTo": "materials",
+					"columnsFrom": ["material_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"notification_items": {
+			"name": "notification_items",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"notifiableType": {
+					"name": "notifiableType",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"notifiableId": {
+					"name": "notifiableId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"notificationId": {
+					"name": "notificationId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"notification_items_notification_idx": {
+					"name": "notification_items_notification_idx",
+					"columns": ["notificationId"],
+					"isUnique": false
+				},
+				"notification_items_item_idx": {
+					"name": "notification_items_item_idx",
+					"columns": ["notifiableType", "notifiableId"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"notification_items_notificationId_notifications_id_fk": {
+					"name": "notification_items_notificationId_notifications_id_fk",
+					"tableFrom": "notification_items",
+					"tableTo": "notifications",
+					"columnsFrom": ["notificationId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"notifications": {
+			"name": "notifications",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"readAt": {
+					"name": "readAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notificationType": {
+					"name": "notificationType",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'birthday'"
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"message": {
+					"name": "message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"isBatch": {
+					"name": "isBatch",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": false
+				},
+				"batchKey": {
+					"name": "batchKey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"totalCount": {
+					"name": "totalCount",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": 1
+				},
+				"recipientId": {
+					"name": "recipientId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"actorId": {
+					"name": "actorId",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"recipient_idx": {
+					"name": "recipient_idx",
+					"columns": ["recipientId"],
+					"isUnique": false
+				},
+				"batch_idx": {
+					"name": "batch_idx",
+					"columns": ["batchKey"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"notifications_recipientId_users_id_fk": {
+					"name": "notifications_recipientId_users_id_fk",
+					"tableFrom": "notifications",
+					"tableTo": "users",
+					"columnsFrom": ["recipientId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"notifications_actorId_users_id_fk": {
+					"name": "notifications_actorId_users_id_fk",
+					"tableFrom": "notifications",
+					"tableTo": "users",
+					"columnsFrom": ["actorId"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_alerts": {
+			"name": "leave_alerts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"request_id": {
+					"name": "request_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"message": {
+					"name": "message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"read_at": {
+					"name": "read_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_classes": {
+			"name": "leave_classes",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"unit_id": {
+					"name": "unit_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_extra_standards": {
+			"name": "leave_extra_standards",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"days": {
+					"name": "days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				}
+			},
+			"indexes": {
+				"leave_extra_standards_code_unique": {
+					"name": "leave_extra_standards_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_localities": {
+			"name": "leave_localities",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"level": {
+					"name": "level",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"parent_id": {
+					"name": "parent_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_mail_log": {
+			"name": "leave_mail_log",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"request_id": {
+					"name": "request_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"to_email": {
+					"name": "to_email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"subject": {
+					"name": "subject",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ok": {
+					"name": "ok",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preview_url": {
+					"name": "preview_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_object_types": {
+			"name": "leave_object_types",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				}
+			},
+			"indexes": {
+				"leave_object_types_code_unique": {
+					"name": "leave_object_types_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_personnel": {
+			"name": "leave_personnel",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"full_name": {
+					"name": "full_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"enlistment_date": {
+					"name": "enlistment_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"recruitment": {
+					"name": "recruitment",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"object_type": {
+					"name": "object_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"position": {
+					"name": "position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_id": {
+					"name": "unit_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_name": {
+					"name": "unit_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"hometown": {
+					"name": "hometown",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"permanent_residence": {
+					"name": "permanent_residence",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"commander_user_id": {
+					"name": "commander_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"commander_name": {
+					"name": "commander_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_name": {
+					"name": "class_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"management_area": {
+					"name": "management_area",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'cán_bộ'"
+				}
+			},
+			"indexes": {
+				"leave_personnel_code_unique": {
+					"name": "leave_personnel_code_unique",
+					"columns": ["code"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_records": {
+			"name": "leave_records",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"request_id": {
+					"name": "request_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'PENDING'"
+				},
+				"leave_type": {
+					"name": "leave_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"personnel_id": {
+					"name": "personnel_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"personnel_code": {
+					"name": "personnel_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"personnel_name": {
+					"name": "personnel_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"object_type": {
+					"name": "object_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"position": {
+					"name": "position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"enlistment_date": {
+					"name": "enlistment_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_id": {
+					"name": "unit_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_name": {
+					"name": "unit_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"service_years": {
+					"name": "service_years",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"base_days": {
+					"name": "base_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"travel_days": {
+					"name": "travel_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"extra_days": {
+					"name": "extra_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"extra_reasons": {
+					"name": "extra_reasons",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"total_days": {
+					"name": "total_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"start_date": {
+					"name": "start_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"end_date": {
+					"name": "end_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"leave_year": {
+					"name": "leave_year",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"locality_id": {
+					"name": "locality_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"locality_path": {
+					"name": "locality_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"replacement_personnel_id": {
+					"name": "replacement_personnel_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"replacement_personnel_name": {
+					"name": "replacement_personnel_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"replacement_position": {
+					"name": "replacement_position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"admin_note": {
+					"name": "admin_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_user_id": {
+					"name": "proposed_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_username": {
+					"name": "proposed_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_display_name": {
+					"name": "proposed_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_user_id": {
+					"name": "decided_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_username": {
+					"name": "decided_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_at": {
+					"name": "decided_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"archived_at": {
+					"name": "archived_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_regulations": {
+			"name": "leave_regulations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"leave_type": {
+					"name": "leave_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"object_type": {
+					"name": "object_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"min_years": {
+					"name": "min_years",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"max_years": {
+					"name": "max_years",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"base_days": {
+					"name": "base_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_requests": {
+			"name": "leave_requests",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"leave_type": {
+					"name": "leave_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"request_scope": {
+					"name": "request_scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'OTHER'"
+				},
+				"class_id": {
+					"name": "class_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"class_name": {
+					"name": "class_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'PENDING'"
+				},
+				"personnel_id": {
+					"name": "personnel_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"personnel_code": {
+					"name": "personnel_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"personnel_name": {
+					"name": "personnel_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"object_type": {
+					"name": "object_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rank": {
+					"name": "rank",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"position": {
+					"name": "position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"enlistment_date": {
+					"name": "enlistment_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_id": {
+					"name": "unit_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"unit_name": {
+					"name": "unit_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"service_years": {
+					"name": "service_years",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"base_days": {
+					"name": "base_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"travel_days": {
+					"name": "travel_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"extra_days": {
+					"name": "extra_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"extra_reasons": {
+					"name": "extra_reasons",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"total_days": {
+					"name": "total_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"start_date": {
+					"name": "start_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"end_date": {
+					"name": "end_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"leave_year": {
+					"name": "leave_year",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"locality_id": {
+					"name": "locality_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"locality_path": {
+					"name": "locality_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_user_id": {
+					"name": "proposed_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_username": {
+					"name": "proposed_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposed_by_display_name": {
+					"name": "proposed_by_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposer_email": {
+					"name": "proposer_email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"commander_user_id": {
+					"name": "commander_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"commander_name": {
+					"name": "commander_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"replacement_personnel_id": {
+					"name": "replacement_personnel_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"replacement_personnel_name": {
+					"name": "replacement_personnel_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"replacement_position": {
+					"name": "replacement_position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"admin_note": {
+					"name": "admin_note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_user_id": {
+					"name": "decided_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_by_username": {
+					"name": "decided_by_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"decided_at": {
+					"name": "decided_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_units": {
+			"name": "leave_units",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"level": {
+					"name": "level",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"parent_id": {
+					"name": "parent_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"commander_user_id": {
+					"name": "commander_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"commander_name": {
+					"name": "commander_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"management_area": {
+					"name": "management_area",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'cán_bộ'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_batches": {
+			"name": "leave_batches",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"request_id": {
+					"name": "request_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"personnel_id": {
+					"name": "personnel_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"personnel_code": {
+					"name": "personnel_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"personnel_name": {
+					"name": "personnel_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"object_type": {
+					"name": "object_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"leave_type": {
+					"name": "leave_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"batch_index": {
+					"name": "batch_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"batch_label": {
+					"name": "batch_label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"start_date": {
+					"name": "start_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"end_date": {
+					"name": "end_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"total_days": {
+					"name": "total_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_by_user_id": {
+					"name": "created_by_user_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"leave_positions": {
+			"name": "leave_positions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				}
+			},
+			"indexes": {
+				"leave_positions_name_unique": {
+					"name": "leave_positions_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/apps/api/migrations/meta/_journal.json
+++ b/apps/api/migrations/meta/_journal.json
@@ -393,6 +393,48 @@
 			"when": 1785555000000,
 			"tag": "0055_sync_exam_log_major_codes",
 			"breakpoints": true
+		},
+		{
+			"idx": 56,
+			"version": "6",
+			"when": 1785660000000,
+			"tag": "0056_standalone-faculties",
+			"breakpoints": true
+		},
+		{
+			"idx": 57,
+			"version": "6",
+			"when": 1785632400000,
+			"tag": "0057_material_asset_defaults",
+			"breakpoints": true
+		},
+		{
+			"idx": 58,
+			"version": "6",
+			"when": 1785636000000,
+			"tag": "0058_leave_replacement_personnel",
+			"breakpoints": true
+		},
+		{
+			"idx": 59,
+			"version": "6",
+			"when": 1785662800042,
+			"tag": "0059_burly_banshee",
+			"breakpoints": true
+		},
+		{
+			"idx": 60,
+			"version": "6",
+			"when": 1785666047014,
+			"tag": "0060_white_scarecrow",
+			"breakpoints": true
+		},
+		{
+			"idx": 61,
+			"version": "6",
+			"when": 1785840000000,
+			"tag": "0061_exam_subject_major_nullable",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/api/schema/exam-bank.ts
+++ b/apps/api/schema/exam-bank.ts
@@ -11,7 +11,13 @@
  * Mã môn: {mã_ngành}_{mã_gốc} — vd B_CDDD_M009K2
  */
 import { sql } from 'drizzle-orm'
-import { int, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core'
+import {
+	index,
+	int,
+	sqliteTable,
+	text,
+	uniqueIndex
+} from 'drizzle-orm/sqlite-core'
 import { baseSchema } from './base'
 
 /** DRAFT | PENDING_DEPT | PENDING_EXAM_OFFICE | PENDING_BGH | APPROVED | RETURNED | REJECTED */
@@ -78,11 +84,11 @@ export const examFaculties = sqliteTable(
 		...baseSchema,
 		code: text('code').notNull(),
 		name: text('name').notNull(),
-		majorId: int('major_id').notNull(),
+		majorId: int('major_id'),
 		description: text('description')
 	},
 	(t) => ({
-		uq: uniqueIndex('exam_faculties_major_code_uq').on(t.majorId, t.code)
+		codeIdx: index('exam_faculties_code_idx').on(t.code)
 	})
 )
 
@@ -114,7 +120,7 @@ export const examSubjects = sqliteTable('exam_subjects', {
 	lessonHours: int('lesson_hours').default(0),
 	facultyId: int('faculty_id').notNull(),
 	/** Denormalized — ngành (từ khoa) để lọc / CNK */
-	majorId: int('major_id').notNull(),
+	majorId: int('major_id'),
 	description: text('description')
 })
 

--- a/apps/api/schema/leave-management.ts
+++ b/apps/api/schema/leave-management.ts
@@ -71,7 +71,7 @@ export const leaveUnits = sqliteTable('leave_units', {
 	managementArea: text('management_area').notNull().default('cán_bộ')
 })
 
-/** Lớp học viên thuộc đại đội (mỗi đại đội tối đa 2 lớp A1–A10). */
+/** Lớp học viên thuộc đại đội; tên tự do theo biên chế thực tế. */
 export const leaveClasses = sqliteTable('leave_classes', {
 	...baseSchema,
 	unitId: int('unit_id').notNull(),
@@ -194,6 +194,10 @@ export const leaveRequests = sqliteTable('leave_requests', {
 	/** Chỉ huy cơ quan phụ trách đơn này */
 	commanderUserId: int('commander_user_id'),
 	commanderName: text('commander_name'),
+	/** Quân nhân được phân công thay thế trong thời gian nghỉ */
+	replacementPersonnelId: int('replacement_personnel_id'),
+	replacementPersonnelName: text('replacement_personnel_name'),
+	replacementPosition: text('replacement_position'),
 	adminNote: text('admin_note'),
 	decidedByUserId: int('decided_by_user_id'),
 	decidedByUsername: text('decided_by_username'),
@@ -263,6 +267,9 @@ export const leaveRecords = sqliteTable('leave_records', {
 	localityId: int('locality_id'),
 	localityPath: text('locality_path'),
 	note: text('note'),
+	replacementPersonnelId: int('replacement_personnel_id'),
+	replacementPersonnelName: text('replacement_personnel_name'),
+	replacementPosition: text('replacement_position'),
 	adminNote: text('admin_note'),
 	proposedByUserId: int('proposed_by_user_id'),
 	proposedByUsername: text('proposed_by_username'),

--- a/apps/api/schema/materials.ts
+++ b/apps/api/schema/materials.ts
@@ -25,6 +25,13 @@ export const materials = sqliteTable('materials', {
 	minQuantity: int('min_quantity').notNull().default(0),
 	price: real('price').default(0),
 	status: text('status').notNull().default('ACTIVE'),
+	/** Thuộc tính mặc định khi cấp vật tư vào phòng */
+	manufactureYear: int('manufacture_year'),
+	usageYear: int('usage_year'),
+	classification: text('classification'),
+	assetStatus: text('asset_status').notNull().default('NORMAL'),
+	purchaseDate: text('purchase_date'),
+	expiryDate: text('expiry_date'),
 	description: text('description')
 })
 
@@ -49,6 +56,12 @@ export interface MaterialDB extends Base {
 	minQuantity: number
 	price?: number
 	status?: string
+	manufactureYear?: number | null
+	usageYear?: number | null
+	classification?: string | null
+	assetStatus?: string | null
+	purchaseDate?: string | null
+	expiryDate?: string | null
 	description?: string
 }
 
@@ -67,6 +80,12 @@ export interface CreateMaterialRequest {
 	minQuantity?: number
 	price?: number
 	status?: string
+	manufactureYear?: number
+	usageYear?: number
+	classification?: string
+	assetStatus?: string
+	purchaseDate?: string
+	expiryDate?: string
 	description?: string
 }
 
@@ -81,5 +100,11 @@ export interface UpdateMaterialRequest {
 	minQuantity?: number
 	price?: number
 	status?: string
+	manufactureYear?: number | null
+	usageYear?: number | null
+	classification?: string | null
+	assetStatus?: string | null
+	purchaseDate?: string | null
+	expiryDate?: string | null
 	description?: string
 }

--- a/apps/api/units/controller.ts
+++ b/apps/api/units/controller.ts
@@ -85,6 +85,45 @@ class controller {
 		return this.repo.create(validParams).catch(AppError.handleAppErr)
 	}
 
+	async update(id: number, params: Partial<UnitParams>): Promise<UnitDB> {
+		const existing = await this.repo.findById(id)
+		if (!existing)
+			throw AppError.handleAppErr(
+				AppError.notFound('Đơn vị không tồn tại')
+			)
+		if (params.alias !== undefined && !params.alias.trim())
+			throw AppError.handleAppErr(
+				AppError.invalidArgument('Alias không được để trống')
+			)
+		if (params.name !== undefined && !params.name.trim())
+			throw AppError.handleAppErr(
+				AppError.invalidArgument('Tên không được để trống')
+			)
+		const rows = await this.repo.update(id, params)
+		return rows[0]!
+	}
+
+	async delete(id: number): Promise<void> {
+		const existing = await this.repo.findById(id)
+		if (!existing)
+			throw AppError.handleAppErr(
+				AppError.notFound('Đơn vị không tồn tại')
+			)
+		const full = (
+			(await this.repo.find({ ids: [id] })) as unknown as Array<{
+				children?: unknown[]
+				classes?: unknown[]
+			}>
+		)[0]
+		if (full?.children?.length || full?.classes?.length)
+			throw AppError.handleAppErr(
+				AppError.invalidArgument(
+					'Không thể xóa đơn vị đang có đơn vị con hoặc lớp'
+				)
+			)
+		await this.repo.delete([existing as InteralUnitDB])
+	}
+
 	find(q: GetUnitsQuery, unitIds: number[]): Promise<Unit[]> {
 		log.trace('UnitController.find params', { params: q })
 

--- a/apps/api/units/index.ts
+++ b/apps/api/units/index.ts
@@ -3,6 +3,7 @@ import { Unit, UnitDB, UnitParams, UnitQuery } from '../schema/units'
 export interface Repository {
 	create(params: UnitParams[]): Promise<UnitDB[]>
 	delete(units: UnitDB[]): Promise<UnitDB[]>
+	update(id: number, params: Partial<UnitParams>): Promise<UnitDB[]>
 	find(query: UnitQuery): Promise<Unit[]>
 	findAll(): Promise<Unit[]>
 	findOne(params: {

--- a/apps/api/units/repo.ts
+++ b/apps/api/units/repo.ts
@@ -28,6 +28,15 @@ class repo implements Repository {
 			.catch(handleDatabaseErr)
 	}
 
+	update(id: number, params: Partial<UnitParams>): Promise<UnitDB[]> {
+		return this.db
+			.update(units)
+			.set(params)
+			.where(eq(units.id, id))
+			.returning()
+			.catch(handleDatabaseErr)
+	}
+
 	async find(query: UnitQuery): Promise<Unit[]> {
 		const baseQuery = this.db.query.units
 		const conditions: SQL[] = []

--- a/apps/api/units/units.ts
+++ b/apps/api/units/units.ts
@@ -42,6 +42,29 @@ export const CreateUnit = api(
 	}
 )
 
+export const UpdateUnit = api(
+	{ auth: true, expose: true, method: 'PATCH', path: '/units/:id' },
+	async ({
+		id,
+		...body
+	}: {
+		id: number
+		alias?: string
+		name?: string
+		parentId?: number | null
+	}): Promise<{ data: UnitDB }> => ({
+		data: await unitController.update(id, body)
+	})
+)
+
+export const DeleteUnit = api(
+	{ auth: true, expose: true, method: 'DELETE', path: '/units/:id' },
+	async (params: { id: number }): Promise<{ ok: boolean }> => {
+		await unitController.delete(params.id)
+		return { ok: true }
+	}
+)
+
 type unit = Omit<UnitDB, 'parentId'>
 
 export type Unit = unit & {

--- a/apps/api/user-roles/controller.ts
+++ b/apps/api/user-roles/controller.ts
@@ -3,9 +3,12 @@ import { AssignRoleRequest } from '../schema'
 import { AppError } from '../errors'
 import userRolesRepo from './repo'
 import log from 'encore.dev/log'
+import orm from '../database'
+import { users } from '../schema/users'
+import { eq } from 'drizzle-orm'
 
 class Controller {
-	constructor(private readonly repo: Repository) { }
+	constructor(private readonly repo: Repository) {}
 
 	async assignRolesToUser(params: AssignRoleRequest): Promise<void> {
 		log.trace('UserRolesController.assignRolesToUser params', { params })
@@ -19,6 +22,15 @@ class Controller {
 		// }
 
 		await this.repo.assignRolesToUser(params).catch(AppError.handleAppErr)
+
+		// Có ít nhất một vai trò nghĩa là tài khoản đã được cấp quyền sử dụng.
+		if (params.roleIds?.length) {
+			await orm
+				.update(users)
+				.set({ status: 'approved' })
+				.where(eq(users.id, params.userId))
+				.catch(AppError.handleAppErr)
+		}
 	}
 
 	async getRolesByUserId(userId: number): Promise<number[]> {

--- a/apps/web/src/api/asset.ts
+++ b/apps/web/src/api/asset.ts
@@ -335,6 +335,12 @@ export type CatalogMaterial = {
 	stockQuantity?: number
 	/** SL danh mục (materials.quantity) — tăng/giảm user ngành */
 	catalogQuantity?: number
+	manufactureYear?: number | null
+	usageYear?: number | null
+	classification?: string | null
+	assetStatus?: string
+	purchaseDate?: string | null
+	expiryDate?: string | null
 }
 
 export type AssetCatalog = {
@@ -422,7 +428,17 @@ export async function CreateCatalogChuyenNganh(body: {
 /** Sửa vật tư danh mục */
 export async function UpdateCatalogMaterial(
 	id: number,
-	body: { name?: string; unit?: string; description?: string | null }
+	body: {
+		name?: string
+		unit?: string
+		description?: string | null
+		manufactureYear?: number | null
+		usageYear?: number | null
+		classification?: string | null
+		assetStatus?: string | null
+		purchaseDate?: string | null
+		expiryDate?: string | null
+	}
 ): Promise<CatalogMaterial> {
 	const resp = await jsonFetch<{ data: CatalogMaterial }>(
 		`/asset-catalog/materials/${id}`,
@@ -501,8 +517,15 @@ export async function CreateCatalogMaterial(body: {
 	chuyenNganhCode: string
 	name: string
 	unit?: string
+	quantity?: number
 	code?: string
 	description?: string
+	manufactureYear?: number
+	usageYear?: number
+	classification?: string
+	assetStatus?: string
+	purchaseDate?: string
+	expiryDate?: string
 }): Promise<CatalogMaterial> {
 	const resp = await jsonFetch<{ data: CatalogMaterial }>(
 		'/asset-catalog/materials',

--- a/apps/web/src/api/exam.ts
+++ b/apps/web/src/api/exam.ts
@@ -471,7 +471,7 @@ export async function ListExamFaculties(params?: {
 export async function CreateExamFaculty(body: {
 	code: string
 	name: string
-	majorId: number
+	majorId?: number | null
 	description?: string
 }) {
 	const resp = await jsonFetch<{ data: ExamFaculty }>('/exam/faculties', {

--- a/apps/web/src/api/index.ts
+++ b/apps/web/src/api/index.ts
@@ -23,7 +23,12 @@ import {
 	type GetUserRolesResponse
 } from '@/types'
 import { appFetcher } from '@/lib/axios'
-import Client, { auth, classes, students, units } from './client'
+import Client, {
+	type auth,
+	type classes,
+	type students,
+	type units
+} from './client'
 import { ApiUrl } from '@/lib/const'
 
 export const requestClient = new Client(ApiUrl, {
@@ -176,6 +181,29 @@ export async function CreateUnit(
 	}
 	const json = (await resp.json()) as { data: units.UnitDB[] }
 	return json.data
+}
+
+export async function UpdateUnit(id: number, body: Partial<CreateUnitBody>) {
+	const { appFetcher } = await import('@/lib/axios')
+	const { ApiUrl } = await import('@/lib/const')
+	const resp = await appFetcher(`${ApiUrl.replace(/\/$/, '')}/units/${id}`, {
+		method: 'PATCH',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body)
+	})
+	if (!resp.ok)
+		throw new Error((await resp.json()).message || `HTTP ${resp.status}`)
+	return ((await resp.json()) as { data: units.UnitDB }).data
+}
+
+export async function DeleteUnit(id: number) {
+	const { appFetcher } = await import('@/lib/axios')
+	const { ApiUrl } = await import('@/lib/const')
+	const resp = await appFetcher(`${ApiUrl.replace(/\/$/, '')}/units/${id}`, {
+		method: 'DELETE'
+	})
+	if (!resp.ok)
+		throw new Error((await resp.json()).message || `HTTP ${resp.status}`)
 }
 
 export function GetUnreadNotificationsCount(): Promise<number> {

--- a/apps/web/src/components/asset-management/AssetAccountsPanel.tsx
+++ b/apps/web/src/components/asset-management/AssetAccountsPanel.tsx
@@ -26,7 +26,14 @@ import { cn } from '@/lib/utils'
 function isDonViUser(u: User): boolean {
 	const pos = (u.position || '').toLowerCase()
 	const un = (u.username || '').toLowerCase()
-	return pos.includes('đơn vị') || un.startsWith('dv.')
+	return (
+		u.unitId != null ||
+		!!u.unit ||
+		!!u.unitName ||
+		pos.includes('đơn vị') ||
+		pos.includes('tài khoản phòng') ||
+		un.startsWith('dv.')
+	)
 }
 
 function isNganhAccount(u: User): boolean {
@@ -189,6 +196,18 @@ export default function AssetAccountsPanel() {
 						<div className='space-y-2'>
 							<Skeleton className='h-10 w-full' />
 							<Skeleton className='h-10 w-full' />
+						</div>
+					) : usersQ.isError ? (
+						<div className='py-10 text-center text-sm text-destructive'>
+							Không tải được danh sách tài khoản.{' '}
+							<Button
+								type='button'
+								variant='link'
+								className='h-auto p-0'
+								onClick={() => void usersQ.refetch()}
+							>
+								Thử lại
+							</Button>
 						</div>
 					) : !rows.length ? (
 						<p className='text-sm text-muted-foreground py-10 text-center'>

--- a/apps/web/src/components/asset-management/BuildingCatalog.tsx
+++ b/apps/web/src/components/asset-management/BuildingCatalog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { Link, useNavigate } from '@tanstack/react-router'
 import {
 	ArrowLeft,
@@ -46,6 +47,7 @@ import AccountDialog from './AccountDialog'
 import AccountAuditLogPanel from './AccountAuditLogPanel'
 import UnitUsagePanel from './UnitUsagePanel'
 import AssetAccountsPanel from './AssetAccountsPanel'
+import UserForm from '@/components/user-table/user-form'
 import { toast } from 'sonner'
 import {
 	Dialog,
@@ -132,6 +134,7 @@ export default function BuildingCatalog({
 	view: viewProp,
 	buildingId: buildingIdProp = null
 }: Props) {
+	const qc = useQueryClient()
 	const navigate = useNavigate()
 	const nganhUser = useIsNganhUser()
 	const bghOnly = isBghOnlyUser()
@@ -195,6 +198,7 @@ export default function BuildingCatalog({
 	const [roomFloorId, setRoomFloorId] = useState<number | null>(null)
 	const [editingRoom, setEditingRoom] = useState<Room | null>(null)
 	const [accountDialogOpen, setAccountDialogOpen] = useState(false)
+	const [userFormOpen, setUserFormOpen] = useState(false)
 	const [editingAccount, setEditingAccount] = useState<FlatRoom | null>(null)
 	const [accountSearch, setAccountSearch] = useState('')
 	/** Trong màn tài khoản: chọn xem danh sách hay nhật ký (một bên) */
@@ -427,18 +431,24 @@ export default function BuildingCatalog({
 									toast.error('Chọn tòa trong Bộ lọc')
 									return
 								}
-								const floors = selectedBuilding.floors ?? []
-								if (!floors.length) {
+								const firstFloor = selectedBuilding.floors?.[0]
+								if (!firstFloor) {
 									toast.error('Tòa chưa có tầng')
 									return
 								}
-								setRoomFloorId(floors[0]!.id)
+								setRoomFloorId(firstFloor.id)
 								setEditingRoom(null)
 								setRoomDialogOpen(true)
 							}}
 						>
 							<Plus className='w-4 h-4 mr-2' />
 							Thêm phòng
+						</Button>
+					)}
+					{view === 'tai-khoan' && !readOnly && (
+						<Button onClick={() => setUserFormOpen(true)}>
+							<Plus className='w-4 h-4 mr-2' />
+							Thêm tài khoản
 						</Button>
 					)}
 					{view === 'don-vi' && !readOnly && (
@@ -501,9 +511,9 @@ export default function BuildingCatalog({
 					<CardContent className='space-y-3'>
 						<div className='flex flex-col sm:flex-row flex-wrap gap-3 items-stretch sm:items-end'>
 							<div className='flex-1 min-w-[220px] space-y-1.5'>
-								<label className='text-base font-medium'>
+								<div className='text-base font-medium'>
 									Tòa nhà
-								</label>
+								</div>
 								<SearchableSelect
 									value={
 										filterBuildingId != null
@@ -568,8 +578,11 @@ export default function BuildingCatalog({
 
 			{view === 'don-vi' ? null : isLoading ? (
 				<div className='space-y-3'>
-					{Array.from({ length: 3 }).map((_, i) => (
-						<Skeleton key={i} className='h-24 w-full rounded-xl' />
+					{['building-1', 'building-2', 'building-3'].map((key) => (
+						<Skeleton
+							key={key}
+							className='h-24 w-full rounded-xl'
+						/>
 					))}
 				</div>
 			) : view === 'toa' ? (
@@ -951,6 +964,14 @@ export default function BuildingCatalog({
 				tree={tree}
 				defaultBuildingId={filterBuildingId}
 				room={editingAccount}
+			/>
+			<UserForm
+				open={userFormOpen}
+				setOpen={setUserFormOpen}
+				onSuccess={() => {
+					void qc.invalidateQueries({ queryKey: ['users'] })
+					setUserFormOpen(false)
+				}}
 			/>
 			{floorBuildingId !== null && (
 				<FloorDialog

--- a/apps/web/src/components/asset-management/NganhCatalog.tsx
+++ b/apps/web/src/components/asset-management/NganhCatalog.tsx
@@ -24,6 +24,7 @@ import {
 import { toast } from 'sonner'
 import {
 	CreateCatalogChuyenNganh,
+	CreateCatalogMaterial,
 	CreateCatalogNganh,
 	DeleteCatalogCategories,
 	DeleteCatalogMaterials,
@@ -58,6 +59,13 @@ import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { ErrorState } from '@/components/error-state'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue
+} from '@/components/ui/select'
 import {
 	Dialog,
 	DialogContent,
@@ -146,6 +154,7 @@ export default function NganhCatalog({
 	const [editMaterial, setEditMaterial] = useState<CatalogMaterial | null>(
 		null
 	)
+	const [createMaterialOpen, setCreateMaterialOpen] = useState(false)
 	const [confirm, setConfirm] = useState<{
 		title: string
 		onConfirm: () => Promise<void>
@@ -174,6 +183,7 @@ export default function NganhCatalog({
 	 * - JWT nganhCodes / catalog (đã filter API) → auto set
 	 * - 1 ngành → khóa cứng
 	 */
+	// biome-ignore lint/correctness/useExhaustiveDependencies: re-scope only when assigned catalog access changes
 	useEffect(() => {
 		if (!nganhScoped) return
 		// Ưu tiên JWT → catalog API (đã scope)
@@ -201,7 +211,8 @@ export default function NganhCatalog({
 		// Mặc định: ngành đầu (user.cntt → HC2A)
 		const first =
 			nganh.find((n) => allowed.includes(n.code.toUpperCase()))?.code ||
-			allowed[0]!
+			allowed[0]
+		if (!first) return
 		setFilterNganhCode(first)
 		void navigate({
 			to: '/vat-tu/danh-muc-nganh',
@@ -539,7 +550,7 @@ export default function NganhCatalog({
 						/* Vật tư: Ngành (cố định user ngành) + Loại vật */
 						<div className='flex flex-col sm:flex-row flex-wrap gap-3 items-stretch sm:items-end'>
 							<div className='flex-1 min-w-[200px] space-y-1.5'>
-								<label className='text-sm font-medium'>
+								<div className='text-sm font-medium'>
 									Ngành
 									{nganhScoped ? (
 										<span className='text-muted-foreground font-normal'>
@@ -547,7 +558,7 @@ export default function NganhCatalog({
 											(cố định)
 										</span>
 									) : null}
-								</label>
+								</div>
 								{nganhScoped && nganh.length === 1 ? (
 									<div className='h-10 px-3 flex items-center rounded-md border bg-muted/50 text-sm font-medium'>
 										{selectedNganh
@@ -581,7 +592,7 @@ export default function NganhCatalog({
 								)}
 							</div>
 							<div className='flex-1 min-w-[200px] space-y-1.5'>
-								<label className='text-sm font-medium'>
+								<div className='text-sm font-medium'>
 									Loại vật
 									{nganhScoped ? (
 										<span className='text-muted-foreground font-normal'>
@@ -589,7 +600,7 @@ export default function NganhCatalog({
 											(trong ngành)
 										</span>
 									) : null}
-								</label>
+								</div>
 								<SearchableSelect
 									value={selectedLoaiVatCode ?? ''}
 									onValueChange={(v) => {
@@ -663,7 +674,7 @@ export default function NganhCatalog({
 						/* Ngành / Loại vật: ngành cố định (user) + nút lọc */
 						<div className='flex flex-col sm:flex-row flex-wrap gap-3 items-stretch sm:items-end'>
 							<div className='flex-1 min-w-[220px] space-y-1.5'>
-								<label className='text-sm font-medium'>
+								<div className='text-sm font-medium'>
 									Ngành
 									{nganhScoped ? (
 										<span className='text-muted-foreground font-normal'>
@@ -671,7 +682,7 @@ export default function NganhCatalog({
 											(cố định)
 										</span>
 									) : null}
-								</label>
+								</div>
 								{nganhScoped && nganh.length === 1 ? (
 									<div className='h-10 px-3 flex items-center rounded-md border bg-muted/50 text-sm font-medium'>
 										{selectedNganh
@@ -1185,6 +1196,14 @@ export default function NganhCatalog({
 									className='pl-9'
 								/>
 							</div>
+							{canMutate && (
+								<Button
+									onClick={() => setCreateMaterialOpen(true)}
+								>
+									<Plus className='mr-2 h-4 w-4' /> Thêm vật
+									tư
+								</Button>
+							)}
 							{materialSuggestions.length > 0 && (
 								<div className='flex flex-wrap gap-1.5'>
 									<span className='text-xs text-muted-foreground self-center'>
@@ -1435,6 +1454,13 @@ export default function NganhCatalog({
 					setEditMaterial(null)
 				}}
 			/>
+			<CreateMaterialDialog
+				open={createMaterialOpen}
+				onOpenChange={setCreateMaterialOpen}
+				categories={loaiVat}
+				defaultCode={selectedLoaiVatCode}
+				onSuccess={invalidate}
+			/>
 
 			<Dialog
 				open={!!confirm}
@@ -1477,6 +1503,217 @@ export default function NganhCatalog({
 	)
 }
 
+function CreateMaterialDialog({
+	open,
+	onOpenChange,
+	categories,
+	defaultCode,
+	onSuccess
+}: {
+	open: boolean
+	onOpenChange: (o: boolean) => void
+	categories: CatalogCategory[]
+	defaultCode: string | null
+	onSuccess: () => void | Promise<void>
+}) {
+	const [code, setCode] = useState(defaultCode || '')
+	const [name, setName] = useState('')
+	const [unit, setUnit] = useState('Bộ')
+	const [quantity, setQuantity] = useState('0')
+	const [manufactureYear, setManufactureYear] = useState('')
+	const [usageYear, setUsageYear] = useState('')
+	const [classification, setClassification] = useState('')
+	const [assetStatus, setAssetStatus] = useState('NORMAL')
+	const [purchaseDate, setPurchaseDate] = useState('')
+	const [expiryDate, setExpiryDate] = useState('')
+	useEffect(() => {
+		if (open) {
+			setCode(defaultCode || categories[0]?.code || '')
+			setName('')
+			setUnit('Bộ')
+			setQuantity('0')
+			setManufactureYear('')
+			setUsageYear('')
+			setClassification('')
+			setAssetStatus('NORMAL')
+			setPurchaseDate('')
+			setExpiryDate('')
+		}
+	}, [open, defaultCode, categories])
+	const mut = useMutation({
+		mutationFn: () =>
+			CreateCatalogMaterial({
+				chuyenNganhCode: code,
+				name: name.trim(),
+				unit: unit.trim() || 'Bộ',
+				quantity: Math.max(0, Number(quantity) || 0),
+				manufactureYear: manufactureYear
+					? Number(manufactureYear)
+					: undefined,
+				usageYear: usageYear ? Number(usageYear) : undefined,
+				classification: classification.trim() || undefined,
+				assetStatus,
+				purchaseDate: purchaseDate || undefined,
+				expiryDate: expiryDate || undefined
+			}),
+		onSuccess: async () => {
+			toast.success('Đã thêm vật tư')
+			await onSuccess()
+			onOpenChange(false)
+		},
+		onError: (err) =>
+			toast.error('Thêm vật tư thất bại', {
+				description: (err as Error).message
+			})
+	})
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className='sm:max-w-2xl max-h-[90vh] overflow-y-auto'>
+				<DialogHeader>
+					<DialogTitle>Thêm vật tư</DialogTitle>
+				</DialogHeader>
+				<form
+					className='space-y-4'
+					onSubmit={(e) => {
+						e.preventDefault()
+						if (!code || !name.trim()) return
+						mut.mutate()
+					}}
+				>
+					<div className='space-y-2'>
+						<Label>Chuyên ngành *</Label>
+						<Select value={code} onValueChange={setCode}>
+							<SelectTrigger>
+								<SelectValue placeholder='Chọn chuyên ngành' />
+							</SelectTrigger>
+							<SelectContent>
+								{categories
+									.filter((c) => !c.isNganh)
+									.map((c) => (
+										<SelectItem key={c.code} value={c.code}>
+											{c.code} — {c.name}
+										</SelectItem>
+									))}
+							</SelectContent>
+						</Select>
+					</div>
+					<div className='space-y-2'>
+						<Label>Tên vật tư *</Label>
+						<Input
+							value={name}
+							onChange={(e) => setName(e.target.value)}
+							required
+						/>
+					</div>
+					<div className='grid grid-cols-2 gap-3'>
+						<div className='space-y-2'>
+							<Label>Đơn vị tính</Label>
+							<Input
+								value={unit}
+								onChange={(e) => setUnit(e.target.value)}
+							/>
+						</div>
+						<div className='space-y-2'>
+							<Label>Số lượng danh mục</Label>
+							<Input
+								type='number'
+								min='0'
+								step='1'
+								value={quantity}
+								onChange={(e) => setQuantity(e.target.value)}
+							/>
+						</div>
+						<div className='space-y-2'>
+							<Label>Năm sản xuất</Label>
+							<Input
+								type='number'
+								value={manufactureYear}
+								onChange={(e) =>
+									setManufactureYear(e.target.value)
+								}
+							/>
+						</div>
+						<div className='space-y-2'>
+							<Label>Năm sử dụng</Label>
+							<Input
+								type='number'
+								value={usageYear}
+								onChange={(e) => setUsageYear(e.target.value)}
+							/>
+						</div>
+						<div className='space-y-2'>
+							<Label>Phân loại</Label>
+							<Input
+								value={classification}
+								onChange={(e) =>
+									setClassification(e.target.value)
+								}
+							/>
+						</div>
+						<div className='space-y-2'>
+							<Label>Trạng thái</Label>
+							<Select
+								value={assetStatus}
+								onValueChange={setAssetStatus}
+							>
+								<SelectTrigger>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value='NORMAL'>
+										Bình thường
+									</SelectItem>
+									<SelectItem value='BROKEN'>Hỏng</SelectItem>
+									<SelectItem value='REPAIRING'>
+										Đang sửa
+									</SelectItem>
+									<SelectItem value='DISPOSED'>
+										Thanh lý
+									</SelectItem>
+								</SelectContent>
+							</Select>
+						</div>
+						<div className='space-y-2'>
+							<Label>Ngày mua</Label>
+							<Input
+								type='date'
+								value={purchaseDate}
+								onChange={(e) =>
+									setPurchaseDate(e.target.value)
+								}
+							/>
+						</div>
+						<div className='space-y-2'>
+							<Label>Ngày hết hạn bảo hành</Label>
+							<Input
+								type='date'
+								min={purchaseDate || undefined}
+								value={expiryDate}
+								onChange={(e) => setExpiryDate(e.target.value)}
+							/>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button
+							type='button'
+							variant='outline'
+							onClick={() => onOpenChange(false)}
+						>
+							Hủy
+						</Button>
+						<Button
+							type='submit'
+							disabled={mut.isPending || !code || !name.trim()}
+						>
+							Lưu
+						</Button>
+					</DialogFooter>
+				</form>
+			</DialogContent>
+		</Dialog>
+	)
+}
+
 function EditMaterialDialog({
 	open,
 	material,
@@ -1499,11 +1736,13 @@ function EditMaterialDialog({
 	}, [open, material])
 
 	const mut = useMutation({
-		mutationFn: () =>
-			UpdateCatalogMaterial(material!.id, {
+		mutationFn: () => {
+			if (!material) throw new Error('Không tìm thấy vật tư cần cập nhật')
+			return UpdateCatalogMaterial(material.id, {
 				name: name.trim(),
 				unit: unit.trim() || 'Bộ'
-			}),
+			})
+		},
 		onSuccess: async () => {
 			toast.success('Đã cập nhật vật tư')
 			await onSuccess()
@@ -1836,8 +2075,10 @@ function EditCategoryDialog({
 	}, [open, target])
 
 	const mut = useMutation({
-		mutationFn: () =>
-			UpdateCatalogCategory(target!.item.id, { name: name.trim() }),
+		mutationFn: () => {
+			if (!target) throw new Error('Không tìm thấy danh mục cần cập nhật')
+			return UpdateCatalogCategory(target.item.id, { name: name.trim() })
+		},
 		onSuccess: async () => {
 			toast.success(
 				target?.kind === 'nganh'

--- a/apps/web/src/components/asset-management/RoomAssetDialog.tsx
+++ b/apps/web/src/components/asset-management/RoomAssetDialog.tsx
@@ -26,6 +26,7 @@ import type {
 	UpdateRoomAssetBody
 } from '@/types/asset'
 import { useEffect, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { ASSET_GRADES } from '@/lib/asset-grade'
 import {
 	isCatalogStyleAssetCode,
@@ -38,6 +39,7 @@ import {
 	validateAssetYears
 } from '@/lib/asset-year'
 import useUnitsData from '@/hooks/useUnitsData'
+import { GetAssetCatalog } from '@/api/asset'
 import { toast } from 'sonner'
 
 const STATUSES = [
@@ -81,6 +83,8 @@ type Props = {
 	/** Mã/tên phòng — gợi ý đơn vị sử dụng (CDHC2-D2 → D2) */
 	roomCode?: string
 	roomName?: string
+	/** Đơn vị quản lý của phòng; đồng thời là đơn vị sử dụng vật tư */
+	managerCode?: string
 	asset?: RoomAsset | null
 	onCreate: (body: CreateRoomAssetBody) => Promise<void>
 	onUpdate: (id: number, body: UpdateRoomAssetBody) => Promise<void>
@@ -93,12 +97,18 @@ export default function RoomAssetDialog({
 	locationCode = '',
 	roomCode = '',
 	roomName = '',
+	managerCode = '',
 	asset,
 	onCreate,
 	onUpdate
 }: Props) {
 	const isEdit = !!asset
 	const { data: unitsTree = [] } = useUnitsData()
+	const catalogQ = useQuery({
+		queryKey: ['asset-catalog', 'room-asset-picker'],
+		queryFn: () => GetAssetCatalog(),
+		enabled: open
+	})
 	const [pending, setPending] = useState(false)
 	/** Mã đầy đủ — một ô (vd. HC2A0113), không tách prefix vị trí */
 	const [fullCode, setFullCode] = useState('')
@@ -127,6 +137,20 @@ export default function RoomAssetDialog({
 	const [holdingPick, setHoldingPick] = useState<string>('')
 	/** Khi pick = OTHER: đơn vị thật bắt buộc */
 	const [otherUnitId, setOtherUnitId] = useState('')
+	const [selectedCatalogCode, setSelectedCatalogCode] = useState('')
+	const [selectedNganhCode, setSelectedNganhCode] = useState('')
+	const [selectedChuyenNganhCode, setSelectedChuyenNganhCode] = useState('')
+	const catalogMaterials = catalogQ.data?.materials ?? []
+	const catalogNganh = catalogQ.data?.nganh ?? []
+	const catalogChuyenNganh = catalogQ.data?.chuyenNganh ?? []
+	const filteredChuyenNganh = catalogChuyenNganh.filter(
+		(item) => !selectedNganhCode || item.nganhCode === selectedNganhCode
+	)
+	const filteredCatalogMaterials = catalogMaterials.filter(
+		(item) =>
+			!selectedChuyenNganhCode ||
+			item.categoryCode === selectedChuyenNganhCode
+	)
 
 	const allUnits: UnitFlat[] = useMemo(() => {
 		const list: UnitFlat[] = []
@@ -155,6 +179,11 @@ export default function RoomAssetDialog({
 
 	/** Gợi ý đơn vị từ mã/tên phòng hiện tại */
 	const suggestedUnitId = useMemo(() => {
+		const managerAlias = managerCode.trim().toUpperCase()
+		if (managerAlias) {
+			const managed = allUnits.find((u) => u.alias === managerAlias)
+			if (managed) return String(managed.id)
+		}
 		const code = (roomCode || '').toUpperCase()
 		const tail = code.includes('-') ? code.split('-').pop() || '' : ''
 		if (tail) {
@@ -169,7 +198,7 @@ export default function RoomAssetDialog({
 			if (byName) return String(byName.id)
 		}
 		return ''
-	}, [roomCode, roomName, allUnits])
+	}, [managerCode, roomCode, roomName, allUnits])
 
 	const unitOptions: SearchableOption[] = useMemo(
 		() => [
@@ -188,12 +217,13 @@ export default function RoomAssetDialog({
 	)
 
 	const resolvedHoldingUnitId = useMemo(() => {
+		if (!isEdit) return suggestedUnitId ? Number(suggestedUnitId) : null
 		if (holdingPick === OTHER_UNIT) {
 			return otherUnitId ? Number(otherUnitId) : null
 		}
 		if (holdingPick) return Number(holdingPick)
 		return null
-	}, [holdingPick, otherUnitId])
+	}, [holdingPick, otherUnitId, isEdit, suggestedUnitId])
 
 	useEffect(() => {
 		if (asset) {
@@ -201,6 +231,20 @@ export default function RoomAssetDialog({
 			setFullCode(cleaned)
 			setName(asset.name)
 			setCategory(asset.category)
+			setSelectedCatalogCode(
+				catalogMaterials.find(
+					(item) =>
+						asset.code === item.code ||
+						asset.code.startsWith(`${item.code}-`)
+				)?.code ?? ''
+			)
+			const picked = catalogMaterials.find(
+				(item) =>
+					asset.code === item.code ||
+					asset.code.startsWith(`${item.code}-`)
+			)
+			setSelectedNganhCode(picked?.nganhCode ?? '')
+			setSelectedChuyenNganhCode(picked?.categoryCode ?? '')
 			setQuantity(asset.quantity)
 			setUnit(asset.unit ?? '')
 			setGrade(String(asset.grade ?? 1))
@@ -238,6 +282,9 @@ export default function RoomAssetDialog({
 			setFullCode('')
 			setName('')
 			setCategory('')
+			setSelectedCatalogCode('')
+			setSelectedNganhCode('')
+			setSelectedChuyenNganhCode('')
 			setQuantity(1)
 			setUnit('')
 			setGrade('1')
@@ -255,7 +302,7 @@ export default function RoomAssetDialog({
 			setHoldingPick(suggestedUnitId || '')
 			setOtherUnitId('')
 		}
-	}, [asset, open, suggestedUnitId])
+	}, [asset, suggestedUnitId, catalogMaterials])
 
 	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault()
@@ -266,21 +313,21 @@ export default function RoomAssetDialog({
 			code = code.toUpperCase()
 		}
 		if (!code || !name.trim() || !category.trim()) {
-			toast.error('Mã, tên và loại vật tư là bắt buộc')
+			toast.error('Hãy chọn vật tư trong danh mục ngành')
 			return
 		}
-		if (!holdingPick) {
+		if (isEdit && !holdingPick) {
 			toast.error('Chọn đơn vị sử dụng')
 			return
 		}
-		if (holdingPick === OTHER_UNIT && !otherUnitId) {
+		if (isEdit && holdingPick === OTHER_UNIT && !otherUnitId) {
 			toast.error(
 				'Đã chọn «Khác» — bắt buộc chọn đơn vị quản lý / sử dụng'
 			)
 			return
 		}
 		if (resolvedHoldingUnitId == null) {
-			toast.error('Chọn đơn vị sử dụng hợp lệ')
+			toast.error('Phòng chưa có đơn vị sử dụng để tự động cập nhật')
 			return
 		}
 		const yearErr = validateAssetYears({
@@ -348,26 +395,98 @@ export default function RoomAssetDialog({
 						<Label className='text-base font-semibold'>
 							Mã vật tư *
 						</Label>
-						<Input
-							value={fullCode}
-							onChange={(e) =>
-								setFullCode(
-									stripLocationPrefixFromCatalog(
-										e.target.value
+						<div className='grid grid-cols-1 gap-3'>
+							<Select
+								value={selectedNganhCode}
+								onValueChange={(value) => {
+									setSelectedNganhCode(value)
+									setSelectedChuyenNganhCode('')
+									setSelectedCatalogCode('')
+								}}
+							>
+								<SelectTrigger className='h-12'>
+									<SelectValue placeholder='Chọn ngành' />
+								</SelectTrigger>
+								<SelectContent>
+									{catalogNganh.map((item) => (
+										<SelectItem
+											key={item.code}
+											value={item.code}
+										>
+											{item.code} — {item.name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+							<Select
+								value={selectedChuyenNganhCode}
+								onValueChange={(value) => {
+									setSelectedChuyenNganhCode(value)
+									setSelectedCatalogCode('')
+								}}
+								disabled={!selectedNganhCode}
+							>
+								<SelectTrigger className='h-12'>
+									<SelectValue placeholder='Chọn loại vật' />
+								</SelectTrigger>
+								<SelectContent>
+									{filteredChuyenNganh.map((item) => (
+										<SelectItem
+											key={item.code}
+											value={item.code}
+										>
+											{item.code} — {item.name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+							<Select
+								value={selectedCatalogCode}
+								onValueChange={(value) => {
+									const m = filteredCatalogMaterials.find(
+										(item) => item.code === value
 									)
-								)
-							}
-							placeholder='VD: HC2A0113-G2-D1'
-							required
-							className='font-mono h-12 text-lg'
-						/>
+									if (!m) return
+									setSelectedCatalogCode(value)
+									setFullCode(value)
+									setName(m.name)
+									setCategory(
+										m.classification ||
+											m.categoryName ||
+											m.categoryCode
+									)
+									setUnit(m.unit)
+									setManufactureYear(
+										m.manufactureYear != null
+											? String(m.manufactureYear)
+											: ''
+									)
+									setUsageYear(
+										m.usageYear != null
+											? String(m.usageYear)
+											: ''
+									)
+									setStatus(m.assetStatus || 'NORMAL')
+									setPurchaseDate(m.purchaseDate || '')
+									setExpiryDate(m.expiryDate || '')
+								}}
+								disabled={!selectedChuyenNganhCode}
+							>
+								<SelectTrigger className='h-12'>
+									<SelectValue placeholder='Chọn vật tư' />
+								</SelectTrigger>
+								<SelectContent>
+									{filteredCatalogMaterials.map((m) => (
+										<SelectItem key={m.id} value={m.code}>
+											{m.code} — {m.name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
 						<p className='text-base text-muted-foreground leading-relaxed'>
-							<strong>Quy tắc mã:</strong>{' '}
-							<span className='font-mono font-medium text-foreground'>
-								HC2A0113-G2-D1
-							</span>{' '}
-							= mã thiết bị danh mục + cấp (G1–G5) + alias đơn vị.
-							Không ghép mã tòa/tầng/phòng.
+							<strong>Danh mục:</strong> chọn lần lượt Ngành, Loại
+							vật và Vật tư.
 							{locationCode ? (
 								<>
 									<br />
@@ -380,27 +499,24 @@ export default function RoomAssetDialog({
 						</p>
 					</div>
 					<div className='grid grid-cols-2 gap-3'>
-						<div className='space-y-2'>
+						<div className={isEdit ? 'space-y-2' : 'hidden'}>
 							<Label className='text-base font-semibold'>
 								Tên thiết bị *
 							</Label>
 							<Input
 								value={name}
-								onChange={(e) => setName(e.target.value)}
-								required
-								className='h-12 text-lg'
+								readOnly
+								className='h-12 text-lg bg-muted'
 							/>
 						</div>
-						<div className='space-y-2'>
+						<div className={isEdit ? 'space-y-2' : 'hidden'}>
 							<Label className='text-base font-semibold'>
 								Loại / nhóm *
 							</Label>
 							<Input
 								value={category}
-								onChange={(e) => setCategory(e.target.value)}
-								placeholder='VD: IT, Khác'
-								required
-								className='h-12 text-lg'
+								readOnly
+								className='h-12 text-lg bg-muted'
 							/>
 						</div>
 					</div>
@@ -419,7 +535,7 @@ export default function RoomAssetDialog({
 								className='h-12 text-lg'
 							/>
 						</div>
-						<div className='space-y-2'>
+						<div className={isEdit ? 'space-y-2' : 'hidden'}>
 							<Label className='text-base font-semibold'>
 								ĐVT
 							</Label>
@@ -430,7 +546,7 @@ export default function RoomAssetDialog({
 								className='h-12 text-lg'
 							/>
 						</div>
-						<div className='space-y-2'>
+						<div className={isEdit ? 'space-y-2' : 'hidden'}>
 							<Label className='text-base font-semibold'>
 								Phân cấp
 							</Label>
@@ -451,15 +567,29 @@ export default function RoomAssetDialog({
 							</Select>
 						</div>
 					</div>
-					{grade === '5' && (
+					{isEdit && grade === '5' && (
 						<p className='text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-md px-2 py-1.5'>
 							Phân cấp 5 (Hỏng): hệ thống sẽ tự đề xuất phiếu sửa
 							chữa.
 						</p>
 					)}
 
-					{/* Đơn vị sử dụng — bắt buộc; Khác → chọn đơn vị quản lý */}
-					<div className='space-y-3 rounded-md border p-3 bg-muted/20'>
+					{/* Khi thêm mới, đơn vị được lấy tự động từ phòng. */}
+					{!isEdit && (
+						<div className='rounded-md border bg-muted/30 p-3 text-sm'>
+							<strong>Đơn vị sử dụng:</strong>{' '}
+							{allUnits.find(
+								(u) => String(u.id) === suggestedUnitId
+							)?.name || 'Chưa xác định từ phòng'}
+						</div>
+					)}
+					<div
+						className={
+							isEdit
+								? 'space-y-3 rounded-md border p-3 bg-muted/20'
+								: 'hidden'
+						}
+					>
 						<div className='space-y-2'>
 							<Label className='text-base font-semibold'>
 								Đơn vị sử dụng{' '}
@@ -512,7 +642,9 @@ export default function RoomAssetDialog({
 						)}
 					</div>
 
-					<div className='grid grid-cols-2 gap-3'>
+					<div
+						className={isEdit ? 'grid grid-cols-2 gap-3' : 'hidden'}
+					>
 						<div className='space-y-2'>
 							<Label className='text-base font-semibold'>
 								Năm sản xuất
@@ -559,7 +691,9 @@ export default function RoomAssetDialog({
 							className='h-12 text-lg'
 						/>
 					</div>
-					<div className='grid grid-cols-2 gap-3'>
+					<div
+						className={isEdit ? 'grid grid-cols-2 gap-3' : 'hidden'}
+					>
 						<div className='space-y-2'>
 							<Label className='text-base font-semibold'>
 								Trạng thái
@@ -591,7 +725,7 @@ export default function RoomAssetDialog({
 							/>
 						</div>
 					</div>
-					<div className='space-y-2'>
+					<div className={isEdit ? 'space-y-2' : 'hidden'}>
 						<Label>Ngày hết hạn / BH</Label>
 						<Input
 							type='date'
@@ -599,56 +733,63 @@ export default function RoomAssetDialog({
 							onChange={(e) => setExpiryDate(e.target.value)}
 						/>
 					</div>
-					{(status === 'BROKEN' || status === 'REPAIRING') && (
-						<div className='rounded-md border p-3 space-y-3 bg-muted/30'>
-							<p className='text-xs font-medium text-muted-foreground'>
-								Thông tin hư hỏng / sửa chữa
-							</p>
-							<div className='grid grid-cols-2 gap-3'>
-								<div className='space-y-2'>
-									<Label>Ngày hư</Label>
-									<Input
-										type='date'
-										value={brokenAt}
-										onChange={(e) =>
-											setBrokenAt(e.target.value)
-										}
-									/>
+					{isEdit &&
+						(status === 'BROKEN' || status === 'REPAIRING') && (
+							<div className='rounded-md border p-3 space-y-3 bg-muted/30'>
+								<p className='text-xs font-medium text-muted-foreground'>
+									Thông tin hư hỏng / sửa chữa
+								</p>
+								<div className='grid grid-cols-2 gap-3'>
+									<div className='space-y-2'>
+										<Label>Ngày hư</Label>
+										<Input
+											type='date'
+											value={brokenAt}
+											onChange={(e) =>
+												setBrokenAt(e.target.value)
+											}
+										/>
+									</div>
+									<div className='space-y-2'>
+										<Label>Bắt đầu sửa</Label>
+										<Input
+											type='date'
+											value={repairStartedAt}
+											onChange={(e) =>
+												setRepairStartedAt(
+													e.target.value
+												)
+											}
+										/>
+									</div>
 								</div>
-								<div className='space-y-2'>
-									<Label>Bắt đầu sửa</Label>
-									<Input
-										type='date'
-										value={repairStartedAt}
-										onChange={(e) =>
-											setRepairStartedAt(e.target.value)
-										}
-									/>
+								<div className='grid grid-cols-2 gap-3'>
+									<div className='space-y-2'>
+										<Label>Hoàn thành SC</Label>
+										<Input
+											type='date'
+											value={repairCompletedAt}
+											onChange={(e) =>
+												setRepairCompletedAt(
+													e.target.value
+												)
+											}
+										/>
+									</div>
+									<div className='space-y-2'>
+										<Label>Người sửa</Label>
+										<Input
+											value={repairPerformer}
+											onChange={(e) =>
+												setRepairPerformer(
+													e.target.value
+												)
+											}
+										/>
+									</div>
 								</div>
 							</div>
-							<div className='grid grid-cols-2 gap-3'>
-								<div className='space-y-2'>
-									<Label>Hoàn thành SC</Label>
-									<Input
-										type='date'
-										value={repairCompletedAt}
-										onChange={(e) =>
-											setRepairCompletedAt(e.target.value)
-										}
-									/>
-								</div>
-								<div className='space-y-2'>
-									<Label>Người sửa</Label>
-									<Input
-										value={repairPerformer}
-										onChange={(e) =>
-											setRepairPerformer(e.target.value)
-										}
-									/>
-								</div>
-							</div>
-						</div>
-					)}
+						)}
 					<div className='space-y-2'>
 						<Label>Mô tả / ghi chú</Label>
 						<Textarea

--- a/apps/web/src/components/asset-management/RoomDialog.tsx
+++ b/apps/web/src/components/asset-management/RoomDialog.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/components/ui/select'
 import type { Room } from '@/types/asset'
 import { useRoomMutations } from '@/hooks/useRooms'
+import useUnitsData from '@/hooks/useUnitsData'
 import { toast } from 'sonner'
 
 type Props = {
@@ -45,10 +46,12 @@ export default function RoomDialog({
 }: Props) {
 	const isEdit = !!room
 	const { create, update } = useRoomMutations()
+	const unitsQ = useUnitsData()
 	const [roomCode, setRoomCode] = useState('')
 	const [roomName, setRoomName] = useState('')
 	const [roomType, setRoomType] = useState('')
 	const [manager, setManager] = useState('')
+	const [managerCode, setManagerCode] = useState('')
 	const [capacity, setCapacity] = useState(0)
 	const [status, setStatus] = useState('ACTIVE')
 	const [description, setDescription] = useState('')
@@ -59,6 +62,7 @@ export default function RoomDialog({
 			setRoomName(room.roomName)
 			setRoomType(room.roomType ?? '')
 			setManager(room.manager ?? '')
+			setManagerCode(room.managerCode ?? '')
 			setCapacity(room.capacity ?? 0)
 			setStatus(room.status ?? 'ACTIVE')
 			setDescription(room.description ?? '')
@@ -67,11 +71,12 @@ export default function RoomDialog({
 			setRoomName('')
 			setRoomType('')
 			setManager('')
+			setManagerCode('')
 			setCapacity(0)
 			setStatus('ACTIVE')
 			setDescription('')
 		}
-	}, [room, open, locationPrefix])
+	}, [room, locationPrefix])
 
 	const pending = create.isPending || update.isPending
 
@@ -88,6 +93,7 @@ export default function RoomDialog({
 			roomType: roomType || undefined,
 			// Chỉ text «Đơn vị quản lý» — không tạo TK đăng nhập phòng
 			manager: manager || undefined,
+			managerCode: managerCode || undefined,
 			capacity,
 			status,
 			description: description || undefined
@@ -141,13 +147,36 @@ export default function RoomDialog({
 					</div>
 					<div className='grid grid-cols-2 gap-3'>
 						<div className='space-y-2 col-span-2'>
-							<Label htmlFor='manager'>Đơn vị quản lý</Label>
-							<Input
-								id='manager'
-								value={manager}
-								onChange={(e) => setManager(e.target.value)}
-								placeholder='VD: Tiểu đoàn 1, Đại đội 1, Ban Giám hiệu…'
-							/>
+							<Label>Đơn vị quản lý</Label>
+							<Select
+								value={managerCode || 'none'}
+								onValueChange={(v) => {
+									const unit = unitsQ.data?.find(
+										(u) => u.alias === v
+									)
+									setManagerCode(v === 'none' ? '' : v)
+									setManager(
+										v === 'none' ? '' : unit?.name || ''
+									)
+								}}
+							>
+								<SelectTrigger>
+									<SelectValue placeholder='Chọn đơn vị sử dụng' />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value='none'>
+										Chưa chọn
+									</SelectItem>
+									{(unitsQ.data || []).map((unit) => (
+										<SelectItem
+											key={unit.id}
+											value={unit.alias}
+										>
+											{unit.alias} — {unit.name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
 							<p className='text-[11px] text-muted-foreground'>
 								Chỉ ghi nhận đơn vị quản lý phòng — không tạo
 								tài khoản đăng nhập. TK đăng nhập: đơn vị sử

--- a/apps/web/src/components/asset-management/RoomProfile.tsx
+++ b/apps/web/src/components/asset-management/RoomProfile.tsx
@@ -1221,6 +1221,7 @@ export default function RoomProfile({ roomId }: { roomId: number }) {
 				}
 				roomCode={data.roomCode}
 				roomName={data.roomName}
+				managerCode={data.managerCode ?? ''}
 				asset={editingAsset}
 				onCreate={async (body) => {
 					await mutations.createAsset.mutateAsync(body)

--- a/apps/web/src/components/asset-management/UnitUsagePanel.tsx
+++ b/apps/web/src/components/asset-management/UnitUsagePanel.tsx
@@ -288,6 +288,7 @@ export default function UnitUsagePanel({
 		setAddOpen(true)
 	}
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: this effect intentionally reacts only to the external signal
 	useEffect(() => {
 		if (openAddSignal > 0) openAddDialog()
 	}, [openAddSignal])

--- a/apps/web/src/components/exam/ExamFacultiesPage.tsx
+++ b/apps/web/src/components/exam/ExamFacultiesPage.tsx
@@ -1,5 +1,7 @@
 import {
 	CreateExamSubject,
+	CreateExamFaculty,
+	DeleteExamFaculty,
 	DeleteExamFacultyHead,
 	DeleteExamSubject,
 	type ExamSubject,
@@ -64,6 +66,10 @@ export default function ExamFacultiesPage() {
 	const qc = useQueryClient()
 	const canManage = canManageExamCatalog()
 	const [editingCode, setEditingCode] = useState<string | null>(null)
+	const [facultyEditorOpen, setFacultyEditorOpen] = useState(false)
+	const [facultyEditorMode, setFacultyEditorMode] = useState<
+		'create' | 'edit'
+	>('edit')
 	const [managingCode, setManagingCode] = useState<string | null>(null)
 	const [subjectEditorOpen, setSubjectEditorOpen] = useState(false)
 	const [editingSubjectId, setEditingSubjectId] = useState<number | null>(
@@ -172,6 +178,31 @@ export default function ExamFacultiesPage() {
 		},
 		onError: (error: Error) => toast.error(error.message)
 	})
+	const createFaculty = useMutation({
+		mutationFn: () =>
+			CreateExamFaculty({ code: form.code, name: form.name }),
+		onSuccess: () => {
+			toast.success('Đã thêm khoa')
+			setFacultyEditorOpen(false)
+			void qc.invalidateQueries({ queryKey: ['exam-faculties'] })
+			void qc.invalidateQueries({ queryKey: ['exam-faculty-options'] })
+		},
+		onError: (error: Error) => toast.error(error.message)
+	})
+	const deleteFaculty = useMutation({
+		mutationFn: async (code: string) => {
+			const records = (facultiesQ.data || []).filter(
+				(f) => f.code === code
+			)
+			for (const record of records) await DeleteExamFaculty(record.id)
+		},
+		onSuccess: () => {
+			toast.success('Đã xóa khoa')
+			void qc.invalidateQueries({ queryKey: ['exam-faculties'] })
+			void qc.invalidateQueries({ queryKey: ['exam-faculty-options'] })
+		},
+		onError: (error: Error) => toast.error(error.message)
+	})
 
 	const managedFaculty = rows.find((faculty) => faculty.code === managingCode)
 	const managedRecords = (facultiesQ.data || []).filter(
@@ -252,14 +283,27 @@ export default function ExamFacultiesPage() {
 
 	return (
 		<div className='space-y-6 p-4 md:p-6'>
-			<div>
-				<h1 className='text-2xl font-semibold tracking-tight'>
-					Danh mục khoa
-				</h1>
-				<p className='text-muted-foreground text-sm'>
-					Khoa quản lý môn học, giáo viên thuộc khoa và Chủ nhiệm khoa
-					duyệt đề.
-				</p>
+			<div className='flex items-start justify-between gap-4'>
+				<div>
+					<h1 className='text-2xl font-semibold tracking-tight'>
+						Danh mục khoa
+					</h1>
+					<p className='text-muted-foreground text-sm'>
+						Khoa quản lý môn học, giáo viên thuộc khoa và Chủ nhiệm
+						khoa duyệt đề.
+					</p>
+				</div>
+				{canManage && (
+					<Button
+						onClick={() => {
+							setFacultyEditorMode('create')
+							setForm({ code: '', name: '', headUserId: 'none' })
+							setFacultyEditorOpen(true)
+						}}
+					>
+						<Plus className='mr-2 h-4 w-4' /> Thêm khoa
+					</Button>
+				)}
 			</div>
 			{error && (
 				<div className='rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive'>
@@ -289,26 +333,43 @@ export default function ExamFacultiesPage() {
 										</CardDescription>
 									</div>
 									{canManage && (
-										<Button
-											size='icon'
-											variant='ghost'
-											title='Sửa khoa'
-											onClick={() => {
-												setEditingCode(faculty.code)
-												setForm({
-													code: faculty.code,
-													name: faculty.name,
-													headUserId: faculty.head
-														? String(
-																faculty.head
-																	.userId
-															)
-														: 'none'
-												})
-											}}
-										>
-											<Pencil className='h-4 w-4' />
-										</Button>
+										<div className='flex gap-1'>
+											<Button
+												size='icon'
+												variant='ghost'
+												title='Sửa khoa'
+												onClick={() => {
+													setEditingCode(faculty.code)
+													setForm({
+														code: faculty.code,
+														name: faculty.name,
+														headUserId: faculty.head
+															? String(
+																	faculty.head
+																		.userId
+																)
+															: 'none'
+													})
+												}}
+											>
+												<Pencil className='h-4 w-4' />
+											</Button>
+											<Button
+												size='icon'
+												variant='ghost'
+												title='Xóa khoa'
+												onClick={() =>
+													window.confirm(
+														`Xóa khoa ${faculty.code}?`
+													) &&
+													deleteFaculty.mutate(
+														faculty.code
+													)
+												}
+											>
+												<Trash2 className='h-4 w-4 text-destructive' />
+											</Button>
+										</div>
 									)}
 								</div>
 							</CardHeader>
@@ -541,6 +602,73 @@ export default function ExamFacultiesPage() {
 							</TableBody>
 						</Table>
 					</div>
+				</DialogContent>
+			</Dialog>
+			<Dialog
+				open={facultyEditorOpen}
+				onOpenChange={setFacultyEditorOpen}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>
+							{facultyEditorMode === 'create'
+								? 'Thêm khoa'
+								: 'Sửa khoa'}
+						</DialogTitle>
+					</DialogHeader>
+					<div className='space-y-3'>
+						<div>
+							<Label>Mã khoa *</Label>
+							<Input
+								value={form.code}
+								onChange={(e) =>
+									setForm((o) => ({
+										...o,
+										code: e.target.value.toUpperCase()
+									}))
+								}
+								placeholder='K1'
+							/>
+						</div>
+						<div>
+							<Label>Tên khoa *</Label>
+							<Input
+								value={form.name}
+								onChange={(e) =>
+									setForm((o) => ({
+										...o,
+										name: e.target.value
+									}))
+								}
+							/>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button
+							variant='outline'
+							onClick={() => setFacultyEditorOpen(false)}
+						>
+							Hủy
+						</Button>
+						<Button
+							disabled={
+								!form.code.trim() ||
+								!form.name.trim() ||
+								createFaculty.isPending ||
+								save.isPending
+							}
+							onClick={() => {
+								if (facultyEditorMode === 'create')
+									createFaculty.mutate()
+								else {
+									setFacultyEditorOpen(false)
+									save.mutate()
+								}
+							}}
+						>
+							Lưu
+						</Button>
+					</DialogFooter>
 				</DialogContent>
 			</Dialog>
 

--- a/apps/web/src/components/exam/ExamTrainingCatalogPage.tsx
+++ b/apps/web/src/components/exam/ExamTrainingCatalogPage.tsx
@@ -1,16 +1,20 @@
 import {
 	CreateExamMajor,
 	CreateExamSubject,
+	CreateExamSystem,
 	DeleteExamMajor,
 	DeleteExamSubject,
+	DeleteExamSystem,
 	type ExamMajor,
 	type ExamSubject,
+	type ExamSystem,
 	ListExamFaculties,
 	ListExamMajors,
 	ListExamSubjects,
 	ListExamSystems,
 	UpdateExamMajor,
-	UpdateExamSubject
+	UpdateExamSubject,
+	UpdateExamSystem
 } from '@/api/exam'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -60,18 +64,13 @@ import { useMemo, useState } from 'react'
 import { toast } from 'sonner'
 
 const QUALIFICATION_OPTIONS = ['Sơ cấp', 'Trung cấp', 'Cao đẳng']
-const TRAINING_DURATION_OPTIONS = [
-	'6 tháng',
-	'1 năm',
-	'2 năm',
-	'2,5 năm',
-	'3 năm'
-]
 const TRAINING_FORM_OPTIONS = ['Chính quy', 'Liên thông', 'Chuyển loại']
 
 export default function ExamTrainingCatalogPage() {
 	const qc = useQueryClient()
 	const canManage = canManageExamCatalog()
+	const [systemOpen, setSystemOpen] = useState(false)
+	const [editingSystemId, setEditingSystemId] = useState<number | null>(null)
 	const [majorOpen, setMajorOpen] = useState(false)
 	const [editingId, setEditingId] = useState<number | null>(null)
 	const [subjectOpen, setSubjectOpen] = useState(false)
@@ -80,6 +79,11 @@ export default function ExamTrainingCatalogPage() {
 	)
 	const [subjectMajorId, setSubjectMajorId] = useState<number | null>(null)
 	const [majorSearch, setMajorSearch] = useState('')
+	const [systemForm, setSystemForm] = useState({
+		code: 'QS',
+		name: 'Hệ quân sự',
+		letter: 'A'
+	})
 	const [form, setForm] = useState({
 		systemId: 0,
 		nationalMajorCode: '',
@@ -199,6 +203,60 @@ export default function ExamTrainingCatalogPage() {
 		})
 		setMajorOpen(true)
 	}
+
+	const openCreateSystem = () => {
+		setEditingSystemId(null)
+		setSystemForm({ code: '', name: '', letter: '' })
+		setSystemOpen(true)
+	}
+
+	const openEditSystem = (system: ExamSystem) => {
+		setEditingSystemId(system.id)
+		setSystemForm({
+			code: system.code,
+			name: system.name,
+			letter: system.letter
+		})
+		setSystemOpen(true)
+	}
+
+	const saveSystem = useMutation({
+		mutationFn: () => {
+			const body = {
+				code: systemForm.code.trim(),
+				name: systemForm.name.trim(),
+				letter: systemForm.letter.trim(),
+				trainingTypeId: 1
+			}
+			return editingSystemId == null
+				? CreateExamSystem(body)
+				: UpdateExamSystem(editingSystemId, body)
+		},
+		onSuccess: (system) => {
+			toast.success(
+				editingSystemId == null
+					? 'Đã thêm hệ đào tạo'
+					: 'Đã cập nhật hệ đào tạo'
+			)
+			setSystemOpen(false)
+			setEditingSystemId(null)
+			setForm((old) => ({
+				...old,
+				systemId: old.systemId || system.id
+			}))
+			void qc.invalidateQueries({ queryKey: ['exam-systems'] })
+		},
+		onError: (error: Error) => toast.error(error.message)
+	})
+
+	const removeSystem = useMutation({
+		mutationFn: (id: number) => DeleteExamSystem(id),
+		onSuccess: () => {
+			toast.success('Đã xóa hệ đào tạo')
+			void qc.invalidateQueries({ queryKey: ['exam-systems'] })
+		},
+		onError: (error: Error) => toast.error(error.message)
+	})
 
 	const openEdit = (major: ExamMajor) => {
 		setEditingId(major.id)
@@ -346,6 +404,98 @@ export default function ExamTrainingCatalogPage() {
 				</div>
 			)}
 			<Card>
+				<CardHeader className='gap-3 pb-3'>
+					<div className='flex flex-col justify-between gap-3 sm:flex-row sm:items-start'>
+						<div>
+							<CardTitle>HỆ ĐÀO TẠO</CardTitle>
+							<CardDescription>
+								Quản lý các hệ và ký hiệu dùng để tạo mã ngành
+								đào tạo.
+							</CardDescription>
+						</div>
+						{canManage && (
+							<Button
+								className='shrink-0'
+								variant='outline'
+								onClick={openCreateSystem}
+							>
+								<Plus className='mr-2 h-4 w-4' /> Thêm hệ
+							</Button>
+						)}
+					</div>
+				</CardHeader>
+				<CardContent>
+					{systems.length ? (
+						<div className='grid gap-3 md:grid-cols-2'>
+							{systems.map((system) => (
+								<div
+									key={system.id}
+									className='flex items-center gap-3 rounded-lg border p-3'
+								>
+									<div className='bg-muted flex h-10 w-10 shrink-0 items-center justify-center rounded-md font-mono font-bold'>
+										{system.letter}
+									</div>
+									<div className='min-w-0 flex-1'>
+										<div className='font-medium'>
+											{system.name}
+										</div>
+										<div className='text-muted-foreground text-xs'>
+											Mã {system.code} ·{' '}
+											{
+												(
+													majorsBySystem.get(
+														system.id
+													) || []
+												).length
+											}{' '}
+											ngành
+										</div>
+									</div>
+									{canManage && (
+										<div className='flex shrink-0 gap-0.5'>
+											<Button
+												type='button'
+												size='icon'
+												variant='ghost'
+												title='Sửa hệ đào tạo'
+												onClick={() =>
+													openEditSystem(system)
+												}
+											>
+												<Pencil className='h-4 w-4' />
+											</Button>
+											<Button
+												type='button'
+												size='icon'
+												variant='ghost'
+												title='Xóa hệ đào tạo'
+												onClick={() => {
+													if (
+														window.confirm(
+															`Xóa ${system.name}?`
+														)
+													)
+														removeSystem.mutate(
+															system.id
+														)
+												}}
+											>
+												<Trash2 className='h-4 w-4 text-destructive' />
+											</Button>
+										</div>
+									)}
+								</div>
+							))}
+						</div>
+					) : (
+						<div className='text-muted-foreground rounded-lg border border-dashed p-6 text-center text-sm'>
+							Chưa có hệ đào tạo. Bấm “Thêm hệ” để tạo hệ quân sự
+							hoặc dân sự.
+						</div>
+					)}
+				</CardContent>
+			</Card>
+			<Card>
 				<CardHeader className='gap-4 pb-3'>
 					<div className='flex flex-col justify-between gap-3 lg:flex-row lg:items-start'>
 						<div>
@@ -389,20 +539,19 @@ export default function ExamTrainingCatalogPage() {
 							</TableRow>
 						</TableHeader>
 						<TableBody>
-							{['B', 'A'].map((letter) => {
+							{systems.map((system) => {
 								const rows = visibleMajors.filter(
-									(major) => major.systemLetter === letter
+									(major) => major.systemId === system.id
 								)
 								if (!rows.length) return null
 								return [
-									<TableRow key={`${letter}-heading`}>
+									<TableRow key={`${system.id}-heading`}>
 										<TableCell
 											colSpan={canManage ? 5 : 4}
 											className='bg-muted/50 h-9 py-2 text-center font-bold text-red-600'
 										>
-											{letter === 'B'
-												? 'HỆ DÂN SỰ'
-												: 'HỆ QUÂN SỰ'}
+											{system.name.toUpperCase()} (
+											{system.letter})
 										</TableCell>
 									</TableRow>,
 									...rows.map((major) => (
@@ -649,6 +798,88 @@ export default function ExamTrainingCatalogPage() {
 					)}
 				</CardContent>
 			</Card>
+			<Dialog
+				open={systemOpen}
+				onOpenChange={(open) => {
+					setSystemOpen(open)
+					if (!open) setEditingSystemId(null)
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>
+							{editingSystemId == null
+								? 'Thêm hệ đào tạo'
+								: 'Sửa hệ đào tạo'}
+						</DialogTitle>
+					</DialogHeader>
+					<p className='text-muted-foreground text-xs'>
+						Nhập ký hiệu chưa được sử dụng; ký hiệu này sẽ đứng đầu
+						mã ngành, ví dụ A.6720301.
+					</p>
+					<div className='space-y-4 py-2'>
+						<div className='space-y-2'>
+							<Label>Ký hiệu hệ *</Label>
+							<Input
+								value={systemForm.letter}
+								onChange={(event) =>
+									setSystemForm((old) => ({
+										...old,
+										letter: event.target.value.toUpperCase()
+									}))
+								}
+								placeholder='Ví dụ: C'
+							/>
+						</div>
+						<div className='space-y-2'>
+							<Label>Mã hệ *</Label>
+							<Input
+								value={systemForm.code}
+								onChange={(event) =>
+									setSystemForm((old) => ({
+										...old,
+										code: event.target.value
+									}))
+								}
+							/>
+						</div>
+						<div className='space-y-2'>
+							<Label>Tên hệ *</Label>
+							<Input
+								value={systemForm.name}
+								onChange={(event) =>
+									setSystemForm((old) => ({
+										...old,
+										name: event.target.value
+									}))
+								}
+							/>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button
+							variant='outline'
+							onClick={() => setSystemOpen(false)}
+						>
+							Hủy
+						</Button>
+						<Button
+							disabled={
+								saveSystem.isPending ||
+								!systemForm.code.trim() ||
+								!systemForm.name.trim() ||
+								!systemForm.letter.trim()
+							}
+							onClick={() => saveSystem.mutate()}
+						>
+							{saveSystem.isPending && (
+								<Loader2 className='mr-2 h-4 w-4 animate-spin' />
+							)}
+							Lưu
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 			<Dialog open={subjectOpen} onOpenChange={setSubjectOpen}>
 				<DialogContent className='max-w-xl'>
 					<DialogHeader>
@@ -879,26 +1110,16 @@ export default function ExamTrainingCatalogPage() {
 						</div>
 						<div className='space-y-2'>
 							<Label>Thời gian đào tạo *</Label>
-							<Select
+							<Input
 								value={form.trainingDuration}
-								onValueChange={(value) =>
+								onChange={(event) =>
 									setForm((old) => ({
 										...old,
-										trainingDuration: value
+										trainingDuration: event.target.value
 									}))
 								}
-							>
-								<SelectTrigger>
-									<SelectValue placeholder='Chọn thời gian' />
-								</SelectTrigger>
-								<SelectContent>
-									{TRAINING_DURATION_OPTIONS.map((option) => (
-										<SelectItem key={option} value={option}>
-											{option}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
+								placeholder='Ví dụ: 2 năm 6 tháng'
+							/>
 						</div>
 						<div className='space-y-2'>
 							<Label>Hình thức đào tạo *</Label>


### PR DESCRIPTION
## Nội dung
- Mở rộng quy trình phòng, đơn vị và tài sản.
- Bổ sung API đơn vị độc lập và dữ liệu vai trò.

## PR đã hấp thụ
- #201: expose standalone units and role data.

#201 được đóng vì toàn bộ thay đổi đã nằm trong PR này.

## Thứ tự merge
Merge sau #198.