### PR TITLE
fix(exam): keep standalone faculty creation API-compatible

### DIFF
--- a/apps/web/src/components/exam/ExamFacultiesPage.tsx
+++ b/apps/web/src/components/exam/ExamFacultiesPage.tsx
@@ -180,7 +180,14 @@ export default function ExamFacultiesPage() {
 	})
 	const createFaculty = useMutation({
 		mutationFn: () =>
-			CreateExamFaculty({ code: form.code, name: form.name }),
+			CreateExamFaculty({
+				code: form.code.trim(),
+				name: form.name.trim(),
+				// Keep the request compatible with API revisions where the nullable
+				// field was required during decoding. Standalone faculties are not
+				// attached to a specific major.
+				majorId: null
+			}),
 		onSuccess: () => {
 			toast.success('Đã thêm khoa')
 			setFacultyEditorOpen(false)


### PR DESCRIPTION
Send an explicit nullable majorId when creating a standalone faculty. This works with both the current optional contract and the previously deployed decoder that required the nullable field.

Verification:
- `pnpm --filter api test -- --run`
- `pnpm --filter web build`
- `encore exec -- pnpm generate` (no schema changes)
- `pnpm --filter api migrate`
- full migration chain on a fresh SQLite database