### PR TITLE
feat(exam): require unique catalog numbers and remove hidden majors

### DIFF
--- a/apps/api/exam-management/catalog.ts
+++ b/apps/api/exam-management/catalog.ts
@@ -4,8 +4,9 @@
  *     → Ngành (cột chương trình: Y sĩ TC/CD/LT, Điều dưỡng…)
  *       → Khoa → Môn
  *
- * Mã ngành: A/B_TC|CD|LT + viết tắt (vd B_CDDD), chỉnh tay được.
- * Mã môn: {mã_ngành}_{mã_gốc}
+ * Mã số: định danh duy nhất của từng chương trình/ngành (vd A.6720301).
+ * Mã ngành: mã danh mục quốc gia, có thể trùng giữa các chương trình trong cùng hệ.
+ * Mã môn: {mã_số}_{mã_gốc}
  */
 import { api, APIError, Query } from 'encore.dev/api'
 import { and, eq, inArray, like, or, sql, isNull } from 'drizzle-orm'
@@ -174,9 +175,7 @@ type LegacySystemRow = {
 }
 
 async function hasTrainingTypeColumn(): Promise<boolean> {
-	const columns = await orm.all(
-		sql`PRAGMA table_info(exam_systems)`
-	)
+	const columns = await orm.all(sql`PRAGMA table_info(exam_systems)`)
 	return columns.some((column) => column.name === 'training_type_id')
 }
 
