### PR TITLE
fix(exam): decouple catalog number from internal major code

### DIFF
--- a/apps/api/exam-management/catalog.ts
+++ b/apps/api/exam-management/catalog.ts
@@ -9,7 +9,7 @@
  * Mã môn: {mã_số}_{mã_gốc}
  */
 import { api, APIError, Query } from 'encore.dev/api'
-import { and, eq, inArray, like, ne, or, sql, isNull } from 'drizzle-orm'
+import { and, eq, inArray, isNull, like, ne, or, sql } from 'drizzle-orm'
 import orm from '../database'
 import {
 	examClasses,
@@ -580,70 +580,25 @@ export const UpdateExamMajor = api(
 		if (!nextCatalogNumber) {
 			throw APIError.invalidArgument('Mã số ngành là bắt buộc')
 		}
-		const catalogNumberChanged =
-			(existing.catalogNumber?.trim().toUpperCase() || null) !==
-			nextCatalogNumber
-		// A metadata-only save must not unexpectedly rename the internal code
-		// and every linked subject. Legacy rows are synchronized by migration;
-		// only an actual catalog-number change triggers the cascade here.
-		const nextCode = catalogNumberChanged
-			? nextCatalogNumber
-			: existing.code
 		const [duplicate] = await orm
 			.select({ id: examMajors.id })
 			.from(examMajors)
 			.where(
 				and(
 					ne(examMajors.id, params.id),
-					or(
-						eq(examMajors.code, nextCatalogNumber),
-						eq(examMajors.catalogNumber, nextCatalogNumber)
-					)
+					eq(examMajors.catalogNumber, nextCatalogNumber)
 				)
 			)
 			.limit(1)
-		if (duplicate && duplicate.id !== params.id) {
+		if (duplicate) {
 			throw APIError.alreadyExists(
 				`Mã số ${nextCatalogNumber} đã tồn tại`
 			)
 		}
 
-		const linkedSubjects = catalogNumberChanged
-			? await orm
-					.select({
-						id: examSubjects.id,
-						code: examSubjects.code,
-						baseCode: examSubjects.baseCode
-					})
-					.from(examSubjects)
-					.where(eq(examSubjects.majorId, params.id))
-			: []
-		for (const subject of linkedSubjects) {
-			const baseCode =
-				subject.baseCode?.trim() ||
-				subject.code.slice(existing.code.length + 1)
-			const nextSubjectCode = buildSubjectCode(nextCode, baseCode)
-			const [conflict] = await orm
-				.select({ id: examSubjects.id })
-				.from(examSubjects)
-				.where(
-					and(
-						ne(examSubjects.id, subject.id),
-						eq(examSubjects.code, nextSubjectCode)
-					)
-				)
-				.limit(1)
-			if (conflict) {
-				throw APIError.alreadyExists(
-					`Không thể đổi mã số: mã môn ${nextSubjectCode} đã tồn tại`
-				)
-			}
-		}
-
 		const [row] = await orm
 			.update(examMajors)
 			.set({
-				code: nextCode,
 				name: params.name?.trim() || existing.name,
 				systemId: params.systemId ?? existing.systemId,
 				levelCode:

--- a/apps/web/src/components/exam/ExamTrainingCatalogPage.tsx
+++ b/apps/web/src/components/exam/ExamTrainingCatalogPage.tsx
@@ -271,7 +271,6 @@ export default function ExamTrainingCatalogPage() {
 		mutationFn: () => {
 			const body = {
 				systemId: form.systemId,
-				code: form.catalogNumber,
 				catalogNumber: form.catalogNumber,
 				nationalMajorCode: form.nationalMajorCode,
 				name: form.name,


### PR DESCRIPTION
## Sửa
- Web không còn gửi mã số vào trường code nội bộ.
- Khi cập nhật mã số, API không còn tự đổi code ngành nội bộ.
- Không còn đổi dây chuyền mã các môn đã liên kết khi chỉ sửa mã số.
- Kiểm tra trùng chỉ áp dụng đúng trên catalog_number.

## Kiểm tra
- Web production build thành công.
- Encore dựng application graph thành công; bước chạy local dừng do môi trường kiểm tra không có secret runtime.

## Thứ tự
PR độc lập, merge sau PR sửa migration production.