### PR TITLE
feat(exam): add faculty abbreviation migration

### DIFF
--- a/apps/api/migrations/0068_exam_faculty_short_code.sql
+++ b/apps/api/migrations/0068_exam_faculty_short_code.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `exam_faculties` ADD COLUMN `short_code` text;

--- a/apps/api/migrations/meta/_journal.json
+++ b/apps/api/migrations/meta/_journal.json
@@ -481,6 +481,13 @@
 		{
 			"idx": 68,
 			"version": "6",
+			"when": 1786011127824,
+			"tag": "0068_exam_faculty_short_code",
+			"breakpoints": true
+		},
+		{
+			"idx": 69,
+			"version": "6",
 			"when": 1786014000000,
 			"tag": "0069_restore_skipped_leave_schema",
 			"breakpoints": true


### PR DESCRIPTION
Only database migration for exam_faculties.short_code. Merge first.