@@ -268,11 +267,24 @@ export const CreateExamSystem = api(
 		const hasTrainingType = await hasTrainingTypeColumn()
 		let row: LegacySystemRow | undefined
 		if (hasTrainingType) {
-			const [inserted] = await orm.insert(examSystems).values({ code, name, letter, trainingTypeId, description: body.description || null }).returning()
+			const [inserted] = await orm
+				.insert(examSystems)
+				.values({
+					code,
+					name,
+					letter,
+					trainingTypeId,
+					description: body.description || null
+				})
+				.returning()
 			row = inserted
 		} else {
-			await orm.run(sql`INSERT INTO exam_systems (code, name, letter, description) VALUES (${code}, ${name}, ${letter}, ${body.description || null})`)
-			row = await listSystems().then((rows) => rows.find((item) => item.code === code))
+			await orm.run(
+				sql`INSERT INTO exam_systems (code, name, letter, description) VALUES (${code}, ${name}, ${letter}, ${body.description || null})`
+			)
+			row = await listSystems().then((rows) =>
+				rows.find((item) => item.code === code)
+			)
 		}
 		return {
 			data: {
@@ -357,20 +369,26 @@ export const UpdateExamSystem = api(
 		const hasTrainingType = await hasTrainingTypeColumn()
 		let row: LegacySystemRow | undefined
 		if (hasTrainingType) {
-			const [updated] = await orm.update(examSystems).set({
-				code,
-				name,
-				letter,
-				trainingTypeId,
-				description:
-					params.description !== undefined
-						? params.description
-						: existing.description
-			}).where(eq(examSystems.id, params.id)).returning()
+			const [updated] = await orm
+				.update(examSystems)
+				.set({
+					code,
+					name,
+					letter,
+					trainingTypeId,
+					description:
+						params.description !== undefined
+							? params.description
+							: existing.description
+				})
+				.where(eq(examSystems.id, params.id))
+				.returning()
 			row = updated
 		} else {
-			await orm.run(sql`UPDATE exam_systems SET code = ${code}, name = ${name}, letter = ${letter}, description = ${params.description !== undefined ? params.description : existing.description} WHERE id = ${params.id}`)
-			row = await getSystem(params.id) ?? undefined
+			await orm.run(
+				sql`UPDATE exam_systems SET code = ${code}, name = ${name}, letter = ${letter}, description = ${params.description !== undefined ? params.description : existing.description} WHERE id = ${params.id}`
+			)
+			row = (await getSystem(params.id)) ?? undefined
 		}
 		return { data: row! }
 	}
@@ -480,25 +498,28 @@ export const CreateExamMajor = api(
 			)
 		}
 		const name = body.name.trim()
-		if (!name || !body.systemId) {
-			throw APIError.invalidArgument('Tên ngành và hệ bắt buộc')
+		const catalogNumber = body.catalogNumber?.trim().toUpperCase() || ''
+		if (!name || !body.systemId || !catalogNumber) {
+			throw APIError.invalidArgument('Mã số, tên ngành và hệ bắt buộc')
 		}
 		const sys = await getSystem(body.systemId)
 		if (!sys) throw APIError.notFound('Hệ không tồn tại')
 
 		const nationalMajorCode = body.nationalMajorCode?.trim() || null
-		const catalogNumber = nationalMajorCode
-			? `${sys.letter.toUpperCase()}.${nationalMajorCode}`
-			: body.catalogNumber?.trim() || null
-		const code =
-			catalogNumber ||
-			buildMajorCode({
-				letter: sys.letter,
-				levelCode: body.levelCode,
-				shortCode: body.shortCode,
-				majorName: name,
-				manualCode: body.code
-			})
+		const [duplicate] = await orm
+			.select({ id: examMajors.id })
+			.from(examMajors)
+			.where(
+				or(
+					eq(examMajors.code, catalogNumber),
+					eq(examMajors.catalogNumber, catalogNumber)
+				)
+			)
+			.limit(1)
+		if (duplicate) {
+			throw APIError.alreadyExists(`Mã số ${catalogNumber} đã tồn tại`)
+		}
+		const code = catalogNumber
 
 		const [row] = await orm
 			.insert(examMajors)
@@ -548,25 +569,32 @@ export const UpdateExamMajor = api(
 			.where(eq(examMajors.id, params.id))
 			.limit(1)
 		if (!existing) throw APIError.notFound('Ngành không tồn tại')
-		const nextSystemId = params.systemId ?? existing.systemId
 		const nextNationalMajorCode =
 			params.nationalMajorCode !== undefined
 				? params.nationalMajorCode?.trim() || null
 				: existing.nationalMajorCode
-		let nextCatalogNumber =
+		const nextCatalogNumber =
 			params.catalogNumber !== undefined
-				? params.catalogNumber?.trim() || null
+				? params.catalogNumber?.trim().toUpperCase() || null
 				: existing.catalogNumber
-		let nextCode = params.code?.trim().toUpperCase() || existing.code
-		if (nextNationalMajorCode) {
-			const [system] = await orm
-				.select({ letter: examSystems.letter })
-				.from(examSystems)
-				.where(eq(examSystems.id, nextSystemId))
-				.limit(1)
-			if (!system) throw APIError.notFound('Hệ không tồn tại')
-			nextCatalogNumber = `${system.letter.toUpperCase()}.${nextNationalMajorCode}`
-			nextCode = nextCatalogNumber
+		if (!nextCatalogNumber) {
+			throw APIError.invalidArgument('Mã số ngành là bắt buộc')
+		}
+		const nextCode = nextCatalogNumber
+		const [duplicate] = await orm
+			.select({ id: examMajors.id })
+			.from(examMajors)
+			.where(
+				or(
+					eq(examMajors.code, nextCatalogNumber),
+					eq(examMajors.catalogNumber, nextCatalogNumber)
+				)
+			)
+			.limit(1)
+		if (duplicate && duplicate.id !== params.id) {
+			throw APIError.alreadyExists(
+				`Mã số ${nextCatalogNumber} đã tồn tại`
+			)
 		}
 
 		const [row] = await orm

--- a/apps/api/migrations/0067_remove_hidden_exam_majors.sql
+++ b/apps/api/migrations/0067_remove_hidden_exam_majors.sql
@@ -1,0 +1,46 @@
+-- Xóa các ngành đào tạo cũ từng bị ẩn vì chưa có mã số.
+-- Giữ lại lớp, môn, khoa và lịch sử; chỉ gỡ liên kết tới ngành bị xóa.
+
+DELETE FROM `exam_major_heads`
+WHERE `major_id` IN (
+	SELECT `id` FROM `exam_majors`
+	WHERE `catalog_number` IS NULL OR trim(`catalog_number`) = ''
+);--> statement-breakpoint
+
+UPDATE `exam_classes`
+SET `major_id` = NULL
+WHERE `major_id` IN (
+	SELECT `id` FROM `exam_majors`
+	WHERE `catalog_number` IS NULL OR trim(`catalog_number`) = ''
+);--> statement-breakpoint
+
+UPDATE `exam_draws`
+SET `major_id` = NULL
+WHERE `major_id` IN (
+	SELECT `id` FROM `exam_majors`
+	WHERE `catalog_number` IS NULL OR trim(`catalog_number`) = ''
+);--> statement-breakpoint
+
+UPDATE `exam_faculties`
+SET `major_id` = NULL
+WHERE `major_id` IN (
+	SELECT `id` FROM `exam_majors`
+	WHERE `catalog_number` IS NULL OR trim(`catalog_number`) = ''
+);--> statement-breakpoint
+
+UPDATE `exam_subjects`
+SET `major_id` = NULL
+WHERE `major_id` IN (
+	SELECT `id` FROM `exam_majors`
+	WHERE `catalog_number` IS NULL OR trim(`catalog_number`) = ''
+);--> statement-breakpoint
+
+UPDATE `exam_teaching_assignment_logs`
+SET `major_id` = NULL
+WHERE `major_id` IN (
+	SELECT `id` FROM `exam_majors`
+	WHERE `catalog_number` IS NULL OR trim(`catalog_number`) = ''
+);--> statement-breakpoint
+
+DELETE FROM `exam_majors`
+WHERE `catalog_number` IS NULL OR trim(`catalog_number`) = '';

--- a/apps/api/migrations/meta/_journal.json
+++ b/apps/api/migrations/meta/_journal.json
@@ -470,6 +470,13 @@
 			"when": 1785929171647,
 			"tag": "0066_drop_legacy_audit_logs",
 			"breakpoints": true
+		},
+		{
+			"idx": 67,
+			"version": "6",
+			"when": 1785931200000,
+			"tag": "0067_remove_hidden_exam_majors",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/api/schema/exam-bank.ts
+++ b/apps/api/schema/exam-bank.ts
@@ -53,7 +53,8 @@ export const examSystems = sqliteTable('exam_systems', {
 /**
  * Ngành đào tạo thuộc một hệ (cột trên sheet tổng hợp).
  * Tên vd «Y sĩ đa khoa (trung cấp)»; trình độ gắn trong ngành (levelCode).
- * Mã dùng chính mã số danh mục — vd B.6720301.
+ * Mã nội bộ dùng chính mã số duy nhất — vd B.6720301. Mã ngành quốc gia
+ * có thể trùng giữa nhiều chương trình trong cùng một hệ.
  */
 export const examMajors = sqliteTable('exam_majors', {
 	...baseSchema,

--- a/apps/web/src/api/exam.ts
+++ b/apps/web/src/api/exam.ts
@@ -409,7 +409,7 @@ export async function CreateExamMajor(body: {
 	systemId: number
 	levelCode?: string | null
 	shortCode?: string | null
-	/** Để trống → tự sinh A/B_CD… */
+	/** Mã nội bộ; với ngành mới dùng cùng giá trị mã số. */
 	code?: string | null
 	catalogNumber?: string | null
 	nationalMajorCode?: string | null

--- a/apps/web/src/components/exam/ExamTrainingCatalogPage.tsx
+++ b/apps/web/src/components/exam/ExamTrainingCatalogPage.tsx
@@ -86,6 +86,7 @@ export default function ExamTrainingCatalogPage() {
 	})
 	const [form, setForm] = useState({
 		systemId: 0,
+		catalogNumber: '',
 		nationalMajorCode: '',
 		name: '',
 		qualification: '',
@@ -120,11 +121,6 @@ export default function ExamTrainingCatalogPage() {
 	const majors = majorsQ.data || []
 	const subjects = subjectsQ.data || []
 	const faculties = facultiesQ.data || []
-	const selectedSystem = systems.find((system) => system.id === form.systemId)
-	const generatedCatalogNumber =
-		selectedSystem && form.nationalMajorCode.trim()
-			? `${selectedSystem.letter.toUpperCase()}.${form.nationalMajorCode.trim()}`
-			: ''
 	const loading =
 		systemsQ.isLoading ||
 		majorsQ.isLoading ||
@@ -132,14 +128,14 @@ export default function ExamTrainingCatalogPage() {
 		facultiesQ.isLoading
 	const error =
 		systemsQ.error || majorsQ.error || subjectsQ.error || facultiesQ.error
-	const officialMajors = majors.filter((major) => major.catalogNumber)
 	const visibleMajors = useMemo(() => {
 		const keyword = majorSearch.trim().toLocaleLowerCase('vi')
-		if (!keyword) return officialMajors
-		return officialMajors.filter((major) =>
+		if (!keyword) return majors
+		return majors.filter((major) =>
 			[
 				major.catalogNumber,
 				major.nationalMajorCode,
+				major.code,
 				major.name,
 				major.qualification,
 				major.trainingForm
@@ -147,7 +143,7 @@ export default function ExamTrainingCatalogPage() {
 				(value || '').toLocaleLowerCase('vi').includes(keyword)
 			)
 		)
-	}, [officialMajors, majorSearch])
+	}, [majors, majorSearch])
 	const facultyDirectory = useMemo(() => {
 		const byCode = new Map<string, (typeof faculties)[number]>()
 		for (const faculty of faculties) {
@@ -183,18 +179,17 @@ export default function ExamTrainingCatalogPage() {
 			new Map(
 				systems.map((system) => [
 					system.id,
-					officialMajors.filter(
-						(major) => major.systemId === system.id
-					)
+					majors.filter((major) => major.systemId === system.id)
 				])
 			),
-		[systems, officialMajors]
+		[systems, majors]
 	)
 
 	const openCreate = () => {
 		setEditingId(null)
 		setForm({
 			systemId: systems[0]?.id || 0,
+			catalogNumber: '',
 			nationalMajorCode: '',
 			name: '',
 			qualification: '',
@@ -262,6 +257,7 @@ export default function ExamTrainingCatalogPage() {
 		setEditingId(major.id)
 		setForm({
 			systemId: major.systemId,
+			catalogNumber: major.catalogNumber || '',
 			nationalMajorCode: major.nationalMajorCode || '',
 			name: major.name,
 			qualification: major.qualification || '',
@@ -275,8 +271,8 @@ export default function ExamTrainingCatalogPage() {
 		mutationFn: () => {
 			const body = {
 				systemId: form.systemId,
-				code: generatedCatalogNumber,
-				catalogNumber: generatedCatalogNumber,
+				code: form.catalogNumber,
+				catalogNumber: form.catalogNumber,
 				nationalMajorCode: form.nationalMajorCode,
 				name: form.name,
 				qualification: form.qualification,
@@ -527,7 +523,7 @@ export default function ExamTrainingCatalogPage() {
 					<Table>
 						<TableHeader>
 							<TableRow>
-								<TableHead>Mã đào tạo</TableHead>
+								<TableHead>Mã số / Mã ngành</TableHead>
 								<TableHead>Tên ngành</TableHead>
 								<TableHead>Trình độ / Thời gian</TableHead>
 								<TableHead>Hình thức đào tạo</TableHead>
@@ -560,9 +556,13 @@ export default function ExamTrainingCatalogPage() {
 											className='text-sm'
 										>
 											<TableCell className='py-2.5 font-mono font-medium'>
-												<div>{major.catalogNumber}</div>
+												<div>
+													{major.catalogNumber ||
+														'Chưa có mã số'}
+												</div>
 												<div className='text-muted-foreground mt-0.5 text-xs'>
-													{major.nationalMajorCode}
+													{major.nationalMajorCode ||
+														`Mã cũ: ${major.code}`}
 												</div>
 											</TableCell>
 											<TableCell className='py-2.5 font-medium'>
@@ -635,8 +635,8 @@ export default function ExamTrainingCatalogPage() {
 						ngành
 					</CardTitle>
 					<CardDescription>
-						Danh sách môn học của {officialMajors.length} ngành
-						trong bảng trên · {subjects.length} môn
+						Danh sách môn học của {majors.length} ngành trong bảng
+						trên · {subjects.length} môn
 					</CardDescription>
 				</CardHeader>
 				<CardContent>
@@ -1061,6 +1061,19 @@ export default function ExamTrainingCatalogPage() {
 							</Select>
 						</div>
 						<div className='space-y-2'>
+							<Label>Mã số * (không được trùng)</Label>
+							<Input
+								value={form.catalogNumber}
+								onChange={(e) =>
+									setForm((old) => ({
+										...old,
+										catalogNumber: e.target.value
+									}))
+								}
+								placeholder='Ví dụ: A.6720301'
+							/>
+						</div>
+						<div className='space-y-2'>
 							<Label>Mã ngành *</Label>
 							<Input
 								value={form.nationalMajorCode}
@@ -1156,7 +1169,7 @@ export default function ExamTrainingCatalogPage() {
 							disabled={
 								saveMajor.isPending ||
 								!form.systemId ||
-								!generatedCatalogNumber ||
+								!form.catalogNumber.trim() ||
 								!form.nationalMajorCode.trim() ||
 								!form.name.trim() ||
 								!form.qualification.trim() ||


### PR DESCRIPTION
## Nội dung
- Xóa các ngành đào tạo cũ từng bị ẩn do chưa có mã số; gỡ liên kết an toàn trước khi xóa.
- Bắt buộc mỗi ngành/chương trình có một mã số riêng và duy nhất.
- Cho phép mã ngành trùng trong cùng một hệ; mã ngành không còn được dùng làm định danh duy nhất.
- Hiển thị toàn bộ ngành và tách riêng trường Mã số / Mã ngành trên giao diện.

## Kiểm tra
- Encore check: đạt
- Migration trên database sạch: đạt
- Web production build: đạt

PR này được xếp sau chuỗi PR hiện tại, bao gồm PR #205.