### PR TITLE
fix(leave): repair administration catalog forms

### DIFF
--- a/apps/api/leave-management/positions.ts
+++ b/apps/api/leave-management/positions.ts
@@ -19,6 +19,28 @@ const mapPosition = (
 	isActive: !!row.isActive
 })
 
+function isUniqueConstraintError(error: unknown): boolean {
+	let current: unknown = error
+	for (let depth = 0; current && depth < 4; depth += 1) {
+		const record = current as {
+			code?: unknown
+			message?: unknown
+			cause?: unknown
+		}
+		const code = String(record.code || '').toUpperCase()
+		const message = String(record.message || '').toUpperCase()
+		if (
+			code.includes('CONSTRAINT_UNIQUE') ||
+			message.includes('UNIQUE CONSTRAINT') ||
+			message.includes('UNIQUE CONSTRAINT FAILED')
+		) {
+			return true
+		}
+		current = record.cause
+	}
+	return false
+}
+
 export const ListLeavePositions = api(
 	{ auth: true, expose: true, method: 'GET', path: '/leave/positions' },
 	async (q: {
@@ -53,8 +75,11 @@ export const CreateLeavePosition = api(
 				})
 				.returning()
 			return { data: mapPosition(rows[0]!) }
-		} catch {
-			throw APIError.alreadyExists('Chức vụ đã tồn tại')
+		} catch (error) {
+			if (isUniqueConstraintError(error)) {
+				throw APIError.alreadyExists('Chức vụ đã tồn tại')
+			}
+			throw error
 		}
 	}
 )

--- a/apps/web/src/api/leave.ts
+++ b/apps/web/src/api/leave.ts
@@ -648,6 +648,8 @@ export function CreateLeaveUnit(body: {
 	name: string
 	code?: string | null
 	parentId?: number | null
+	level?: string | null
+	managementArea?: string
 	isActive?: boolean
 	commanderUserId?: number | null
 }) {
@@ -663,6 +665,8 @@ export function UpdateLeaveUnit(
 		name: string
 		code: string | null
 		parentId: number | null
+		level: string | null
+		managementArea: string
 		isActive: boolean
 		commanderUserId: number | null
 	}>

--- a/apps/web/src/components/leave-management/RegulationsPage.tsx
+++ b/apps/web/src/components/leave-management/RegulationsPage.tsx
@@ -820,7 +820,7 @@ export default function RegulationsPage() {
 									<SelectValue placeholder='Chọn…' />
 								</SelectTrigger>
 								<SelectContent>
-									{objectTypes.map((o) => (
+									{displayedObjectTypes.map((o) => (
 										<SelectItem key={o.code} value={o.code}>
 											{o.code} — {o.name}
 										</SelectItem>


### PR DESCRIPTION
Fix the reported leave administration failures by preserving unit hierarchy fields in API payload types, using fallback object types in the annual-leave dialog, and only reporting a duplicate position for actual unique-constraint failures.

Verification:
- `pnpm --filter api test -- --run`
- `pnpm --filter web build`
- `encore exec -- pnpm generate` (no schema changes)
- `pnpm --filter api migrate`
- full migration chain on a fresh SQLite database