### PR TITLE
fix: align exam major and faculty catalog rules

### DIFF
--- a/apps/api/exam-management/catalog.ts
+++ b/apps/api/exam-management/catalog.ts
@@ -71,6 +71,9 @@ export interface FacultyResponse {
 	code: string
 	shortCode: string | null
 	name: string
+	majorId: number | null
+	majorCode: string | null
+	majorName: string | null
 	description: string | null
 }
 
@@ -680,6 +683,13 @@ export const DeleteExamMajor = api(
 async function mapFaculty(
 	r: typeof examFaculties.$inferSelect
 ): Promise<FacultyResponse> {
+	const [major] = r.majorId
+		? await orm
+				.select({ code: examMajors.code, name: examMajors.name })
+				.from(examMajors)
+				.where(eq(examMajors.id, r.majorId))
+				.limit(1)
+		: []
 	return {
 		id: r.id,
 		createdAt: r.createdAt,
@@ -687,16 +697,33 @@ async function mapFaculty(
 		code: r.code,
 		shortCode: r.shortCode ?? null,
 		name: r.name,
+		majorId: r.majorId ?? null,
+		majorCode: major?.code ?? null,
+		majorName: major?.name ?? null,
 		description: r.description
 	}
 }
 
 export const ListExamFaculties = api(
 	{ auth: true, expose: true, method: 'GET', path: '/exam/faculties' },
-	async (q: { q?: Query<string> }): Promise<{ data: FacultyResponse[] }> => {
+	async (q: {
+		q?: Query<string>
+		majorId?: Query<number>
+	}): Promise<{ data: FacultyResponse[] }> => {
 		const actor = await getActor()
 		const conditions = []
 		const kw = (q.q || '').trim()
+		if (q.majorId) {
+			const majorId = Number(q.majorId)
+			if (!Number.isInteger(majorId) || majorId <= 0)
+				throw APIError.invalidArgument('Ngành của khoa không hợp lệ')
+			conditions.push(
+				or(
+					eq(examFaculties.majorId, majorId),
+					isNull(examFaculties.majorId)
+				)!
+			)
+		}
 		if (kw) {
 			conditions.push(
 				or(
@@ -738,6 +765,7 @@ export const CreateExamFaculty = api(
 		code: string
 		shortCode?: string | null
 		name: string
+		majorId?: number | null
 		description?: string
 	}): Promise<{ data: FacultyResponse }> => {
 		const actor = await getActor()
@@ -747,12 +775,26 @@ export const CreateExamFaculty = api(
 		const code = body.code.trim().toUpperCase()
 		const shortCode = body.shortCode?.trim().toUpperCase() || null
 		const name = body.name.trim()
+		const majorId = body.majorId == null ? null : Number(body.majorId)
 		if (!code || !name)
 			throw APIError.invalidArgument('Mã và tên khoa bắt buộc')
+		if (majorId == null || !Number.isInteger(majorId) || majorId <= 0)
+			throw APIError.invalidArgument('Ngành của khoa là bắt buộc')
+		const [major] = await orm
+			.select({ id: examMajors.id })
+			.from(examMajors)
+			.where(eq(examMajors.id, majorId))
+			.limit(1)
+		if (!major) throw APIError.notFound('Ngành không tồn tại')
 		const duplicate = await orm
 			.select({ id: examFaculties.id })
 			.from(examFaculties)
-			.where(and(eq(examFaculties.code, code)))
+			.where(
+				and(
+					eq(examFaculties.code, code),
+					eq(examFaculties.majorId, majorId)
+				)
+			)
 			.limit(1)
 		if (duplicate[0])
 			throw APIError.alreadyExists(
@@ -764,6 +806,7 @@ export const CreateExamFaculty = api(
 				code,
 				shortCode,
 				name,
+				majorId,
 				description: body.description || null
 			})
 			.returning()
@@ -778,6 +821,7 @@ export const UpdateExamFaculty = api(
 		code?: string
 		shortCode?: string | null
 		name?: string
+		majorId?: number | null
 		description?: string | null
 	}): Promise<{ data: FacultyResponse }> => {
 		const actor = await getActor()
@@ -804,14 +848,35 @@ export const UpdateExamFaculty = api(
 		if (!code || !name) {
 			throw APIError.invalidArgument('Mã và tên khoa bắt buộc')
 		}
+		const majorId =
+			params.majorId !== undefined
+				? params.majorId == null
+					? null
+					: Number(params.majorId)
+				: existing.majorId
+		if (majorId != null && (!Number.isInteger(majorId) || majorId <= 0))
+			throw APIError.invalidArgument('Ngành của khoa không hợp lệ')
+		if (majorId != null) {
+			const [major] = await orm
+				.select({ id: examMajors.id })
+				.from(examMajors)
+				.where(eq(examMajors.id, majorId))
+				.limit(1)
+			if (!major) throw APIError.notFound('Ngành không tồn tại')
+		}
 
-		if (code !== existing.code) {
+		if (code !== existing.code || majorId !== existing.majorId) {
+			const majorCondition =
+				majorId == null
+					? isNull(examFaculties.majorId)
+					: eq(examFaculties.majorId, majorId)
 			const [dup] = await orm
 				.select({ id: examFaculties.id })
 				.from(examFaculties)
 				.where(
 					and(
 						eq(examFaculties.code, code),
+						majorCondition,
 						sql`${examFaculties.id} != ${params.id}`
 					)
 				)
@@ -828,6 +893,7 @@ export const UpdateExamFaculty = api(
 			.set({
 				code,
 				shortCode,
+				majorId,
 				name,
 				description:
 					params.description !== undefined

--- a/apps/api/migrations/0075_exam_faculty_major_code_unique.sql
+++ b/apps/api/migrations/0075_exam_faculty_major_code_unique.sql
@@ -1,0 +1,5 @@
+-- Mã khoa được phép lặp giữa các ngành nhưng duy nhất trong từng ngành.
+DROP INDEX IF EXISTS `exam_faculties_code_unique`;
+DROP INDEX IF EXISTS `exam_faculties_code_idx`;
+CREATE UNIQUE INDEX IF NOT EXISTS `exam_faculties_major_code_unique`
+ON `exam_faculties` (`major_id`, `code`);

--- a/apps/api/migrations/meta/_journal.json
+++ b/apps/api/migrations/meta/_journal.json
@@ -519,6 +519,13 @@
 			"when": 1786103000000,
 			"tag": "0074_repair_leave_personnel_schema",
 			"breakpoints": true
+		},
+		{
+			"idx": 73,
+			"version": "7",
+			"when": 1786104000000,
+			"tag": "0075_exam_faculty_major_code_unique",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/api/schema/exam-bank.ts
+++ b/apps/api/schema/exam-bank.ts
@@ -98,7 +98,10 @@ export const examFaculties = sqliteTable(
 		description: text('description')
 	},
 	(t) => ({
-		codeIdx: uniqueIndex('exam_faculties_code_unique').on(t.code)
+		codeIdx: uniqueIndex('exam_faculties_major_code_unique').on(
+			t.majorId,
+			t.code
+		)
 	})
 )
 

--- a/apps/web/src/api/exam.ts
+++ b/apps/web/src/api/exam.ts
@@ -71,6 +71,9 @@ export interface ExamFaculty {
 	code: string
 	shortCode: string | null
 	name: string
+	majorId: number | null
+	majorCode: string | null
+	majorName: string | null
 	description: string | null
 }
 
@@ -452,9 +455,13 @@ export async function DeleteExamMajor(id: number) {
 	})
 }
 
-export async function ListExamFaculties(params?: { q?: string }) {
+export async function ListExamFaculties(params?: {
+	q?: string
+	majorId?: number
+}) {
 	const sp = new URLSearchParams()
 	if (params?.q) sp.set('q', params.q)
+	if (params?.majorId) sp.set('majorId', String(params.majorId))
 	const qs = sp.toString() ? `?${sp}` : ''
 	const resp = await jsonFetch<{ data: ExamFaculty[] }>(
 		`/exam/faculties${qs}`
@@ -466,6 +473,7 @@ export async function CreateExamFaculty(body: {
 	code: string
 	shortCode?: string | null
 	name: string
+	majorId: number
 	description?: string
 }) {
 	// Encore không nhận `null` cho field optional. Bỏ hẳn các field rỗng
@@ -473,6 +481,7 @@ export async function CreateExamFaculty(body: {
 	const payload = {
 		code: body.code,
 		name: body.name,
+		majorId: body.majorId,
 		...(body.shortCode?.trim()
 			? { shortCode: body.shortCode.trim().toUpperCase() }
 			: {}),
@@ -491,6 +500,7 @@ export async function UpdateExamFaculty(
 		code?: string
 		shortCode?: string | null
 		name?: string
+		majorId?: number | null
 		description?: string | null
 	}
 ) {

--- a/apps/web/src/components/exam/ExamCatalogPage.tsx
+++ b/apps/web/src/components/exam/ExamCatalogPage.tsx
@@ -103,7 +103,9 @@ export default function ExamCatalogPage() {
 	const [facultyForm, setFacultyForm] = useState({
 		code: '',
 		shortCode: '',
-		name: ''
+		name: '',
+		majorId: 0,
+		majorLabel: ''
 	})
 	const [subjectForm, setSubjectForm] = useState({
 		baseCode: '',
@@ -155,7 +157,14 @@ export default function ExamCatalogPage() {
 
 	const facultiesByMajor = useMemo(() => {
 		const m = new Map<number, ExamFaculty[]>()
-		for (const major of majors) m.set(major.id, faculties)
+		for (const major of majors) {
+			m.set(
+				major.id,
+				faculties.filter(
+					(f) => f.majorId === major.id || f.majorId == null
+				)
+			)
+		}
 		return m
 	}, [faculties, majors])
 
@@ -340,7 +349,8 @@ export default function ExamCatalogPage() {
 						UpdateExamFaculty(faculty.id, {
 							code: facultyForm.code,
 							shortCode: facultyForm.shortCode,
-							name: facultyForm.name
+							name: facultyForm.name,
+							majorId: facultyForm.majorId || null
 						})
 					)
 				)
@@ -350,7 +360,8 @@ export default function ExamCatalogPage() {
 					await UpdateExamFaculty(editFacultyId, {
 						code: facultyForm.code,
 						shortCode: facultyForm.shortCode,
-						name: facultyForm.name
+						name: facultyForm.name,
+						majorId: facultyForm.majorId
 					})
 				]
 			}
@@ -358,7 +369,8 @@ export default function ExamCatalogPage() {
 				await CreateExamFaculty({
 					code: facultyForm.code,
 					shortCode: facultyForm.shortCode,
-					name: facultyForm.name
+					name: facultyForm.name,
+					majorId: facultyForm.majorId
 				})
 			]
 		},
@@ -478,22 +490,26 @@ export default function ExamCatalogPage() {
 		setMajorOpen(true)
 	}
 
-	function openAddFaculty() {
+	function openAddFaculty(major: ExamMajor) {
 		setEditFacultyId(null)
 		setFacultyForm({
 			code: '',
 			shortCode: '',
-			name: ''
+			name: '',
+			majorId: major.id,
+			majorLabel: `${major.code} — ${major.name}`
 		})
 		setFacultyOpen(true)
 	}
 
-	function openEditFaculty(fac: ExamFaculty) {
+	function openEditFaculty(fac: ExamFaculty, major?: ExamMajor) {
 		setEditFacultyId(fac.id)
 		setFacultyForm({
 			code: fac.code,
 			shortCode: fac.shortCode || '',
-			name: fac.name
+			name: fac.name,
+			majorId: fac.majorId ?? major?.id ?? 0,
+			majorLabel: fac.majorName || major?.name || 'Ngành chưa xác định'
 		})
 		setFacultyOpen(true)
 	}
@@ -503,7 +519,9 @@ export default function ExamCatalogPage() {
 		setFacultyForm({
 			code,
 			shortCode: '',
-			name
+			name,
+			majorId: 0,
+			majorLabel: 'Khoa dùng chung cũ'
 		})
 		setFacultyOpen(true)
 	}
@@ -609,6 +627,11 @@ export default function ExamCatalogPage() {
 										>
 											{faculty.code}
 										</Badge>
+										{faculty.shortCode && (
+											<Badge variant='secondary'>
+												{faculty.shortCode}
+											</Badge>
+										)}
 										<span className='font-medium'>
 											{faculty.name}
 										</span>
@@ -1036,6 +1059,16 @@ export default function ExamCatalogPage() {
 																											fac.code
 																										}
 																									</span>
+																									{fac.shortCode && (
+																										<Badge
+																											variant='secondary'
+																											className='text-[10px]'
+																										>
+																											{
+																												fac.shortCode
+																											}
+																										</Badge>
+																									)}
 																									<span>
 																										{
 																											fac.name

--- a/apps/web/src/components/exam/ExamFacultiesPage.tsx
+++ b/apps/web/src/components/exam/ExamFacultiesPage.tsx
@@ -8,6 +8,7 @@ import {
 	ListExamFaculties,
 	ListExamFacultyHeads,
 	ListExamFacultyOptions,
+	ListExamMajors,
 	ListExamSubjects,
 	ListExamTeacherCatalog,
 	UpdateExamFaculty,
@@ -75,7 +76,13 @@ export default function ExamFacultiesPage() {
 	const [editingSubjectId, setEditingSubjectId] = useState<number | null>(
 		null
 	)
-	const [form, setForm] = useState({ code: '', name: '', headUserId: 'none' })
+	const [form, setForm] = useState({
+		code: '',
+		name: '',
+		shortCode: '',
+		majorId: '',
+		headUserId: 'none'
+	})
 	const [subjectForm, setSubjectForm] = useState({
 		baseCode: '',
 		name: '',
@@ -90,6 +97,10 @@ export default function ExamFacultiesPage() {
 	const facultiesQ = useQuery({
 		queryKey: ['exam-faculties'],
 		queryFn: () => ListExamFaculties()
+	})
+	const majorsQ = useQuery({
+		queryKey: ['exam-majors'],
+		queryFn: ListExamMajors
 	})
 	const subjectsQ = useQuery({
 		queryKey: ['exam-subjects'],
@@ -145,7 +156,9 @@ export default function ExamFacultiesPage() {
 				records.map((faculty) =>
 					UpdateExamFaculty(faculty.id, {
 						code: form.code,
-						name: form.name
+						name: form.name,
+						shortCode: form.shortCode || null,
+						majorId: faculty.majorId
 					})
 				)
 			)
@@ -182,7 +195,9 @@ export default function ExamFacultiesPage() {
 		mutationFn: () =>
 			CreateExamFaculty({
 				code: form.code.trim(),
-				name: form.name.trim()
+				name: form.name.trim(),
+				shortCode: form.shortCode.trim() || null,
+				majorId: Number(form.majorId)
 			}),
 		onSuccess: () => {
 			toast.success('Đã thêm khoa')
@@ -300,7 +315,13 @@ export default function ExamFacultiesPage() {
 					<Button
 						onClick={() => {
 							setFacultyEditorMode('create')
-							setForm({ code: '', name: '', headUserId: 'none' })
+							setForm({
+								code: '',
+								name: '',
+								shortCode: '',
+								majorId: '',
+								headUserId: 'none'
+							})
 							setFacultyEditorOpen(true)
 						}}
 					>
@@ -328,6 +349,11 @@ export default function ExamFacultiesPage() {
 											<Badge variant='outline'>
 												{faculty.code}
 											</Badge>
+											{faculty.shortCode && (
+												<Badge variant='secondary'>
+													{faculty.shortCode}
+												</Badge>
+											)}
 											{faculty.name}
 										</CardTitle>
 										<CardDescription className='mt-1'>
@@ -346,6 +372,14 @@ export default function ExamFacultiesPage() {
 													setForm({
 														code: faculty.code,
 														name: faculty.name,
+														shortCode:
+															faculty.shortCode ||
+															'',
+														majorId: faculty.majorId
+															? String(
+																	faculty.majorId
+																)
+															: '',
 														headUserId: faculty.head
 															? String(
 																	faculty.head
@@ -399,6 +433,14 @@ export default function ExamFacultiesPage() {
 													setForm({
 														code: faculty.code,
 														name: faculty.name,
+														shortCode:
+															faculty.shortCode ||
+															'',
+														majorId: faculty.majorId
+															? String(
+																	faculty.majorId
+																)
+															: '',
 														headUserId: faculty.head
 															? String(
 																	faculty.head
@@ -620,6 +662,31 @@ export default function ExamFacultiesPage() {
 						</DialogTitle>
 					</DialogHeader>
 					<div className='space-y-3'>
+						{facultyEditorMode === 'create' && (
+							<div>
+								<Label>Ngành *</Label>
+								<Select
+									value={form.majorId}
+									onValueChange={(majorId) =>
+										setForm((o) => ({ ...o, majorId }))
+									}
+								>
+									<SelectTrigger>
+										<SelectValue placeholder='Chọn ngành' />
+									</SelectTrigger>
+									<SelectContent>
+										{(majorsQ.data || []).map((major) => (
+											<SelectItem
+												key={major.id}
+												value={String(major.id)}
+											>
+												{major.code} — {major.name}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
+						)}
 						<div>
 							<Label>Mã khoa *</Label>
 							<Input
@@ -631,6 +698,19 @@ export default function ExamFacultiesPage() {
 									}))
 								}
 								placeholder='K1'
+							/>
+						</div>
+						<div>
+							<Label>Viết tắt khoa</Label>
+							<Input
+								value={form.shortCode}
+								onChange={(e) =>
+									setForm((o) => ({
+										...o,
+										shortCode: e.target.value.toUpperCase()
+									}))
+								}
+								placeholder='CNTT'
 							/>
 						</div>
 						<div>
@@ -657,6 +737,8 @@ export default function ExamFacultiesPage() {
 							disabled={
 								!form.code.trim() ||
 								!form.name.trim() ||
+								(facultyEditorMode === 'create' &&
+									!form.majorId) ||
 								createFaculty.isPending ||
 								save.isPending
 							}


### PR DESCRIPTION
Fix backend and frontend exam catalog rules: allow duplicate national major codes, keep catalog numbers unique, require and persist majorId when creating/updating faculties, scope faculty code uniqueness by major, and show faculty abbreviations in the web UI.